### PR TITLE
fix(slskd): parse the real per-user downloads response shape

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm run check)",
+      "Bash(pnpm check)",
+      "Bash(pnpm run test:cov)",
+      "Bash(pnpm run typecheck)",
+      "Bash(pnpm run lint)",
+      "Bash(npm view *)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ Hard rules. A change that violates one is wrong regardless of anything else:
 - **No breaking changes** to public contracts. Additive-only within a version; enforced by contract tests. → `api-compatibility.md`
 - **Every commit passes the gate** — build, lint, typecheck, format, tests. → `development-workflow.md`
 - **Config comes from the environment.** No secrets in source. → `twelve-factor.md`
+- **Use `jj`, never `git`, for all VCS operations.** This repo is driven by jujutsu (git-backed). Commit, describe, split, rebase, branch, and push with `jj` — do not run `git commit`/`git branch`/`git push` etc. Read-only `git` inspection is fine when no `jj` equivalent fits. → `development-workflow.md`
 
 ## Development constitution — `docs/development/`
 
@@ -36,7 +37,7 @@ Hard rules. A change that violates one is wrong regardless of anything else:
 
 ## Stack
 
-Node · TypeScript (strict) · pnpm · neverthrow · zod · Fastify · pino · vitest · SQLite · ffmpeg. Local VCS: jujutsu (git-backed).
+Node · TypeScript (strict) · pnpm · neverthrow · zod · Fastify · pino · vitest · SQLite · ffmpeg. **VCS: jujutsu (`jj`), git-backed — drive all version control through `jj`, not `git` (see Non-negotiables).**
 
 ## Where things live
 

--- a/src/adapters/slskd/download.test.ts
+++ b/src/adapters/slskd/download.test.ts
@@ -30,7 +30,12 @@ function transfer(name: string, extra: Record<string, unknown> = {}): Record<str
 }
 
 function poll(files: readonly unknown[]): HttpResponse {
-  return { status: 200, body: JSON.stringify([{ directory: 'd', files }]) };
+  // Mirror slskd's real per-user download payload: a single object whose transfers hang off
+  // `directories`, each group carrying a `files` array (verified against slskd 0.22.5).
+  return {
+    status: 200,
+    body: JSON.stringify({ username: 'u1', directories: [{ directory: 'd', files }] }),
+  };
 }
 
 function fakeTimer(): Timer {
@@ -60,7 +65,7 @@ function downloader(opts: Opts): { adapter: SlskdDownload; deletes: string[] } {
         return Promise.resolve({ status: 204, body: '' });
       }
       const next = queue.length > 1 ? queue.shift() : queue[0];
-      return Promise.resolve(next ?? { status: 200, body: '[]' });
+      return Promise.resolve(next ?? { status: 200, body: '{"directories":[]}' });
     },
   };
   const adapter = new SlskdDownload(

--- a/src/adapters/slskd/transfers.test.ts
+++ b/src/adapters/slskd/transfers.test.ts
@@ -6,13 +6,22 @@ describe('flattenDownloads', () => {
     expect(flattenDownloads(undefined)).toEqual([]);
   });
 
-  it('flattens transfers across directory groups, tolerating empty groups', () => {
-    const flat = flattenDownloads([
-      { files: [{ id: 't1' }, { id: 't2' }] },
-      { directory: 'empty' },
-    ]);
+  it("flattens transfers across a user payload's directory groups, tolerating empty groups", () => {
+    // slskd's `GET …/downloads/{username}` returns a single user object whose transfers are nested
+    // under `directories` — not a bare array of directory groups (verified against slskd 0.22.5).
+    const flat = flattenDownloads({
+      username: 'nathan_988',
+      directories: [
+        { directory: 'a', files: [{ id: 't1' }, { id: 't2' }] },
+        { directory: 'empty' },
+      ],
+    });
 
     expect(flat.map((t) => t.id)).toEqual(['t1', 't2']);
+  });
+
+  it('returns nothing when the payload carries no directories', () => {
+    expect(flattenDownloads({ username: 'u', directories: [] })).toEqual([]);
   });
 });
 

--- a/src/adapters/slskd/transfers.ts
+++ b/src/adapters/slskd/transfers.ts
@@ -18,10 +18,14 @@ export interface SlskdTransfer {
   readonly exception?: string;
 }
 
-/** slskd's `GET …/downloads/{username}` groups transfers by directory; flatten to a file list. */
+/**
+ * slskd's `GET …/downloads/{username}` returns a single user object whose transfers are grouped by
+ * directory under `directories`; flatten those groups to a flat file list.
+ */
 export function flattenDownloads(json: unknown): SlskdTransfer[] {
-  const directories = (json as readonly { files?: readonly SlskdTransfer[] }[] | undefined) ?? [];
-  return directories.flatMap((directory) => directory.files ?? []);
+  const payload = json as
+    { directories?: readonly { files?: readonly SlskdTransfer[] }[] } | undefined;
+  return (payload?.directories ?? []).flatMap((directory) => directory.files ?? []);
 }
 
 type TransferStatus = 'succeeded' | 'failed' | 'queued' | 'transferring';

--- a/test/e2e/stubs/slskd/mappings/transfers-poll-completed.json
+++ b/test/e2e/stubs/slskd/mappings/transfers-poll-completed.json
@@ -9,19 +9,23 @@
   "response": {
     "status": 200,
     "headers": { "Content-Type": "application/json" },
-    "jsonBody": [
-      {
-        "directory": "@@music\\Test Artist\\Test Album",
-        "files": [
-          {
-            "id": "transfer-1",
-            "filename": "@@music\\Test Artist\\Test Album\\01 Track One.flac",
-            "state": "Completed, Succeeded",
-            "size": 1234567,
-            "bytesTransferred": 1234567
-          }
-        ]
-      }
-    ]
+    "jsonBody": {
+      "username": "peer1",
+      "directories": [
+        {
+          "directory": "@@music\\Test Artist\\Test Album",
+          "fileCount": 1,
+          "files": [
+            {
+              "id": "transfer-1",
+              "filename": "@@music\\Test Artist\\Test Album\\01 Track One.flac",
+              "state": "Completed, Succeeded",
+              "size": 1234567,
+              "bytesTransferred": 1234567
+            }
+          ]
+        }
+      ]
+    }
   }
 }

