### PR TITLE
ci(release): set git identity so the release job can tag

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -176,6 +176,9 @@ jobs:
           VERSION="${{ steps.ver.outputs.version }}"
           TAG="${{ steps.ver.outputs.tag }}"
           pnpm tsx scripts/release/changelog-section.ts "$VERSION" > /tmp/notes.md
+          # The runner has no git identity; an annotated tag needs a tagger.
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git tag -a "$TAG" -m "Release $TAG" "$GITHUB_SHA"
           git push origin "$TAG"
           gh release create "$TAG" --verify-tag --title "$TAG" --notes-file /tmp/notes.md


### PR DESCRIPTION
The first post-merge run of the new pipeline published the 2.1.0 image and passed the E2E gate, but the **Tag + GitHub Release** step failed: `git tag -a` needs a committer identity the runner doesn't have. This configures the github-actions bot identity before tagging.

No version bump (`ci:` scope) — `version-check` passes at 2.1.0. Once merged, the post-merge release job completes the pending 2.1.0 release (tag `v2.1.0` + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)