### PR TITLE
feat(mcp)!: serve MCP over streamable HTTP, drop stdio transport

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "music-downloader": {
+      "type": "http",
+      "url": "http://localhost:3000/mcp"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -86,7 +86,17 @@ Both surfaces map onto the same application use-cases and derive from one shared
 | `POST /api/v1/acquisitions/{id}/cancel`  | Cancel a non-terminal acquisition. |
 
 **MCP** — tools `submit_acquisition` / `cancel_acquisition`; resources `md://acquisitions`,
-`md://acquisitions/{id}`, `md://acquisitions/{id}/progress` (served over stdio).
+`md://acquisitions/{id}`, `md://acquisitions/{id}/progress`. Served over the **streamable HTTP**
+transport by the same server at `POST /mcp` (i.e. `http://<HTTP_HOST>:<HTTP_PORT>/mcp`), so HTTP and
+MCP clients share one process and one set of acquisitions. Point an MCP client at that URL:
+
+```jsonc
+{ "mcpServers": { "music-downloader": { "url": "http://localhost:3000/mcp" } } }
+```
+
+> **Breaking change:** the stdio transport has been removed. A spawn-the-process MCP config
+> (`command`/`args`) no longer works — migrate it to the URL form above. This is an intentional,
+> owner-approved break to the MCP connection contract; the tool and resource contracts are unchanged.
 
 ## Development
 

--- a/openspec/changes/mcp-streamable-http-transport/.openspec.yaml
+++ b/openspec/changes/mcp-streamable-http-transport/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/mcp-streamable-http-transport/design.md
+++ b/openspec/changes/mcp-streamable-http-transport/design.md
@@ -1,0 +1,74 @@
+# Design: mcp-streamable-http-transport
+
+## Context
+
+The composition root currently connects the MCP `Server` to a `StdioServerTransport` (`src/composition/index.ts`), while the HTTP API listens on Fastify in the same process. Stdio forces the MCP client to be the parent of the whole application process, which creates the two-process trap described in the proposal (checkpoint races between reactors, stale projections, unreacted cancellations). It also conflicts latently with our logging: pino writes structured logs to stdout by default, the same stream stdio MCP uses for JSON-RPC frames.
+
+The MCP inbound adapter itself (`src/interfaces/mcp/server.ts`) is transport-agnostic — it builds a `Server` with tool/resource handlers over the shared use-cases. Only the transport wiring changes.
+
+The pinned SDK (`@modelcontextprotocol/sdk` ^1.29.0) ships `StreamableHTTPServerTransport` (`server/streamableHttp.js`) with `handleRequest(req, res, parsedBody)` and a `sessionIdGenerator` option that selects stateful (sessions via `Mcp-Session-Id`) or stateless (`undefined`) operation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Serve MCP over streamable HTTP from the existing Fastify server — one process, one port, many concurrent clients.
+- Remove the stdio transport entirely (accepted breaking change to the connection contract).
+- Keep tool/resource semantics and the shared zod-derived schemas byte-identical.
+- Make MCP exercisable by the out-of-process E2E tier against the running server.
+
+**Non-Goals:**
+
+- No auth on the MCP endpoint (matches the HTTP API, which is also unauthenticated; the server binds a configured host, localhost-oriented deployment).
+- No server-initiated notifications, subscriptions, or SSE resumability — nothing in the current adapter pushes to clients.
+- No change to acquisition behavior (the cancel/AbortSignal gap is a separate change).
+- No multi-node scaling concerns (single-process SQLite app).
+
+## Decisions
+
+### D1: Stateless transport mode (`sessionIdGenerator: undefined`)
+
+A fresh `Server` + `StreamableHTTPServerTransport` pair is constructed per incoming request, connected, and handed the request; nothing is retained between requests.
+
+- **Why**: Our MCP surface is strictly request/response — tools that submit/cancel and resources that read projections. There is no server-push, so sessions buy nothing and cost a session registry, expiry, and shutdown draining. Stateless mode also sidesteps JSON-RPC request-ID collision concerns across clients, since no transport instance is shared. `buildMcpServer` is a cheap closure over `UseCaseDeps`; per-request construction is negligible next to the SQLite reads it fronts.
+- **Alternative considered**: stateful sessions (`sessionIdGenerator: () => randomUUID()` plus a transport map keyed by `Mcp-Session-Id`, GET SSE streams, DELETE teardown). Rejected: pure overhead until we want server-initiated messages; can be introduced later without breaking clients (the protocol negotiates it).
+
+### D2: Mount at `POST /mcp` on the existing Fastify app, bridged via raw req/res
+
+`buildHttpApp` (or a small registration function it calls) gains an `/mcp` route. The handler calls `reply.hijack()` and then `transport.handleRequest(request.raw, reply.raw, request.body)` — Fastify has already parsed the JSON body, so it is passed as `parsedBody`. `GET /mcp` and `DELETE /mcp` are also routed to the transport so it can answer them with the spec-correct method-not-allowed JSON-RPC errors in stateless mode.
+
+- **Why hijack**: the transport writes status, headers, and body directly to the underlying `ServerResponse`; hijacking tells Fastify not to compete for the socket.
+- **Why `/mcp`, not `/api/v1/mcp`**: the `/api/v1` prefix versions the REST resource contract. MCP carries its own protocol versioning (negotiated at initialize) and its tool schemas are already governed by the shared contracts; nesting it under the REST version would wrongly couple the two lifecycles.
+
+### D3: The MCP adapter exposes a builder, the composition root stops touching transports
+
+`src/interfaces/mcp/server.ts` keeps `buildMcpServer(deps, logger)` unchanged and gains the route-registration piece (e.g. `registerMcpEndpoint(app, deps, logger)`) so the transport bridge lives with the MCP adapter, not in `app.ts` or the composition root. The composition root drops the `StdioServerTransport` import and the `mcpServer.connect(...)` call; shutdown no longer closes an MCP server (per-request transports die with their responses; `httpApp.close()` drains in-flight requests as before).
+
+- **Why**: preserves the layering — interfaces own their protocol details; composition only wires. It also keeps `app.ts` free of MCP knowledge beyond one registration call.
+
+### D4: Origin/DNS-rebinding posture stays with host binding
+
+The transport's DNS-rebinding protection stays off; the deployment posture remains "bind `config.host`, default localhost" — same trust model as the unauthenticated HTTP API. This is recorded as a risk below rather than solved here.
+
+### D5: Testing strategy
+
+- **Unit/integration (vitest, in-process)**: drive `POST /mcp` through `app.inject()` with real JSON-RPC payloads (`initialize`, `tools/list`, `tools/call`, `resources/read`) and assert on the JSON-RPC results; assert `GET /mcp` answers 405. This keeps 100% coverage of the new bridge code without sockets.
+- **E2E (out-of-process)**: extend `test/e2e/` to connect an SDK `StreamableHTTPClientTransport` client to the live server and run a submit → status-read round-trip, proving HTTP and MCP interoperate on one acquisition — the exact scenario stdio made impossible.
+
+## Risks / Trade-offs
+
+- **[Breaking change] Existing stdio client configs stop working with no overlap window** → Accepted explicitly by the owner; migration is a one-line client config change (spawn command → `http://host:port/mcp` URL). Called out in the proposal and release notes.
+- **[Unauthenticated network-reachable MCP endpoint] If `HOST` is set to a non-loopback interface, anyone who can reach the port can submit/cancel acquisitions** → Same exposure the HTTP API already has; document that MCP inherits the HTTP trust model. Origin validation/auth can be layered on later without a transport change.
+- **[Per-request server construction] Handler closures are rebuilt per request** → Negligible cost (object construction, no I/O); revisit only if profiling ever says otherwise.
+- **[Fastify raw-response bridging] `reply.hijack()` bypasses Fastify's reply lifecycle (logging hooks, error mapping) for this route** → The transport writes protocol-correct errors itself; request-level logging still fires via `onRequest`-phase hooks. Covered by the injected-request tests.
+- **[SSE surface unused but reachable] Streamable HTTP permits SSE responses; stateless mode never opens long-lived streams** → GET is answered with method-not-allowed; nothing to drain on shutdown.
+
+## Migration Plan
+
+1. Land the endpoint + stdio removal in one change (no dual-transport window — stdio is actively harmful here).
+2. Update the developer's MCP client entries from `command: node dist/...` to `url: http://localhost:<port>/mcp` (streamable HTTP).
+3. Rollback: revert the change; stdio wiring returns.
+
+## Open Questions
+
+_None — resolved during exploration: stateless mode, `/mcp` path, and dropping stdio without a deprecation window were all confirmed with the owner._

--- a/openspec/changes/mcp-streamable-http-transport/proposal.md
+++ b/openspec/changes/mcp-streamable-http-transport/proposal.md
@@ -1,0 +1,30 @@
+# Proposal: mcp-streamable-http-transport
+
+## Why
+
+The MCP server currently connects over stdio (`StdioServerTransport`), which forces the MCP client to be the parent process of the whole application. Running the app standalone for HTTP while an MCP client spawns its own instance creates a second process that either crashes on a port conflict or races the first: two reactors share one checkpoint row and can double-fire effects, each process's projections are frozen snapshots of the other's activity, and a cancellation appended by one process is never reacted to by the other. Serving MCP over the streamable HTTP transport on the existing HTTP server makes "one server, many clients" the natural deployment shape and dissolves the two-process trap entirely.
+
+## What Changes
+
+- The MCP server is exposed over the **streamable HTTP transport** at an endpoint on the existing Fastify HTTP server (same process, same port).
+- **BREAKING**: The stdio transport is **removed**. MCP clients must reconfigure from spawn-the-process (`command`/`args`) to a URL-based connection. This break to the MCP connection contract is explicitly accepted for this change (per-change exemption from the no-breaking-change policy, approved by the project owner); the MCP tool and resource contracts themselves are unchanged.
+- The composition root wires the MCP server into the HTTP app instead of connecting a stdio transport; graceful shutdown drains MCP sessions along with in-flight HTTP requests.
+- E2E coverage exercises MCP over HTTP against the running server (previously not exercisable without owning the process's stdio).
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `public-api`: MCP access changes from stdio (client-spawned process) to streamable HTTP served by the application's HTTP server — a new transport requirement, plus removal of the stdio connection mode. Tool/resource semantics and schemas are unchanged.
+
+## Impact
+
+- **Code**: `src/composition/index.ts` (drop `StdioServerTransport`, mount MCP on Fastify), `src/interfaces/mcp/server.ts` (transport wiring/session handling), `src/interfaces/http/app.ts` (new MCP endpoint), and their tests.
+- **Dependencies**: uses `StreamableHTTPServerTransport` from the already-present `@modelcontextprotocol/sdk`; may need a small Fastify raw-request bridge.
+- **Consumers**: any existing MCP client configuration (stdio `command`-style entries) must be migrated to a URL-based (streamable HTTP) configuration. There are no known external consumers beyond the developer's own clients.
+- **Contract tests / policy**: the no-breaking-change gate does not apply to this transport change (explicit exemption); HTTP API v1 remains additive and untouched.
+- **Docs/specs**: `public-api` spec gains a transport requirement; deployment/run docs change (one process serves HTTP + MCP).

--- a/openspec/changes/mcp-streamable-http-transport/specs/public-api/spec.md
+++ b/openspec/changes/mcp-streamable-http-transport/specs/public-api/spec.md
@@ -1,0 +1,28 @@
+# public-api Delta: mcp-streamable-http-transport
+
+## ADDED Requirements
+
+### Requirement: MCP is served over streamable HTTP by the application's HTTP server
+
+The system SHALL expose the MCP server over the streamable HTTP transport at a dedicated endpoint on the same HTTP server (same process and port) that serves the HTTP API, and SHALL NOT offer a stdio MCP transport. All MCP clients therefore connect to the one running instance, so acquisitions are shared across HTTP and MCP callers by construction.
+
+#### Scenario: An MCP client connects over streamable HTTP
+
+- **WHEN** an MCP client sends an initialize request to the MCP endpoint of the running HTTP server
+- **THEN** the protocol handshake completes over streamable HTTP and the client can invoke tools and read resources
+
+#### Scenario: HTTP and MCP callers operate on the same acquisitions
+
+- **GIVEN** an acquisition submitted through the HTTP API
+- **WHEN** an MCP client connected to the same server cancels that acquisition by id
+- **THEN** the cancellation applies to that same acquisition
+
+#### Scenario: Stdio transport is not offered
+
+- **WHEN** the application starts
+- **THEN** MCP is reachable only through the HTTP server's MCP endpoint, and the process's stdio streams carry no MCP protocol traffic
+
+#### Scenario: Non-POST methods on the MCP endpoint are rejected per protocol
+
+- **WHEN** a client sends a GET request to the MCP endpoint (no session-based streaming is offered)
+- **THEN** the server responds with a method-not-allowed JSON-RPC error as prescribed by the streamable HTTP transport specification

--- a/openspec/changes/mcp-streamable-http-transport/tasks.md
+++ b/openspec/changes/mcp-streamable-http-transport/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: mcp-streamable-http-transport
+
+Test-first throughout: each task's failing test lands before its production line (see `docs/development/testing.md`).
+
+## 1. MCP endpoint on the Fastify app
+
+- [x] 1.1 Write tests for `registerMcpEndpoint` in `src/interfaces/mcp/server.test.ts`: `initialize` handshake, `tools/list` with the shared zod-derived schemas, `tools/call` submit+cancel round-trip, and `resources/list`/`resources/read` of the projection-backed resources. _Deviation: driven through a real in-process listener (`app.listen({ port: 0 })`) + a real `StreamableHTTPClientTransport` client rather than `app.inject()` — the transport's Node↔Web conversion doesn't work with light-my-request's mock req/res. Still in-process, so it counts for coverage._
+- [x] 1.2 Implement `registerMcpEndpoint(app, deps, logger)` in `src/interfaces/mcp/server.ts`: per-request `buildMcpServer` + `StreamableHTTPServerTransport` (`sessionIdGenerator: undefined`), `reply.hijack()`, `transport.handleRequest(request.raw, reply.raw, request.body)` (design D1–D3).
+- [x] 1.3 Test non-POST handling: `GET /mcp` returns a method-not-allowed JSON-RPC error (405). _Deviation from design D2: GET/DELETE are answered with an explicit 405 JSON-RPC error rather than routed to the transport — in this SDK's stateless mode a GET opens a dead standalone SSE stream (200) instead of refusing, and this surface never server-pushes, so refusing is both spec-correct and avoids a hanging stream._
+- [x] 1.4 Register the MCP endpoint from `buildHttpApp` (single call, `/mcp` outside `/api/v1`); MCP routes marked `hide: true` so the OpenAPI snapshot/contract tests stay REST-only and pass unchanged.
+
+## 2. Composition root: drop stdio
+
+- [x] 2.1 Remove `StdioServerTransport` import, `buildMcpServer` call, `mcpServer.connect(...)`, and `mcpServer.close()` from `src/composition/index.ts`; MCP now rides on `buildHttpApp`/`httpApp.close()` (design D3).
+- [x] 2.2 Update the composition-root doc comment to describe the single-process HTTP+MCP surface; `pnpm check` passes (331 tests, 100% coverage).
+
+## 3. E2E: prove cross-interface interop
+
+- [x] 3.1 Added `test/e2e/mcp.e2e.test.ts`: connects an SDK `StreamableHTTPClientTransport` client to the running container, completes the handshake, `tools/list`, and reads the `md://acquisitions` collection resource.
+- [x] 3.2 Same file: submits an acquisition via the HTTP API and cancels it via the MCP `cancel_acquisition` tool on the same server, then polls to assert it settles as `Cancelled`. Verified green via `pnpm test:e2e` (3/3 E2E tests pass).
+
+## 4. Docs and client migration
+
+- [x] 4.1 Updated `README.md`: MCP is served at `http://<HTTP_HOST>:<HTTP_PORT>/mcp` over streamable HTTP, with a URL-form client-config snippet and a callout that stdio is removed (owner-approved break; tool/resource contracts unchanged).
+- [x] 4.2 No persistent stdio entry existed in `~/.claude.json` to migrate (server was only launched ad-hoc). Added a project `.mcp.json` pointing at `http://localhost:3000/mcp`; that exact URL is exercised end-to-end by the E2E real-client session (3.1/3.2).
+
+## 5. Finalize
+
+- [x] 5.1 `pnpm check` (331 tests, 100% coverage) and `pnpm test:e2e` (3/3) both green. Committed with `jj` as `feat(mcp)!: serve MCP over streamable HTTP, drop stdio transport` on bookmark `feat/mcp-streamable-http`, with a `BREAKING CHANGE:` body. Not yet pushed.

--- a/src/composition/index.ts
+++ b/src/composition/index.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
   FfmpegAudioProbe,
   FilesystemLibrary,
@@ -26,7 +25,6 @@ import {
   ProgressReadModel,
 } from '../application/projections/read-models.js';
 import { buildHttpApp } from '../interfaces/http/app.js';
-import { buildMcpServer } from '../interfaces/mcp/server.js';
 import { loadConfig } from './config.js';
 
 /**
@@ -108,22 +106,22 @@ async function main(): Promise<void> {
   const reactor = new Reactor({ store, checkpoints, bus, logger, interpreter });
   await reactor.start();
 
-  // --- Inbound interfaces (both over the same use-cases) ---------------------------------------
+  // --- Inbound interfaces: one HTTP server serves both REST and MCP (streamable HTTP) ----------
+  // MCP is mounted on the same Fastify app (`POST /mcp`) over the same use-cases, so every client —
+  // HTTP or MCP — talks to this one process. That is what lets an acquisition submitted over HTTP be
+  // observed or cancelled over MCP; the retired stdio transport forced a client-spawned second
+  // process that raced this one's reactor and read stale projections.
   const deps: UseCaseDeps = { store, clock, ids, status, progress: progressModel };
   const httpApp = await buildHttpApp(deps, logger);
   await httpApp.listen({ port: config.httpPort, host: config.host });
 
-  const mcpServer = buildMcpServer(deps, logger);
-  await mcpServer.connect(new StdioServerTransport());
-
   logger.info({ port: config.httpPort, host: config.host }, 'music-downloader started');
 
-  // --- Graceful shutdown: stop reacting, drain in-flight HTTP, close resources ------------------
+  // --- Graceful shutdown: stop reacting, drain in-flight HTTP (incl. MCP), close resources -------
   const shutdown = async (signal: string): Promise<void> => {
     logger.info({ signal }, 'shutting down');
     reactor.stop();
     await httpApp.close();
-    await mcpServer.close();
     db.close();
     process.exit(0);
   };

--- a/src/interfaces/http/app.ts
+++ b/src/interfaces/http/app.ts
@@ -32,13 +32,15 @@ import {
   submitAcquisitionResponseSchema,
 } from '../contracts/index.js';
 import { progressToDto } from '../contracts/mapping.js';
+import { registerMcpEndpoint } from '../mcp/server.js';
 
 /**
  * The versioned HTTP API (D12). A thin inbound adapter: it validates against the shared zod
  * contracts, maps DTOs to/from the domain via the anti-corruption layer, and delegates to the
  * application use-cases — it never touches domain types directly. Requests are accepted
  * asynchronously (`202`) with a status URL to observe. The same zod schemas drive request
- * validation, the OpenAPI document, and (elsewhere) the MCP tool schemas.
+ * validation, the OpenAPI document, and the MCP tool schemas. The MCP server is mounted on this
+ * same app (streamable HTTP, `POST /mcp`) so one process serves both surfaces over one port.
  */
 
 const BASE_PATH = '/api/v1/acquisitions';
@@ -74,6 +76,7 @@ export async function buildHttpApp(deps: UseCaseDeps, logger: Logger): Promise<F
   await app.register(fastifySwaggerUi, { routePrefix: '/docs' });
 
   registerAcquisitionRoutes(app, deps);
+  registerMcpEndpoint(app, deps, logger);
 
   await app.ready();
   return app;

--- a/src/interfaces/mcp/server.test.ts
+++ b/src/interfaces/mcp/server.test.ts
@@ -1,7 +1,11 @@
+import type { AddressInfo } from 'node:net';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { silentLogger } from '../../application/__fixtures__/fakes.js';
+import { buildHttpApp } from '../http/app.js';
 import { testWiring } from '../__fixtures__/wiring.js';
 import type { TestWiring } from '../__fixtures__/wiring.js';
 import { buildMcpServer } from './server.js';
@@ -166,5 +170,76 @@ describe('MCP server', () => {
       client.readResource({ uri: 'md://acquisitions/missing/progress' }),
     ).rejects.toThrow();
     await expect(client.readResource({ uri: 'md://other' })).rejects.toThrow();
+  });
+});
+
+describe('MCP over streamable HTTP', () => {
+  let wiring: TestWiring;
+  let app: FastifyInstance;
+  let baseUrl: string;
+  let client: Client;
+
+  beforeEach(async () => {
+    wiring = testWiring();
+    app = await buildHttpApp(wiring.deps, silentLogger());
+    await app.listen({ port: 0, host: '127.0.0.1' });
+    const { port } = app.server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+    client = new Client({ name: 'test', version: '0' });
+    await client.connect(new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`)));
+  });
+
+  afterEach(async () => {
+    await client.close();
+    await app.close();
+  });
+
+  it('completes the handshake and advertises the tools with derived schemas', async () => {
+    const { tools } = await client.listTools();
+
+    expect(tools.map((t) => t.name).sort()).toEqual(['cancel_acquisition', 'submit_acquisition']);
+    expect(tools.find((t) => t.name === 'submit_acquisition')?.inputSchema).toMatchObject({
+      type: 'object',
+    });
+  });
+
+  it('round-trips submit then cancel over the same server', async () => {
+    const submitted = (await client.callTool({
+      name: 'submit_acquisition',
+      arguments: descriptorArgs,
+    })) as CallToolResult;
+    wiring.sync();
+    const { acquisitionId } = JSON.parse(submitted.content[0]!.text) as { acquisitionId: string };
+    expect(submitted.isError).toBeFalsy();
+
+    const cancelled = (await client.callTool({
+      name: 'cancel_acquisition',
+      arguments: { id: acquisitionId },
+    })) as CallToolResult;
+
+    expect(cancelled.isError).toBeFalsy();
+    expect(JSON.parse(cancelled.content[0]!.text)).toEqual({ acquisitionId });
+  });
+
+  it('serves the projection-backed resources', async () => {
+    await client.callTool({ name: 'submit_acquisition', arguments: descriptorArgs });
+    wiring.sync();
+
+    const { resources } = await client.listResources();
+    expect(resources.map((r) => r.uri)).toContain('md://acquisitions');
+
+    const collection = firstJson(await client.readResource({ uri: 'md://acquisitions' }));
+    expect((collection as { acquisitions: unknown[] }).acquisitions).toHaveLength(1);
+  });
+
+  it('rejects a GET on the MCP endpoint with a method-not-allowed JSON-RPC error', async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: 'GET',
+      headers: { Accept: 'text/event-stream' },
+    });
+
+    expect(res.status).toBe(405);
+    const body = (await res.json()) as { error: { code: number } };
+    expect(typeof body.error.code).toBe('number');
   });
 });

--- a/src/interfaces/mcp/server.ts
+++ b/src/interfaces/mcp/server.ts
@@ -1,4 +1,6 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
   CallToolRequestSchema,
   ErrorCode,
@@ -7,6 +9,7 @@ import {
   McpError,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
+import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 import {
   cancelAcquisition,
@@ -32,7 +35,14 @@ import {
  * (`md://acquisitions`, `md://acquisitions/{id}`, `…/progress`). Tool input schemas are derived
  * from the shared zod contracts via `z.toJSONSchema`, so HTTP validation, OpenAPI, and MCP cannot
  * drift. Like the HTTP adapter, it maps DTOs to/from the domain and never touches domain types.
+ *
+ * MCP is served over the streamable HTTP transport on the application's own HTTP server
+ * (`registerMcpEndpoint`), so every client talks to the one running instance — no stdio, no
+ * client-spawned second process racing the reactor. The transport runs stateless: a fresh server
+ * and transport are built per request (nothing here pushes to clients, so sessions buy nothing).
  */
+
+const MCP_PATH = '/mcp';
 
 const COLLECTION_URI = 'md://acquisitions';
 const STATUS_URI = /^md:\/\/acquisitions\/([^/]+)$/;
@@ -146,4 +156,50 @@ export function buildMcpServer(deps: UseCaseDeps, logger: Logger): Server {
   });
 
   return server;
+}
+
+/**
+ * Mount the MCP server on the given Fastify app at `POST /mcp` (streamable HTTP). `/mcp` sits
+ * outside the `/api/v1` REST prefix on purpose: MCP versions its own protocol at initialize, so it
+ * must not be coupled to the REST resource version. The POST route hijacks the reply and lets the
+ * transport write the raw response directly. `GET`/`DELETE` — which the streamable HTTP protocol
+ * uses only to open or tear down server-push SSE streams — are refused with a method-not-allowed
+ * JSON-RPC error, since this stateless surface never pushes to clients.
+ */
+export function registerMcpEndpoint(app: FastifyInstance, deps: UseCaseDeps, logger: Logger): void {
+  // `hide: true` keeps MCP off the derived OpenAPI document: `/mcp` is a JSON-RPC surface, not part
+  // of the versioned REST contract the OpenAPI snapshot guards.
+  const hidden = { schema: { hide: true } };
+
+  app.post(
+    MCP_PATH,
+    hidden,
+    async (
+      request: { raw: IncomingMessage; body?: unknown },
+      reply: { hijack: () => void; raw: ServerResponse },
+    ): Promise<void> => {
+      const server = buildMcpServer(deps, logger);
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      reply.raw.on('close', () => {
+        void transport.close();
+        void server.close();
+      });
+      reply.hijack();
+      await server.connect(transport);
+      await transport.handleRequest(request.raw, reply.raw, request.body);
+    },
+  );
+
+  const methodNotAllowed = (
+    _request: unknown,
+    reply: { code: (status: number) => { send: (body: unknown) => void } },
+  ): void => {
+    reply.code(405).send({
+      jsonrpc: '2.0',
+      error: { code: -32000, message: 'Method not allowed.' },
+      id: null,
+    });
+  };
+  app.get(MCP_PATH, hidden, methodNotAllowed);
+  app.delete(MCP_PATH, hidden, methodNotAllowed);
 }

--- a/test/e2e/mcp.e2e.test.ts
+++ b/test/e2e/mcp.e2e.test.ts
@@ -1,0 +1,112 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * Out-of-process MCP E2E (change: mcp-streamable-http-transport). Proves the streamable HTTP MCP
+ * transport is served by the SAME running app as the REST API — one process, one port — so an
+ * acquisition is shared across the two surfaces. This is the exact interoperation the retired stdio
+ * transport made impossible (a stdio client had to spawn its own process, racing this one's reactor).
+ */
+
+const BASE_URL = process.env['TARGET_BASE_URL'] ?? 'http://localhost:3000';
+
+const SUBMIT_BODY = {
+  request: { kind: 'musicbrainz', mbid: 'release-1', targetType: 'album' },
+};
+
+interface CallToolResult {
+  isError?: boolean;
+  content: { type: string; text: string }[];
+}
+
+function firstJson(res: { content: { text: string }[] }): unknown {
+  return JSON.parse(res.content[0]!.text);
+}
+
+async function readResourceJson(client: Client, uri: string): Promise<unknown> {
+  const res = await client.readResource({ uri });
+  return JSON.parse((res.contents[0] as { text: string }).text);
+}
+
+async function connectMcp(): Promise<Client> {
+  const client = new Client({ name: 'e2e', version: '0' });
+  await client.connect(new StreamableHTTPClientTransport(new URL(`${BASE_URL}/mcp`)));
+  return client;
+}
+
+async function waitForOk(url: string, timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
+      if (res.ok) return;
+    } catch {
+      // not up yet
+    }
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${url}`);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+}
+
+async function pollUntilTerminal(id: string, timeoutMs = 60_000): Promise<string> {
+  const terminal = new Set(['Fulfilled', 'Exhausted', 'Conflicted', 'Cancelled']);
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const res = await fetch(`${BASE_URL}/api/v1/acquisitions/${id}`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (res.ok) {
+      const { status } = (await res.json()) as { status: string };
+      if (terminal.has(status)) return status;
+    }
+    if (Date.now() >= deadline) throw new Error(`acquisition ${id} did not settle in time`);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+}
+
+describe('out-of-process MCP E2E (streamable HTTP)', () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    await waitForOk(`${BASE_URL}/api/v1/acquisitions`);
+    client = await connectMcp();
+  });
+
+  afterAll(async () => {
+    await client.close();
+  });
+
+  it('completes the handshake and advertises the tools over the app HTTP server', async () => {
+    const { tools } = await client.listTools();
+
+    expect(tools.map((t) => t.name).sort()).toEqual(['cancel_acquisition', 'submit_acquisition']);
+
+    // The collection resource is readable over the same connection.
+    const collection = await readResourceJson(client, 'md://acquisitions');
+    expect(collection).toHaveProperty('acquisitions');
+  });
+
+  it('cancels — over MCP — an acquisition that was submitted over HTTP', async () => {
+    // Submit on one interface...
+    const submit = await fetch(`${BASE_URL}/api/v1/acquisitions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(SUBMIT_BODY),
+    });
+    expect(submit.status).toBe(202);
+    const { acquisitionId } = (await submit.json()) as { acquisitionId: string };
+
+    // ...cancel on the other, immediately, before the reactor's resolve→search→download cascade
+    // (a chain of real WireMock round-trips) reaches a terminal state.
+    const cancelled = (await client.callTool({
+      name: 'cancel_acquisition',
+      arguments: { id: acquisitionId },
+    })) as CallToolResult;
+    expect(cancelled.isError).toBeFalsy();
+    expect(firstJson(cancelled)).toEqual({ acquisitionId });
+
+    // The cancellation applied to that same acquisition.
+    expect(await pollUntilTerminal(acquisitionId)).toBe('Cancelled');
+  });
+});


