### PR TITLE
ci: pin renovate action to exact version v46.1.17

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -36,7 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v46
+        # This action publishes only full-version tags (no floating major), so pin the exact version.
+        # Renovate keeps this pin updated once it is running.
+        uses: renovatebot/github-action@v46.1.17
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:


### PR DESCRIPTION
The first Renovate run failed with `unable to find version v46` — `renovatebot/github-action` publishes only full-version tags (no floating major), unlike the other actions bumped in #2. Pin the exact version `v46.1.17`.

Renovate will keep this pin updated automatically once it's running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)