--- a/test/e2e/stubs/slskd/mappings/transfers-poll-inprogress.json
+++ b/test/e2e/stubs/slskd/mappings/transfers-poll-inprogress.json
@@ -10,19 +10,23 @@
   "response": {
     "status": 200,
     "headers": { "Content-Type": "application/json" },
-    "jsonBody": [
-      {
-        "directory": "@@music\\Test Artist\\Test Album",
-        "files": [
-          {
-            "id": "transfer-1",
-            "filename": "@@music\\Test Artist\\Test Album\\01 Track One.flac",
-            "state": "InProgress, Transferring",
-            "size": 1234567,
-            "bytesTransferred": 617283
-          }
-        ]
-      }
-    ]
+    "jsonBody": {
+      "username": "peer1",
+      "directories": [
+        {
+          "directory": "@@music\\Test Artist\\Test Album",
+          "fileCount": 1,
+          "files": [
+            {
+              "id": "transfer-1",
+              "filename": "@@music\\Test Artist\\Test Album\\01 Track One.flac",
+              "state": "InProgress, Transferring",
+              "size": 1234567,
+              "bytesTransferred": 617283
+            }
+          ]
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## What & why

Fixes a real bug found by running the app against a live **slskd 0.22.5** instance (not the WireMock stub): every download poll crashed, stranding acquisitions in `Downloading`.

### Root cause — a fake-vs-reality divergence
slskd's `GET /api/v0/transfers/downloads/{username}` returns a **single user object** with transfers nested under `directories`:

```json
{ "username": "...", "directories": [ { "directory": "...", "files": [ ... ] } ] }
```

`flattenDownloads` assumed a **bare array** of directory groups, so `directories.flatMap` was `undefined.flatMap` → `TypeError: directories.flatMap is not a function` on every poll. 100% coverage missed it because the WireMock E2E stub returned the wrong (array) shape — the fake and the real server disagreed.

### The fix
- `flattenDownloads` now reads `json.directories`.
- Corrected both `transfers-poll-*.json` E2E stubs and the `download.test.ts` `poll()` helper to the **real** object shape so the divergence can't recur.
- Test-first: the unit suite first reproduced the exact production error (red), then went green.

## Verification
- Gate: **327 tests pass, 100% coverage**; typecheck + lint + format clean.
- **Live slskd re-run:** `Pending → Searching → Downloading` with zero crashes; the progress endpoint returned real data (12.1%, 86 MB / 716 MB) matching slskd's own transfer view. Cancel path also exercised (`202 → Cancelled`).

## Also included
- `docs(claude)`: make it a Non-negotiable that VCS runs through `jj`, not `git`.
- `chore(claude)`: project-shared permission allowlist for read-only gate commands.

## Known gaps (not in scope here)
- Cancelling an acquisition does **not** stop the in-flight slskd transfer (no `AbortSignal` on `DownloadPort`; `AcquisitionCancelled` emits no effect).
- Descriptor metadata resolution fails for popular albums (MusicBrainz tie-guard in `bestMatchId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