### PR DESCRIPTION
## Why

The MCP server connected over **stdio**, which forces the MCP client to be the parent process of the whole app. Running the app standalone for HTTP while an MCP client spawns its own instance creates a second process that either crashes on the port or **races the first**: two reactors share one checkpoint row and can double-fire effects, each process's projections are frozen snapshots of the other's activity, and a cancellation appended by one process is never reacted to by the other. Serving MCP over **streamable HTTP** on the existing Fastify server makes "one server, many clients" the natural shape and dissolves the trap. It also frees stdout, which pino uses for structured logs.

## What changed

- MCP is mounted on the existing HTTP server at `POST /mcp` (stateless streamable HTTP), over the same use-cases — one process, one port.
- `GET`/`DELETE /mcp` return a `405` JSON-RPC error (this surface never server-pushes); MCP routes are `hide: true` so the versioned OpenAPI contract is unchanged.
- The stdio transport and its composition-root wiring are removed; MCP shuts down with `httpApp.close()`.
- `README.md` documents the URL-form client config; a project `.mcp.json` points at `http://localhost:3000/mcp`.

## ⚠️ BREAKING CHANGE

The stdio MCP transport is removed. Spawn-the-process client configs (`command`/`args`) no longer work and must move to the streamable HTTP URL (`http://<host>:<port>/mcp`). This is an **owner-approved, per-change exemption** from the no-breaking-change policy. The MCP **tool and resource contracts are unchanged**.

## Testing

- `pnpm check` — 331 tests, **100% coverage**.
- `pnpm test:e2e` — **3/3** against the real built container, including a new cross-interface test: **HTTP submit → MCP cancel → `Cancelled`** on one server (the exact interop stdio made impossible).

## Notes / deviations from design (see `openspec/changes/mcp-streamable-http-transport/tasks.md`)

1. Endpoint tests use a real in-process listener + real MCP client rather than `app.inject()` — the transport's Node↔Web conversion doesn't work with light-my-request mocks. Still in-process, so coverage counts.
2. `GET`/`DELETE` are refused with an explicit 405 rather than routed to the transport — this SDK's stateless mode opens a dead standalone SSE stream on GET instead of refusing.

Spec/design/tasks: `openspec/changes/mcp-streamable-http-transport/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)