### PR TITLE
fix(acquisition): model AcquisitionState as a phase discriminated union and close staging-cleanup gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [2.1.1](https://github.com/jgchk/music-downloader/compare/v2.1.0...v2.1.1) (2026-07-05)
+
+
+### Bug Fixes
+
+* **acquisition:** model AcquisitionState as a phase discriminated union and close staging-cleanup gaps ([1f9289e](https://github.com/jgchk/music-downloader/commit/1f9289eba2ce1079fe5907d2ef98339ddbe848ce))
+
 ## [2.1.0](https://github.com/jgchk/music-downloader/compare/v2.0.1...v2.1.0) (2026-07-05)
 
 

--- a/openspec/changes/acquisition-state-phase-union/.openspec.yaml
+++ b/openspec/changes/acquisition-state-phase-union/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/acquisition-state-phase-union/design.md
+++ b/openspec/changes/acquisition-state-phase-union/design.md
@@ -1,0 +1,175 @@
+## Context
+
+`AcquisitionState` (`src/domain/acquisition/state.ts`) is the folded write-model of the decide/evolve/react decider (D2). It is one interface with a `phase: AcquisitionPhase` field and six optional fields (`request`, `policies`, `target`, `current`, `location`, plus always-present collections). Which fields are populated in which phase is documented only in comments and enforced only by `decide`'s runtime phase guards — so `decide` and `react` carry 14 non-null assertions, and TypeScript happily represents states like `Downloading` with no `current`.
+
+The state type is fully encapsulated: only `state.ts`, `decide.ts`, `react.ts`, and `acquisition.ts` touch it; everything else sees `AcquisitionSnapshot` or `AcquisitionPhase` (both unchanged by this design). Blast radius is those four files plus tests.
+
+The exploration also surfaced a staging leak (see Decision 5): `Cleanup` fires only on `CandidateRejected`, so import conflicts, cancellations, and even successful imports leave files or directories orphaned under the staging root.
+
+Literature grounding (researched 2026-07-05): the discriminated-union state and the totality semantics below are the explicitly recommended practice of the decider pattern's authors — Chassaing's Decider posts/gists, Dudycz's event-driven.io articles and Emmett framework, Equinox's documentation, and the Greg Young school. Key sources:
+
+- Dudycz, ["Should you throw an exception when rebuilding the state from events?"](https://event-driven.io/en/should_you_throw_exception_when_rebuilding_state_from_events/) — argues **ignore** head-on; throwing permanently bricks a stream because a compensating event can never be reached.
+- Dudycz, ["Writing and testing business logic in F#"](https://event-driven.io/en/writing_and_testing_business_logic_in_fsharp/) — DU state with `| _ -> state` wildcard: "our business logic should guard us later on."
+- Chassaing, [Functional Event Sourcing Decider](https://thinkbeforecoding.com/post/2021/12/17/functional-event-sourcing-decider) + his implementation gists (`| _ -> state`).
+- [Equinox DOCUMENTATION.md](https://github.com/jet/equinox/blob/master/DOCUMENTATION.md): a fold "should not throw Exceptions or log."
+- Wlaschin, [Making illegal states unrepresentable](https://fsharpforfunandprofit.com/posts/designing-with-types-making-illegal-states-unrepresentable/).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make invalid acquisition states unrepresentable: each phase variant carries exactly the fields valid in that phase.
+- Delete all 14 state-related non-null assertions; `decide`'s existing guards narrow the union for free.
+- Give `evolve` explicit, tested totality semantics for out-of-protocol events.
+- Make terminal states honest (no stale in-flight payload) and use the variant payloads to fix the staging-cleanup gaps that are cleanly fixable today.
+- Zero public-contract change: commands, events, `DomainError`, `Effect`, `AcquisitionPhase`, `AcquisitionSnapshot` shape, HTTP/MCP surfaces all untouched.
+
+**Non-Goals:**
+
+- Aborting in-flight slskd transfers on cancellation. Cancel-during-`Downloading` cleanup is racy without port-level transfer cancellation (slskd keeps writing into the staging dir after we `rm` it). This design leaves a deliberate seam (Decision 4) for that future change.
+- Typing the event↔post-state correlation in `react` via conditional types / transition-table types (Decision 3 explains why not).
+- Fat events / stateless `react` (fmodel-ts style). Noted as a possible long-term direction; not now.
+- Persisted snapshots of folded state. We refold from events every time; if snapshotting is ever added, the union becomes a serialization contract and needs its own design.
+
+## Decisions
+
+### 1. One variant per phase, with shared payload bases
+
+`AcquisitionState` becomes a union of 11 variants discriminated on `phase`, built from factored bases rather than 11 hand-rolled shapes:
+
+```ts
+/** History facts valid in every non-Empty phase. */
+interface Progress {
+  readonly rejected: readonly string[];
+  readonly searchRounds: number;
+  readonly attempts: number;
+}
+interface Requested extends Progress {
+  readonly request: AcquisitionRequest;
+  readonly policies: AcquisitionPolicies;
+}
+interface Targeted extends Requested {
+  readonly target: Target;
+}
+
+export interface EmptyState { readonly phase: 'Empty' }
+export interface PendingState extends Requested { readonly phase: 'Pending' }
+export interface SearchingState extends Targeted { readonly phase: 'Searching' }
+export interface SelectingState extends Targeted {
+  readonly phase: 'Selecting';
+  readonly working: readonly RankedCandidate[];
+}
+export interface DownloadingState extends Targeted {
+  readonly phase: 'Downloading';
+  readonly working: readonly RankedCandidate[];
+  readonly current: Candidate;
+}
+export interface ValidatingState extends Targeted {
+  readonly phase: 'Validating';
+  readonly working: readonly RankedCandidate[];
+  readonly current: Candidate;
+  readonly downloadedFiles: readonly DownloadedFile[];
+}
+export interface ImportingState extends Targeted { /* same payload as Validating */ ... }
+// Terminal:
+export interface FulfilledState extends Progress { readonly phase: 'Fulfilled'; readonly location: string }
+export interface ConflictedState extends Progress {
+  readonly phase: 'Conflicted';
+  readonly location: string;
+  readonly current: Candidate; // always reachable from Importing — non-optional
+}
+export interface ExhaustedState extends Progress { readonly phase: 'Exhausted' }
+export interface CancelledState extends Progress {
+  readonly phase: 'Cancelled';
+  readonly current?: Candidate; // present iff cancelled from Validating/Importing (Decision 4)
+}
+export interface MetadataFailedState extends Requested { readonly phase: 'MetadataFailed' }
+
+export type AcquisitionState = EmptyState | PendingState | ... ;
+```
+
+Rationale: this is exactly the pattern exhibited by Chassaing/Dudycz/Emmett; shared bases are the attested mitigation for variant count (cf. nordfjord's Equinox sample sharing one payload record across tags). `Validating`/`Importing` keep distinct variants even though payloads match — grouping would re-blur the phase distinctions this change exists to sharpen. `working` is kept on `Downloading`–`Importing` because `selectNext` consults it after a rejection.
+
+The `phase` field keeps the existing `AcquisitionPhase` values, so the public phase type is untouched (it stays exported; the union's discriminant simply references it).
+
+**Alternative considered:** grouped variants (one `InFlight` variant with `current?`) — rejected; it reintroduces the optionality we're removing.
+
+**A warning from the literature we adopt:** resist compressing `evolve`'s per-phase arms with clever generics. Trivial, verbose arms are the point (Chassaing: evolve "should be extremely simple").
+
+### 2. `evolve` totality: ignore out-of-protocol events
+
+Each `evolve` case narrows to the event's legal source phase(s) and returns `state` unchanged otherwise:
+
+```ts
+case 'TargetResolved':
+  if (state.phase !== 'Pending') return state; // out-of-protocol: ignore (see design.md D2)
+  return { ...state, phase: 'Searching', target: event.target };
+```
+
+Rationale (the researched consensus, unanimous among argued positions):
+
+- **Recoverability** (Dudycz's strongest argument): a throwing fold permanently bricks the stream — the compensating event that would heal it can never take effect because replay dies first. Ignoring keeps the stream foldable.
+- **Errors-as-values fit:** `evolve` returning `Result` is *not* the errors-as-values answer — no mid-fold caller can meaningfully handle the error. Totality is the errors-as-values design for folds.
+- **Safety is preserved by construction:** an ignored event leaves the state in its prior phase, so the very next command hits `decide`'s phase guards and returns a typed `IllegalTransition`. Validation after folding, in the business logic — exactly where Dudycz says it belongs.
+
+**Alternatives considered:**
+
+- *Throw* — violates the no-throw domain rule and recoverability; minority position attested only in code samples, argued against by the literature.
+- *`Corrupted` pseudo-phase* — unattested anywhere in the decider literature; costs a new variant, a blanket `decide` rejection path, and public `DomainError` growth, to buy only diagnosability — which belongs in the application layer (a load-time integrity check may log; the domain may not). Not adopted; noted as a possible future application-layer addition.
+- *Log-and-ignore* — the fold may not log (domain purity; Equinox agrees).
+
+Scope note: this covers genuinely corrupt/hand-edited histories only. Legacy event-schema drift is a codec problem (upcasters at deserialization, cf. FsCodec/Marten), not an `evolve` problem — `evolve` only ever sees current event shapes.
+
+### 3. `react`: runtime narrowing on post-state with a no-op fallback
+
+`react(event, postState)` keeps its event-keyed switch; cases that need state payload narrow on `postState.phase` and return `[]` on mismatch:
+
+```ts
+case 'SearchRequested':
+  return state.phase === 'Searching'
+    ? [{ type: 'Search', target: state.target, round: event.round }]
+    : [];
+```
+
+The guarantee "after `DownloadCompleted` the state is `Validating`" exists only by construction (`state = evolve(prev, event)`); no decider implementation in the surveyed literature expresses it in types. Chassaing's canonical decider has no `react` at all; fmodel-ts makes its saga stateless (data rides on events). A conditional-type `PostPhase<E>` encoding exists in the TS FSM literature but would mean hand-maintaining the transition table twice with no compiler check they agree — adopt only if `evolve` is ever *derived* from a single transition table.
+
+The `[]` fallbacks are consistent with Decision 2's semantics (a mismatched pair yields no effects) and are directly testable, satisfying the coverage gate with meaningful tests rather than ignore-pragmas.
+
+### 4. Terminal variant payloads, and what `Cancelled` deliberately forgets
+
+- `Conflicted.current: Candidate` — non-optional; `ImportConflicted` is only reachable from `Importing`. Enables conflict cleanup (Decision 5) with zero event-schema change.
+- `Cancelled.current?: Candidate` — populated by `evolve` **only when cancelling from `Validating` or `Importing`** (transfer settled, staged files known and stable). Cancelling from `Downloading` drops `current`: an in-flight slskd transfer keeps writing after any `rm`, so firing cleanup there is a lie — the racy case is deliberately excluded and the absent-`current` variant is the seam where a future download-abort change plugs in. Cancelling from earlier phases has no `current` to begin with, so the optionality is honest domain truth, not incidental modeling.
+- `Fulfilled`/`Exhausted` carry no candidate/working payload. Consequence: `AcquisitionSnapshot.currentCandidate` (derived via `state.current`) is absent on terminal states, where today spreading leaks a stale in-flight candidate into cancelled/conflicted snapshots. This is a small observable read-model change — from misleading to truthful — and no consumer depends on the stale value.
+- `Imported` becomes a state no-op in `evolve`: `AcquisitionFulfilled` (always co-emitted by `decide` in the same batch, and the only reader path) carries `location`, so `Importing` needs no `location?` field. `react` still handles `Imported` (Decision 5).
+
+### 5. Staging cleanup via the new variants
+
+`react` gains three `Cleanup` emissions, all enabled by Decision 4's payloads and requiring **no** port, adapter, event, or command changes (`Cleanup` effect and `LibraryPort.discardStaging` already exist):
+
+| Event | Narrow | Effect |
+| --- | --- | --- |
+| `ImportConflicted` | post-state `Conflicted` | `Cleanup(state.current.identity)` — the downloaded release will never be imported |
+| `AcquisitionCancelled` | post-state `Cancelled` **and** `current` present | `Cleanup(state.current.identity)` — settled staged files discarded |
+| `Imported` | post-state `Importing` | `Cleanup(state.current.identity)` — removes the now-empty candidate staging dir after files moved to the library |
+
+The `Imported` case is safe by ordering: the library adapter has already renamed/copied every file out of staging before `RecordImported` is applied, and `discardStaging` is a forced recursive `rm` (idempotent on an empty or missing dir). Reactor at-least-once redelivery of any of these events re-fires `Cleanup` harmlessly for the same reason.
+
+### 6. Testing strategy for the fold's totality (coverage gate)
+
+One **table-driven cartesian test**: every `AcquisitionEvent` type applied to every non-matching phase variant, asserting `evolve` returns the input state **identically** (same reference or deep-equal). This single parameterized test covers all ignore-fallback branches for the 100% gate *and* doubles as the totality property. `react`'s `[]` fallbacks get the same treatment (event × mismatched post-state ⇒ no effects). Existing decider given/when/then tests continue to cover the happy paths unchanged — per the standing `acquisition-aggregate` spec, all existing decider and e2e assertions must hold.
+
+## Risks / Trade-offs
+
+- **[Silently tolerated corruption]** A genuinely corrupt history replays to a confident-looking prior-phase state instead of failing loudly. → Mitigation: `decide`'s guards reject the next command with a typed error (the literature's recommended safety net); diagnosability can later be added as an application-layer load-time integrity check (allowed to log) without touching the domain.
+- **[`evolve` verbosity]** 11 variants × 17 events makes `evolve` longer and each case must construct a full variant rather than spread blindly. → Accepted deliberately; arms stay trivial, and the blind spread was exactly the bug surface (Frankenstates, stale terminal payload).
+- **[Behavioral deltas, small but real]** Terminal snapshots stop reporting `currentCandidate`; `Imported` no longer sets `location` on intermediate state; conflicts/cancels now delete staged files that yesterday lingered. → Each is an intended fix, called out in specs; e2e suite must still pass unmodified per the aggregate spec.
+- **[Cleanup redelivery]** At-least-once reactor delivery can re-fire `Cleanup`. → `discardStaging` is idempotent (`rm -rf` force); already true for the existing rejection path.
+- **[Future snapshotting]** If folded-state persistence is ever introduced, the union's shape becomes a versioned contract. → Out of scope; flagged here so that change knows to treat snapshots as schema-bearing (cf. Equinox snapshots-as-events).
+
+## Migration Plan
+
+Pure refactor of private domain internals plus additive `react` behavior — no data migration, no API version bump, no event upcasting (event schemas unchanged). Existing persisted histories fold correctly under the new `evolve` because every event sequence `decide` has ever produced follows the protocol; the ignore-fallbacks are unreachable for legal histories by construction. Rollback is a revert.
+
+## Open Questions
+
+None — the exploration and literature research (2026-07-05) resolved all of them: totality semantics (ignore), variant granularity (one per phase), react typing (runtime narrowing), cleanup scope (conflict + settled cancel + post-import in; download-abort out).

--- a/openspec/changes/acquisition-state-phase-union/proposal.md
+++ b/openspec/changes/acquisition-state-phase-union/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`AcquisitionState` is one wide interface with six optional fields, so every phase-specific guarantee ("Downloading always has a current candidate") lives only in comments and runtime guards — the type system permits invalid states, the domain carries 14 non-null assertions (`decide.ts` ×10, `react.ts` ×4), and terminal states retain stale in-flight data by accident of object spreading. This violates our "make invalid states unrepresentable" principle. Investigating the restructure also surfaced a real staging leak: import conflicts and cancellations never fire the `Cleanup` effect, so fully-downloaded releases sit orphaned in staging — and fixing that depends on exactly the variant-payload decisions this change must make anyway.
+
+## What Changes
+
+- Restructure the private `AcquisitionState` into a discriminated union keyed on `phase` — one variant per phase (11), with shared base interfaces (a `Progress` core of `rejected`/`searchRounds`/`attempts`, and accreting payload bases) factored out.
+- `evolve` narrows to each event's legal source phase(s) and **ignores out-of-protocol events** (returns state unchanged) — adopting the community-standard totality semantics for event-sourced folds (Dudycz, Chassaing, Emmett, Equinox), verified by a table-driven cartesian test (every event × every non-matching phase).
+- `react` narrows on the post-event state's phase with a no-op `[]` fallback; `decide`'s existing phase guards now narrow the union, deleting all non-null assertions.
+- Terminal variants carry only honest payload: `Conflicted` keeps its `current` candidate (always reachable from `Importing`); `Cancelled` keeps `current` only when cancelled from `Validating`/`Importing` (transfer settled); `Fulfilled`/`Exhausted`/`Cancelled` drop stale working-set data. The read snapshot consequently stops reporting an in-flight candidate on terminal acquisitions.
+- **Staging cleanup fixes** enabled by those variants — `react` now emits `Cleanup`:
+  - on `ImportConflicted` (the downloaded release will never be imported);
+  - on `AcquisitionCancelled` when a settled candidate's files are staged;
+  - on `Imported` (removes the now-empty candidate staging directory after files move to the library).
+- The `Imported` event becomes a state no-op in `evolve` (`AcquisitionFulfilled`, always co-emitted, carries `location`), so `Importing` needs no optional `location`.
+- **Out of scope:** aborting an in-flight slskd transfer on cancel (cancel-during-`Downloading` cleanup is racy without it). The `Cancelled`-without-`current` variant is the deliberate seam for that future change.
+- No public contract changes: the state type is a private module internal; commands, events, `DomainError`, `Effect`, and `AcquisitionPhase` are untouched.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `acquisition-aggregate`: adds a requirement that rehydration is a total, tolerant fold — events that do not fit the current phase are ignored during replay (never throw, never produce an invalid state), with protocol violations surfacing as typed rejections on the next command.
+- `library-import`: extends staging hygiene beyond candidate rejection — staged files are also discarded on import conflict and on cancellation once the transfer has settled, and the staging directory is removed after a successful import.
+
+## Impact
+
+- **Code:** `src/domain/acquisition/{state,decide,react,acquisition}.ts` and their tests; new `evolve` totality tests and `react` fallback tests. No changes to ports, adapters, events, commands, or interfaces — the `Cleanup` effect and `discardStaging` port already exist.
+- **Behavior:** staged files no longer leak on conflict/cancel/import; `AcquisitionSnapshot.currentCandidate` is absent on terminal acquisitions (previously could report a stale in-flight candidate — a read-model lie, now fixed). Replay of a corrupt/hand-edited history degrades to ignored events instead of a silently invalid folded state.
+- **Constraints honored:** domain stays pure and throw-free (totality *is* the errors-as-values design for folds); 100% coverage via cartesian totality tests and reachable fallback branches; additive-only public contracts (nothing public changes).

--- a/openspec/changes/acquisition-state-phase-union/specs/acquisition-aggregate/spec.md
+++ b/openspec/changes/acquisition-state-phase-union/specs/acquisition-aggregate/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Rehydration is a total, tolerant fold
+Rehydrating an acquisition from its event history SHALL be a total fold: it SHALL never throw and SHALL never produce a state whose data is inconsistent with its phase. An event that does not fit the phase the history has reached (possible only for corrupted or externally edited histories, since the decision function is the sole event producer) SHALL be ignored — the fold returns the prior state unchanged — so that the stream remains foldable and a compensating event can still take effect. Protocol violations SHALL surface as typed domain errors on the next command executed against the folded state, not during rehydration.
+
+#### Scenario: An out-of-protocol event is ignored during replay
+- **WHEN** a history containing an event that is illegal for the phase reached at that point (for example, a download completion before any candidate was selected) is folded
+- **THEN** the fold ignores that event, the resulting state reflects only the legal prefix of the history, and no exception is thrown
+
+#### Scenario: The next command on a tolerantly folded state is rejected with a typed error
+- **WHEN** a command that the resulting phase does not permit is executed against an aggregate rehydrated from such a history
+- **THEN** execution returns an illegal-transition domain error as a value
+
+#### Scenario: Every event type is ignored by every non-matching phase
+- **WHEN** each acquisition event type is applied, in isolation, to a state in each phase that is not a legal source phase for that event
+- **THEN** the fold returns the input state unchanged in every combination

--- a/openspec/changes/acquisition-state-phase-union/specs/library-import/spec.md
+++ b/openspec/changes/acquisition-state-phase-union/specs/library-import/spec.md
@@ -1,10 +1,4 @@
-# library-import Specification
-
-## Purpose
-
-Govern how validated downloads move from staging into the library: gating import on validation, organizing files by the naming policy, working across filesystems, and refusing to overwrite existing releases.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: Only validated downloads enter the library
 The system SHALL move files into the library only after they pass validation, keeping downloads in a staging area until then so the library contains only valid music. The system SHALL also discard staged files that will never enter the library — a rejected candidate's files, a conflicted import's files, and the staged files of an acquisition cancelled after its transfer has settled — and SHALL remove a candidate's staging directory once its files have been imported, so the staging area does not accumulate orphaned downloads. Cleanup of a candidate whose transfer is still in flight is explicitly not attempted (the source may still be writing into staging); aborting in-flight transfers on cancellation is deferred to a future change.
@@ -38,27 +32,3 @@ The system SHALL move files into the library only after they pass validation, ke
 - **GIVEN** a candidate whose files were imported into the library
 - **WHEN** the import outcome is processed
 - **THEN** the candidate's now-empty staging directory is removed
-
-### Requirement: Imported files are organized by a naming policy
-The system SHALL place imported files at a path rendered from the library naming policy and the target's canonical metadata.
-
-#### Scenario: Files land at the policy path
-- **GIVEN** a library naming policy and a validated album
-- **WHEN** import runs
-- **THEN** the files are placed under a path derived from the album's canonical artist, title, and year
-
-### Requirement: Import works across filesystems
-The system SHALL move files into the library when staging and the library share a filesystem, and SHALL fall back to a copy-then-remove when they do not.
-
-#### Scenario: Cross-filesystem import
-- **GIVEN** a staging area on a different filesystem from the library
-- **WHEN** import runs
-- **THEN** the files are copied to the library and then removed from staging
-
-### Requirement: Existing library releases are never overwritten
-The system SHALL NOT overwrite an existing release in the library; when the target location is already occupied it SHALL report a conflict as the acquisition's terminal outcome.
-
-#### Scenario: Conflict is reported, not clobbered
-- **GIVEN** a library that already contains the target release
-- **WHEN** import runs for a new acquisition of the same release
-- **THEN** the existing files are left untouched and the acquisition terminates reporting a conflict

--- a/openspec/changes/acquisition-state-phase-union/tasks.md
+++ b/openspec/changes/acquisition-state-phase-union/tasks.md
@@ -1,0 +1,30 @@
+## 1. State union (`src/domain/acquisition/state.ts`)
+
+- [x] 1.1 Define the shared bases (`Progress`, `Requested`, `Targeted`) and the 11 per-phase variants; replace the wide `AcquisitionState` interface with the discriminated union (design.md D1). Keep `AcquisitionPhase`, `initialState` (now `EmptyState`), `isTerminal`, and `foldEvents` signatures unchanged.
+- [x] 1.2 Red: add the table-driven cartesian totality test — every event type × every non-matching phase variant returns the input state unchanged (design.md D6; aggregate spec "Rehydration is a total, tolerant fold"). Include a builder producing a representative state for each phase.
+- [x] 1.3 Green: rewrite `evolve` — each case narrows to its legal source phase(s) and falls through to `return state`; construct full variants instead of spreading; `Imported` becomes a state no-op; terminal variants carry only their designed payload (`Conflicted.current` required, `Cancelled.current` only from Validating/Importing, stale `working`/`current` dropped elsewhere).
+- [x] 1.4 Verify all existing `evolve`/fold test expectations still hold (adjusting only assertions that inspected fields the target phase no longer carries).
+
+## 2. Decide (`src/domain/acquisition/decide.ts`)
+
+- [x] 2.1 Delete all 10 non-null assertions, letting the existing phase guards narrow the union; retype `selectNext`/`rejectAndAdvance` parameters to the narrowed variants (`DownloadingState | ValidatingState`). No behavior change — the full existing decide test suite must pass untouched.
+
+## 3. React (`src/domain/acquisition/react.ts`)
+
+- [x] 3.1 Red: tests for the new `Cleanup` emissions — on `ImportConflicted` (post-state `Conflicted`), on `AcquisitionCancelled` with a settled `current` (cancel from Validating/Importing), and on `Imported` (post-state `Importing`); plus tests that cancel-from-Downloading and cancel-from-pre-download phases emit no `Cleanup` (library-import spec scenarios).
+- [x] 3.2 Red: tests for the no-op fallbacks — each state-consuming event paired with a mismatched post-state phase yields `[]` (design.md D3).
+- [x] 3.3 Green: rewrite `react` — replace the 4 non-null assertions with phase narrowing + `[]` fallbacks, and add the three `Cleanup` emissions per design.md D5.
+
+## 4. Aggregate and boundary (`src/domain/acquisition/acquisition.ts`)
+
+- [x] 4.1 Update the `snapshot` getter to read `current`/`location` via phase-aware narrowing (terminal snapshots no longer report a stale in-flight candidate); update/extend aggregate snapshot tests for the cancelled/conflicted cases.
+
+## 5. Cleanup coverage in the e2e tiers
+
+- [x] 5.1 In-process composition e2e (`src/composition/e2e.test.ts`): make the fake library port record `discardStaging` calls, and assert the existing "reports an import conflict" scenario discards the conflicted candidate's staging (currently the fake is a silent stub, so conflict cleanup is otherwise unobserved end-to-end).
+- [x] 5.2 Out-of-process e2e (`test/e2e/acquisition.e2e.test.ts`): after the Fulfilled assertion, assert the candidate staging directory (already computed in the test via `candidateStagingDir`) has been removed — poll/retry briefly, since the reactor dispatches the `Imported` Cleanup around the same time the status turns Fulfilled. Note: the out-of-process cancel test (`mcp.e2e.test.ts`) cancels immediately after submit, *before* anything is staged — it exercises no cleanup path and needs no change; settled-phase cancel cleanup is covered by the unit tests in 3.1.
+
+## 6. Verification
+
+- [x] 6.1 Run `pnpm check` (format, lint, typecheck, build, 100%-coverage tests) and confirm zero `!` non-null assertions remain on acquisition state fields (`grep -n 'state\.\w*!' src/domain` is empty).
+- [x] 6.2 Run `pnpm test:e2e` against live stubs — all pre-existing assertions pass unchanged (aggregate spec: behavior identical for legal histories), plus the new staging assertions from section 5.

--- a/openspec/specs/acquisition-aggregate/spec.md
+++ b/openspec/specs/acquisition-aggregate/spec.md
@@ -45,3 +45,18 @@ Rehydration SHALL be the existing fold over events, execution SHALL be the exist
 #### Scenario: End-to-end behavior is unchanged
 - **WHEN** the existing end-to-end suite runs against the refactored build
 - **THEN** all scenarios pass without modification to their assertions
+
+### Requirement: Rehydration is a total, tolerant fold
+Rehydrating an acquisition from its event history SHALL be a total fold: it SHALL never throw and SHALL never produce a state whose data is inconsistent with its phase. An event that does not fit the phase the history has reached (possible only for corrupted or externally edited histories, since the decision function is the sole event producer) SHALL be ignored — the fold returns the prior state unchanged — so that the stream remains foldable and a compensating event can still take effect. Protocol violations SHALL surface as typed domain errors on the next command executed against the folded state, not during rehydration.
+
+#### Scenario: An out-of-protocol event is ignored during replay
+- **WHEN** a history containing an event that is illegal for the phase reached at that point (for example, a download completion before any candidate was selected) is folded
+- **THEN** the fold ignores that event, the resulting state reflects only the legal prefix of the history, and no exception is thrown
+
+#### Scenario: The next command on a tolerantly folded state is rejected with a typed error
+- **WHEN** a command that the resulting phase does not permit is executed against an aggregate rehydrated from such a history
+- **THEN** execution returns an illegal-transition domain error as a value
+
+#### Scenario: Every event type is ignored by every non-matching phase
+- **WHEN** each acquisition event type is applied, in isolation, to a state in each phase that is not a legal source phase for that event
+- **THEN** the fold returns the input state unchanged in every combination

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "description": "An extensible, event-sourced music downloader.",
   "type": "module",

--- a/src/application/projections/read-models.test.ts
+++ b/src/application/projections/read-models.test.ts
@@ -56,7 +56,9 @@ describe('projectStatus', () => {
     expect(view.location).toBe('/lib/c');
     expect(view.attempts).toBe(3);
     expect(view.rejectedCount).toBe(2);
-    expect(view.currentCandidate?.username).toBe('c');
+    // A fulfilled acquisition has nothing in flight, so it reports no current candidate; the
+    // candidate that succeeded is recorded in the history's 'imported' entry below.
+    expect(view.currentCandidate).toBeUndefined();
     expect(view.history.map((entry) => entry.kind)).toEqual([
       'selected',
       'download-failed',

--- a/src/composition/e2e.test.ts
+++ b/src/composition/e2e.test.ts
@@ -68,6 +68,7 @@ function wire(opts: E2eOptions) {
   const bus = new InProcessEventBus();
   const store = new SqliteEventStore(db, new UpcasterRegistry(), bus);
   const checkpoints = new SqliteCheckpointStore(db);
+  const discardStaging = vi.fn((_candidate) => okAsync<void>(undefined));
   const status = new AcquisitionStatusProjection();
   const progressModel = new ProgressReadModel();
   const libraryView = new LibraryViewProjection();
@@ -89,7 +90,7 @@ function wire(opts: E2eOptions) {
       },
     },
     probe: { probe: (path) => okAsync(PROBES[path]!) },
-    library: { import: () => okAsync(opts.importResult), discardStaging: () => okAsync(undefined) },
+    library: { import: () => okAsync(opts.importResult), discardStaging },
   };
   const interpreter: InterpreterDeps = {
     store,
@@ -105,7 +106,7 @@ function wire(opts: E2eOptions) {
     status,
     progress: progressModel,
   };
-  return { db, reactor, status, progressModel, libraryView, deps };
+  return { db, reactor, status, progressModel, libraryView, deps, discardStaging };
 }
 
 type Wiring = ReturnType<typeof wire>;
@@ -214,6 +215,10 @@ describe('acquisition E2E', () => {
     const id = res.json<{ acquisitionId: string }>().acquisitionId;
 
     await settle(w, id, 'Conflicted');
+    // The conflicted candidate's staged files must not be left orphaned in staging.
+    await vi.waitFor(() => {
+      expect(w.discardStaging).toHaveBeenCalledWith(matchingCandidate('a').identity);
+    });
   });
 
   it('fulfills an acquisition submitted over MCP', async () => {

--- a/src/domain/acquisition/acquisition.test.ts
+++ b/src/domain/acquisition/acquisition.test.ts
@@ -328,11 +328,8 @@ describe('Acquisition.reactTo — the event → effect table', () => {
     { type: 'CandidatesRanked', ranked: [] },
     { type: 'DownloadFailed', candidate: a.identity, reason: 'Stalled' },
     { type: 'ValidationFailed', candidate: a.identity, verdict: { confidence: 0, reasons: [] } },
-    { type: 'Imported', candidate: a.identity, location: '/x' },
     { type: 'AcquisitionFulfilled', location: '/x' },
     { type: 'AcquisitionExhausted' },
-    { type: 'ImportConflicted', location: '/x' },
-    { type: 'AcquisitionCancelled' },
   ];
 
   it.each(inertEvents)('emits no effect for $type', (event) => {
@@ -343,6 +340,62 @@ describe('Acquisition.reactTo — the event → effect table', () => {
     expect(
       Acquisition.fromHistory([]).reactTo({ type: 'CandidateRejected', candidate: a.identity }),
     ).toEqual([{ type: 'Cleanup', candidate: a.identity }]);
+  });
+
+  it('cleans up staging after a successful import', () => {
+    // The reactor folds the whole stream, so the post-Imported state is already Fulfilled; the
+    // Cleanup keys off the event's own candidate, not folded state.
+    expect(
+      Acquisition.fromHistory(fulfilledHistory).reactTo({
+        type: 'Imported',
+        candidate: a.identity,
+        location: '/library/x',
+      }),
+    ).toEqual([{ type: 'Cleanup', candidate: a.identity }]);
+  });
+
+  it('cleans up the conflicted candidate’s staging on an import conflict', () => {
+    expect(
+      Acquisition.fromHistory(conflictedHistory).reactTo({
+        type: 'ImportConflicted',
+        location: '/library/x',
+      }),
+    ).toEqual([{ type: 'Cleanup', candidate: a.identity }]);
+  });
+
+  it('cleans up staging when cancelling after the transfer has settled', () => {
+    const cancelledFromValidating: AcquisitionEvent[] = [
+      ...validatingHistory([a]),
+      { type: 'AcquisitionCancelled' },
+    ];
+    expect(
+      Acquisition.fromHistory(cancelledFromValidating).reactTo({ type: 'AcquisitionCancelled' }),
+    ).toEqual([{ type: 'Cleanup', candidate: a.identity }]);
+  });
+
+  it('does not clean up staging when cancelling an in-flight download', () => {
+    // cancelledHistory cancels from Downloading, where the transfer may still be writing.
+    expect(
+      Acquisition.fromHistory(cancelledHistory).reactTo({ type: 'AcquisitionCancelled' }),
+    ).toEqual([]);
+  });
+
+  it('emits no effect when a state-dependent event lands on a mismatched phase', () => {
+    // Out-of-protocol pairings (post-state does not match the event) react to nothing.
+    const empty = Acquisition.fromHistory([]);
+    expect(empty.reactTo({ type: 'SearchRequested', round: 2 })).toEqual([]);
+    expect(empty.reactTo({ type: 'CandidateSelected', candidate: a })).toEqual([]);
+    expect(empty.reactTo({ type: 'DownloadCompleted', candidate: a.identity, files: [] })).toEqual(
+      [],
+    );
+    expect(
+      empty.reactTo({
+        type: 'ValidationPassed',
+        candidate: a.identity,
+        verdict: { confidence: 1, reasons: [] },
+      }),
+    ).toEqual([]);
+    expect(empty.reactTo({ type: 'ImportConflicted', location: '/x' })).toEqual([]);
   });
 });
 
@@ -385,6 +438,36 @@ describe('Acquisition.fromHistory — phase, isTerminal, and the read snapshot',
 
     const fulfilled = Acquisition.fromHistory(fulfilledHistory).snapshot;
     expect(fulfilled.location).toBe('/library/x');
+  });
+
+  it('projects an empty acquisition with zeroed counters and no candidate or location', () => {
+    const empty = Acquisition.fromHistory([]).snapshot;
+    expect(empty).toEqual({
+      phase: 'Empty',
+      currentCandidate: undefined,
+      attempts: 0,
+      rejectedCount: 0,
+      location: undefined,
+    });
+  });
+
+  it('does not leak an in-flight candidate into a terminal snapshot', () => {
+    // Cancelled from Downloading: the transfer was in flight, so the snapshot reports no candidate.
+    const cancelledInFlight = Acquisition.fromHistory(cancelledHistory).snapshot;
+    expect(cancelledInFlight.phase).toBe('Cancelled');
+    expect(cancelledInFlight.currentCandidate).toBeUndefined();
+  });
+
+  it('retains the settled candidate and location on terminal snapshots that keep them', () => {
+    const cancelledFromValidating = Acquisition.fromHistory([
+      ...validatingHistory([a]),
+      { type: 'AcquisitionCancelled' },
+    ]).snapshot;
+    expect(cancelledFromValidating.currentCandidate).toEqual(a.identity);
+
+    const conflicted = Acquisition.fromHistory(conflictedHistory).snapshot;
+    expect(conflicted.currentCandidate).toEqual(a.identity);
+    expect(conflicted.location).toBe('/library/x');
   });
 });
 

--- a/src/domain/acquisition/acquisition.ts
+++ b/src/domain/acquisition/acquisition.ts
@@ -37,6 +37,16 @@ export interface AcquisitionSnapshot {
   readonly location?: string;
 }
 
+/**
+ * The in-flight candidate's identity, for phases that track one. Terminal phases only retain it
+ * when the candidate's staged files still matter (a conflict, or a cancellation after the transfer
+ * settled) — so a cancelled-in-flight or exhausted acquisition reports none.
+ */
+function currentIdentityOf(state: AcquisitionState): CandidateIdentity | undefined {
+  if (state.phase === 'Cancelled') return state.current?.identity;
+  return 'current' in state ? state.current.identity : undefined;
+}
+
 export class Acquisition {
   private constructor(private readonly state: AcquisitionState) {}
 
@@ -65,12 +75,13 @@ export class Acquisition {
 
   /** The read-model projection of this aggregate's folded state. */
   get snapshot(): AcquisitionSnapshot {
+    const state = this.state;
     return {
-      phase: this.state.phase,
-      currentCandidate: this.state.current?.identity,
-      attempts: this.state.attempts,
-      rejectedCount: this.state.rejected.length,
-      location: this.state.location,
+      phase: state.phase,
+      currentCandidate: currentIdentityOf(state),
+      attempts: 'attempts' in state ? state.attempts : 0,
+      rejectedCount: 'rejected' in state ? state.rejected.length : 0,
+      location: 'location' in state ? state.location : undefined,
     };
   }
 }

--- a/src/domain/acquisition/decide.ts
+++ b/src/domain/acquisition/decide.ts
@@ -6,7 +6,12 @@ import { rankCandidates } from '../ranking/ranking.js';
 import type { AcquisitionCommand, AcquisitionCommandType } from './commands.js';
 import type { AcquisitionEvent } from './events.js';
 import { isTerminal } from './state.js';
-import type { AcquisitionPhase, AcquisitionState } from './state.js';
+import type {
+  AcquisitionPhase,
+  AcquisitionState,
+  DownloadingState,
+  ValidatingState,
+} from './state.js';
 
 /**
  * `decide` is the brain (D2): a pure function that, given a command and the current state,
@@ -57,8 +62,8 @@ function usableCandidates(
  * next-best candidate, request a fresh bounded re-search, or give up (D6). `RetryPolicy` bounds
  * guarantee termination.
  */
-function selectNext(state: AcquisitionState): AcquisitionEvent {
-  const retry = state.policies!.retry;
+function selectNext(state: DownloadingState | ValidatingState): AcquisitionEvent {
+  const retry = state.policies.retry;
   if (state.attempts >= retry.maxTotalAttempts) return { type: 'AcquisitionExhausted' };
   const next = state.working[0];
   if (next !== undefined) return { type: 'CandidateSelected', candidate: next.candidate };
@@ -70,11 +75,14 @@ function selectNext(state: AcquisitionState): AcquisitionEvent {
 
 /** After a candidate fails, reject it and decide the next move in one batch. */
 function rejectAndAdvance(
-  state: AcquisitionState,
+  state: DownloadingState | ValidatingState,
   failure: AcquisitionEvent,
 ): readonly AcquisitionEvent[] {
-  const current = state.current!;
-  return [failure, { type: 'CandidateRejected', candidate: current.identity }, selectNext(state)];
+  return [
+    failure,
+    { type: 'CandidateRejected', candidate: state.current.identity },
+    selectNext(state),
+  ];
 }
 
 export function decide(command: AcquisitionCommand, state: AcquisitionState): Decision {
@@ -101,9 +109,9 @@ export function decide(command: AcquisitionCommand, state: AcquisitionState): De
       const usable = usableCandidates(command.candidates, state.rejected);
       const ranked = rankCandidates(
         usable,
-        state.target!,
-        state.policies!.quality,
-        state.policies!.match,
+        state.target,
+        state.policies.quality,
+        state.policies.match,
       );
       const events: AcquisitionEvent[] = [
         { type: 'SearchCompleted', round: state.searchRounds + 1, candidates: command.candidates },
@@ -121,7 +129,7 @@ export function decide(command: AcquisitionCommand, state: AcquisitionState): De
       if (isTerminal(state)) return ok([]);
       if (state.phase !== 'Downloading') return err(illegal(command.type, state));
       return ok([
-        { type: 'DownloadCompleted', candidate: state.current!.identity, files: command.files },
+        { type: 'DownloadCompleted', candidate: state.current.identity, files: command.files },
       ]);
 
     case 'RecordDownloadFailed':
@@ -130,7 +138,7 @@ export function decide(command: AcquisitionCommand, state: AcquisitionState): De
       return ok(
         rejectAndAdvance(state, {
           type: 'DownloadFailed',
-          candidate: state.current!.identity,
+          candidate: state.current.identity,
           reason: command.reason,
         }),
       );
@@ -139,7 +147,7 @@ export function decide(command: AcquisitionCommand, state: AcquisitionState): De
       if (isTerminal(state)) return ok([]);
       if (state.phase !== 'Validating') return err(illegal(command.type, state));
       return ok([
-        { type: 'ValidationPassed', candidate: state.current!.identity, verdict: command.verdict },
+        { type: 'ValidationPassed', candidate: state.current.identity, verdict: command.verdict },
       ]);
 
     case 'RecordValidationFailed':
@@ -148,7 +156,7 @@ export function decide(command: AcquisitionCommand, state: AcquisitionState): De
       return ok(
         rejectAndAdvance(state, {
           type: 'ValidationFailed',
-          candidate: state.current!.identity,
+          candidate: state.current.identity,
           verdict: command.verdict,
         }),
       );
@@ -157,7 +165,7 @@ export function decide(command: AcquisitionCommand, state: AcquisitionState): De
       if (isTerminal(state)) return ok([]);
       if (state.phase !== 'Importing') return err(illegal(command.type, state));
       return ok([
-        { type: 'Imported', candidate: state.current!.identity, location: command.location },
+        { type: 'Imported', candidate: state.current.identity, location: command.location },
         { type: 'AcquisitionFulfilled', location: command.location },
       ]);
 

--- a/src/domain/acquisition/react.ts
+++ b/src/domain/acquisition/react.ts
@@ -22,7 +22,19 @@ export type Effect =
   | { readonly type: 'Import'; readonly files: readonly DownloadedFile[]; readonly target: Target }
   | { readonly type: 'Cleanup'; readonly candidate: CandidateIdentity };
 
-/** `state` is the state *after* the event has been applied. */
+/**
+ * `state` is the aggregate's *current* folded state — NOT strictly the state right after `event`.
+ * The reactor folds the whole stream before reacting (see `Reactor.process`), so when `decide`
+ * co-emits `event` with a follow-on (e.g. `Imported`, always trailed by `AcquisitionFulfilled`),
+ * `state` is already the *later* phase (`Fulfilled`), not `event`'s post-state (`Importing`). This
+ * also holds under at-least-once redelivery: a re-reacted event sees whatever state the stream has
+ * since reached. Two rules follow:
+ *   1. A reaction that must fire for a non-final co-emitted event MUST key off the event's own
+ *      payload, never the folded state (e.g. `Imported` → `Cleanup(event.candidate)`).
+ *   2. A reaction that reads `state` narrows on its phase and falls through to no effects when the
+ *      pairing does not match — consistent with `evolve`'s tolerant fold, and doubling as a guard
+ *      that suppresses re-emitting an effect whose consequences the stream already records.
+ */
 export function react(event: AcquisitionEvent, state: AcquisitionState): readonly Effect[] {
   switch (event.type) {
     case 'AcquisitionRequested':
@@ -30,33 +42,53 @@ export function react(event: AcquisitionEvent, state: AcquisitionState): readonl
     case 'TargetResolved':
       return [{ type: 'Search', target: event.target, round: 1 }];
     case 'SearchRequested':
-      return [{ type: 'Search', target: state.target!, round: event.round }];
+      return state.phase === 'Searching'
+        ? [{ type: 'Search', target: state.target, round: event.round }]
+        : [];
     case 'CandidateSelected':
-      return [{ type: 'Download', candidate: event.candidate, policy: state.policies!.download }];
+      return state.phase === 'Downloading'
+        ? [{ type: 'Download', candidate: event.candidate, policy: state.policies.download }]
+        : [];
     case 'DownloadCompleted':
-      return [
-        {
-          type: 'Validate',
-          files: event.files,
-          target: state.target!,
-          matchPolicy: state.policies!.match,
-        },
-      ];
+      return state.phase === 'Validating'
+        ? [
+            {
+              type: 'Validate',
+              files: event.files,
+              target: state.target,
+              matchPolicy: state.policies.match,
+            },
+          ]
+        : [];
     case 'ValidationPassed':
-      return [{ type: 'Import', files: state.downloadedFiles, target: state.target! }];
+      return state.phase === 'Importing'
+        ? [{ type: 'Import', files: state.downloadedFiles, target: state.target }]
+        : [];
     case 'CandidateRejected':
       // A rejected candidate's staged files must never reach the library (D13).
       return [{ type: 'Cleanup', candidate: event.candidate }];
+    case 'Imported':
+      // The imported candidate's now-empty staging directory is removed. Keyed off the event's own
+      // candidate because the folded post-state is already Fulfilled (see the note above).
+      return [{ type: 'Cleanup', candidate: event.candidate }];
+    case 'ImportConflicted':
+      // The downloaded release will never be imported (the location is occupied) — discard staging.
+      return state.phase === 'Conflicted'
+        ? [{ type: 'Cleanup', candidate: state.current.identity }]
+        : [];
+    case 'AcquisitionCancelled':
+      // Discard staging only when the transfer had settled (the folded Cancelled state kept the
+      // candidate); an in-flight download is left alone (no `current`) to avoid racing the source.
+      return state.phase === 'Cancelled' && state.current !== undefined
+        ? [{ type: 'Cleanup', candidate: state.current.identity }]
+        : [];
     case 'MetadataResolutionFailed':
     case 'SearchCompleted':
     case 'CandidatesRanked':
     case 'DownloadFailed':
     case 'ValidationFailed':
-    case 'Imported':
     case 'AcquisitionFulfilled':
     case 'AcquisitionExhausted':
-    case 'ImportConflicted':
-    case 'AcquisitionCancelled':
       return [];
   }
 }

--- a/src/domain/acquisition/state.test.ts
+++ b/src/domain/acquisition/state.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import type { AcquisitionEvent } from './events.js';
+import { evolve, foldEvents } from './state.js';
+import type { AcquisitionPhase, AcquisitionState } from './state.js';
+import {
+  defaultPolicies,
+  importingHistory,
+  matchingCandidate,
+  requestedHistory,
+  resolvedHistory,
+  sampleRequest,
+  sampleTarget,
+  selectedHistory,
+  validatingHistory,
+} from './__fixtures__/acquisition-fixtures.js';
+
+const a = matchingCandidate('a');
+const b = matchingCandidate('b');
+
+// A history landing in Selecting: a is tried and rejected, leaving b untried in the working set.
+const selectingHistory: AcquisitionEvent[] = [
+  ...selectedHistory([a, b]),
+  { type: 'DownloadFailed', candidate: a.identity, reason: 'Stalled' },
+  { type: 'CandidateRejected', candidate: a.identity },
+];
+
+/** One representative, reachable state per phase, built by folding a real history. */
+const stateByPhase: Record<AcquisitionPhase, AcquisitionState> = {
+  Empty: foldEvents([]),
+  Pending: foldEvents(requestedHistory()),
+  Searching: foldEvents(resolvedHistory()),
+  Selecting: foldEvents(selectingHistory),
+  Downloading: foldEvents(selectedHistory([a])),
+  Validating: foldEvents(validatingHistory([a])),
+  Importing: foldEvents(importingHistory([a])),
+  MetadataFailed: foldEvents([...requestedHistory(), { type: 'MetadataResolutionFailed' }]),
+  Fulfilled: foldEvents([
+    ...importingHistory([a]),
+    { type: 'Imported', candidate: a.identity, location: '/library/x' },
+    { type: 'AcquisitionFulfilled', location: '/library/x' },
+  ]),
+  Conflicted: foldEvents([...importingHistory([a]), { type: 'ImportConflicted', location: '/x' }]),
+  Exhausted: foldEvents([...selectingHistory, { type: 'AcquisitionExhausted' }]),
+  Cancelled: foldEvents([...selectedHistory([a]), { type: 'AcquisitionCancelled' }]),
+};
+
+/** One representative instance of every event type. */
+const allEvents: AcquisitionEvent[] = [
+  { type: 'AcquisitionRequested', request: sampleRequest, policies: defaultPolicies() },
+  { type: 'TargetResolved', target: sampleTarget },
+  { type: 'MetadataResolutionFailed' },
+  { type: 'SearchRequested', round: 2 },
+  { type: 'SearchCompleted', round: 1, candidates: [] },
+  { type: 'CandidatesRanked', ranked: [] },
+  { type: 'CandidateSelected', candidate: a },
+  { type: 'DownloadCompleted', candidate: a.identity, files: [] },
+  { type: 'DownloadFailed', candidate: a.identity, reason: 'Stalled' },
+  { type: 'CandidateRejected', candidate: a.identity },
+  { type: 'ValidationPassed', candidate: a.identity, verdict: { confidence: 1, reasons: [] } },
+  { type: 'ValidationFailed', candidate: a.identity, verdict: { confidence: 0, reasons: [] } },
+  { type: 'Imported', candidate: a.identity, location: '/x' },
+  { type: 'AcquisitionFulfilled', location: '/x' },
+  { type: 'AcquisitionExhausted' },
+  { type: 'ImportConflicted', location: '/x' },
+  { type: 'AcquisitionCancelled' },
+];
+
+// The phases each event legally transitions FROM (where `evolve` changes state). Any other pairing
+// is out-of-protocol and MUST be ignored. Kept in lockstep with `evolve`.
+const NON_TERMINAL: readonly AcquisitionPhase[] = [
+  'Empty',
+  'Pending',
+  'Searching',
+  'Selecting',
+  'Downloading',
+  'Validating',
+  'Importing',
+];
+const legalSources: Record<AcquisitionEvent['type'], readonly AcquisitionPhase[]> = {
+  AcquisitionRequested: ['Empty'],
+  TargetResolved: ['Pending'],
+  MetadataResolutionFailed: ['Pending'],
+  SearchRequested: ['Selecting'],
+  SearchCompleted: ['Searching'],
+  CandidatesRanked: ['Searching'],
+  CandidateSelected: ['Selecting'],
+  DownloadCompleted: ['Downloading'],
+  DownloadFailed: [],
+  CandidateRejected: ['Downloading', 'Validating'],
+  ValidationPassed: ['Validating'],
+  ValidationFailed: [],
+  Imported: [],
+  AcquisitionFulfilled: ['Importing'],
+  AcquisitionExhausted: ['Selecting'],
+  ImportConflicted: ['Importing'],
+  AcquisitionCancelled: NON_TERMINAL,
+};
+
+const ALL_PHASES = Object.keys(stateByPhase) as AcquisitionPhase[];
+
+describe('evolve — totality: out-of-protocol events are ignored', () => {
+  for (const event of allEvents) {
+    const legal = legalSources[event.type];
+    for (const phase of ALL_PHASES) {
+      if (legal.includes(phase)) continue;
+      it(`ignores ${event.type} in phase ${phase}`, () => {
+        const state = stateByPhase[phase];
+        expect(evolve(state, event)).toBe(state); // unchanged, same reference
+      });
+    }
+  }
+});
+
+describe('evolve — cancellation edge cases', () => {
+  it('cancels an empty acquisition into a terminal cancelled state with zeroed progress', () => {
+    const cancelled = foldEvents([{ type: 'AcquisitionCancelled' }]);
+    expect(cancelled.phase).toBe('Cancelled');
+    expect(cancelled).toMatchObject({ rejected: [], searchRounds: 0, attempts: 0 });
+    expect('current' in cancelled).toBe(false);
+  });
+});

--- a/src/domain/acquisition/state.ts
+++ b/src/domain/acquisition/state.ts
@@ -6,9 +6,12 @@ import type { Target } from '../target/target.js';
 import type { AcquisitionEvent, AcquisitionRequest, DownloadedFile } from './events.js';
 
 /**
- * The folded state of one acquisition (the sole aggregate, D1). `evolve` is a pure, total fold
- * over the event history; it never fails and performs no I/O. Business intelligence lives in
- * `decide`, not here.
+ * The folded state of one acquisition (the sole aggregate, D1), modelled as a discriminated union
+ * on {@link AcquisitionPhase} so that each phase carries exactly the fields valid in it — invalid
+ * states are unrepresentable. `evolve` is a pure, total fold over the event history: it never fails,
+ * performs no I/O, and ignores any event that does not fit the current phase (so a corrupt or
+ * externally-edited history degrades to a foldable state rather than throwing). Business
+ * intelligence lives in `decide`, not here.
  */
 export type AcquisitionPhase =
   | 'Empty' // no acquisition yet
@@ -24,28 +27,91 @@ export type AcquisitionPhase =
   | 'MetadataFailed' // terminal
   | 'Conflicted'; // terminal
 
-export interface AcquisitionState {
-  readonly phase: AcquisitionPhase;
-  readonly request?: AcquisitionRequest;
-  readonly policies?: AcquisitionPolicies;
-  readonly target?: Target;
-  readonly working: readonly RankedCandidate[]; // untried, ranked candidates
-  readonly current?: Candidate; // the candidate currently in flight
-  readonly downloadedFiles: readonly DownloadedFile[];
+// --- Shared payload bases: fields accrete as an acquisition advances through its phases. ---
+
+/** History facts carried by every phase past `Empty`. */
+interface Progress {
   readonly rejected: readonly string[]; // candidate identity keys already rejected
   readonly searchRounds: number;
   readonly attempts: number; // download attempts made
-  readonly location?: string; // library location once imported
+}
+/** A request accepted: the intent and the policies that govern it. */
+interface Requested extends Progress {
+  readonly request: AcquisitionRequest;
+  readonly policies: AcquisitionPolicies;
+}
+/** Metadata resolved: a concrete target to search for. */
+interface Targeted extends Requested {
+  readonly target: Target;
 }
 
-export const initialState: AcquisitionState = {
-  phase: 'Empty',
-  working: [],
-  downloadedFiles: [],
-  rejected: [],
-  searchRounds: 0,
-  attempts: 0,
-};
+// --- The phase variants. ---
+
+export interface EmptyState {
+  readonly phase: 'Empty';
+}
+export interface PendingState extends Requested {
+  readonly phase: 'Pending';
+}
+export interface SearchingState extends Targeted {
+  readonly phase: 'Searching';
+}
+export interface SelectingState extends Targeted {
+  readonly phase: 'Selecting';
+  readonly working: readonly RankedCandidate[]; // untried, ranked candidates
+}
+export interface DownloadingState extends Targeted {
+  readonly phase: 'Downloading';
+  readonly working: readonly RankedCandidate[];
+  readonly current: Candidate; // the candidate currently in flight
+}
+export interface ValidatingState extends Targeted {
+  readonly phase: 'Validating';
+  readonly working: readonly RankedCandidate[];
+  readonly current: Candidate;
+  readonly downloadedFiles: readonly DownloadedFile[];
+}
+export interface ImportingState extends Targeted {
+  readonly phase: 'Importing';
+  readonly working: readonly RankedCandidate[];
+  readonly current: Candidate;
+  readonly downloadedFiles: readonly DownloadedFile[];
+}
+export interface MetadataFailedState extends Requested {
+  readonly phase: 'MetadataFailed';
+}
+export interface FulfilledState extends Progress {
+  readonly phase: 'Fulfilled';
+  readonly location: string; // library location once imported
+}
+export interface ConflictedState extends Progress {
+  readonly phase: 'Conflicted';
+  readonly location: string; // the occupied library location left untouched
+  readonly current: Candidate; // whose staged files must still be cleaned up
+}
+export interface ExhaustedState extends Progress {
+  readonly phase: 'Exhausted';
+}
+export interface CancelledState extends Progress {
+  readonly phase: 'Cancelled';
+  readonly current?: Candidate; // present only when cancelled after the transfer settled (D: Validating/Importing)
+}
+
+export type AcquisitionState =
+  | EmptyState
+  | PendingState
+  | SearchingState
+  | SelectingState
+  | DownloadingState
+  | ValidatingState
+  | ImportingState
+  | MetadataFailedState
+  | FulfilledState
+  | ConflictedState
+  | ExhaustedState
+  | CancelledState;
+
+export const initialState: EmptyState = { phase: 'Empty' };
 
 const TERMINAL_PHASES: ReadonlySet<AcquisitionPhase> = new Set<AcquisitionPhase>([
   'Fulfilled',
@@ -59,26 +125,51 @@ export function isTerminal(state: AcquisitionState): boolean {
   return TERMINAL_PHASES.has(state.phase);
 }
 
+/** The progress counters, defaulted to zero for the empty state. */
+function progressOf(state: AcquisitionState): Progress {
+  if (state.phase === 'Empty') {
+    return { rejected: [], searchRounds: 0, attempts: 0 };
+  }
+  return { rejected: state.rejected, searchRounds: state.searchRounds, attempts: state.attempts };
+}
+
 export function evolve(state: AcquisitionState, event: AcquisitionEvent): AcquisitionState {
   switch (event.type) {
     case 'AcquisitionRequested':
+      if (state.phase !== 'Empty') return state;
       return {
-        ...initialState,
         phase: 'Pending',
         request: event.request,
         policies: event.policies,
+        rejected: [],
+        searchRounds: 0,
+        attempts: 0,
       };
     case 'TargetResolved':
+      if (state.phase !== 'Pending') return state;
       return { ...state, phase: 'Searching', target: event.target };
     case 'MetadataResolutionFailed':
+      if (state.phase !== 'Pending') return state;
       return { ...state, phase: 'MetadataFailed' };
     case 'SearchRequested':
-      return { ...state, phase: 'Searching' };
+      if (state.phase !== 'Selecting') return state;
+      return {
+        phase: 'Searching',
+        request: state.request,
+        policies: state.policies,
+        target: state.target,
+        rejected: state.rejected,
+        searchRounds: state.searchRounds,
+        attempts: state.attempts,
+      };
     case 'SearchCompleted':
+      if (state.phase !== 'Searching') return state;
       return { ...state, searchRounds: state.searchRounds + 1 };
     case 'CandidatesRanked':
+      if (state.phase !== 'Searching') return state;
       return { ...state, phase: 'Selecting', working: event.ranked };
     case 'CandidateSelected':
+      if (state.phase !== 'Selecting') return state;
       return {
         ...state,
         phase: 'Downloading',
@@ -87,34 +178,69 @@ export function evolve(state: AcquisitionState, event: AcquisitionEvent): Acquis
           (ranked) =>
             candidateKey(ranked.candidate.identity) !== candidateKey(event.candidate.identity),
         ),
-        downloadedFiles: [],
         attempts: state.attempts + 1,
       };
     case 'DownloadCompleted':
+      if (state.phase !== 'Downloading') return state;
       return { ...state, phase: 'Validating', downloadedFiles: event.files };
     case 'DownloadFailed':
       return state; // the following CandidateRejected does the state work
     case 'CandidateRejected':
+      if (state.phase !== 'Downloading' && state.phase !== 'Validating') return state;
       return {
-        ...state,
         phase: 'Selecting',
-        current: undefined,
+        request: state.request,
+        policies: state.policies,
+        target: state.target,
+        working: state.working,
         rejected: [...state.rejected, candidateKey(event.candidate)],
+        searchRounds: state.searchRounds,
+        attempts: state.attempts,
       };
     case 'ValidationPassed':
+      if (state.phase !== 'Validating') return state;
       return { ...state, phase: 'Importing' };
     case 'ValidationFailed':
       return state; // the following CandidateRejected does the state work
     case 'Imported':
-      return { ...state, location: event.location };
+      // A state no-op: the co-emitted AcquisitionFulfilled carries the location; the import itself
+      // is observed via `react` (staging cleanup), not folded into state.
+      return state;
     case 'AcquisitionFulfilled':
-      return { ...state, phase: 'Fulfilled', location: event.location };
+      if (state.phase !== 'Importing') return state;
+      return {
+        phase: 'Fulfilled',
+        location: event.location,
+        rejected: state.rejected,
+        searchRounds: state.searchRounds,
+        attempts: state.attempts,
+      };
     case 'AcquisitionExhausted':
-      return { ...state, phase: 'Exhausted' };
+      if (state.phase !== 'Selecting') return state;
+      return {
+        phase: 'Exhausted',
+        rejected: state.rejected,
+        searchRounds: state.searchRounds,
+        attempts: state.attempts,
+      };
     case 'ImportConflicted':
-      return { ...state, phase: 'Conflicted', location: event.location };
+      if (state.phase !== 'Importing') return state;
+      return {
+        phase: 'Conflicted',
+        location: event.location,
+        current: state.current,
+        rejected: state.rejected,
+        searchRounds: state.searchRounds,
+        attempts: state.attempts,
+      };
     case 'AcquisitionCancelled':
-      return { ...state, phase: 'Cancelled' };
+      if (isTerminal(state)) return state;
+      // Retain the in-flight candidate only when its transfer has settled (files are staged and
+      // stable); an in-flight Downloading transfer is still being written, so cleaning it is unsafe.
+      if (state.phase === 'Validating' || state.phase === 'Importing') {
+        return { phase: 'Cancelled', current: state.current, ...progressOf(state) };
+      }
+      return { phase: 'Cancelled', ...progressOf(state) };
   }
 }
 

--- a/test/e2e/acquisition.e2e.test.ts
+++ b/test/e2e/acquisition.e2e.test.ts
@@ -106,5 +106,14 @@ describe('out-of-process acquisition E2E (HTTP)', () => {
 
     // The store is durable, not in-memory: events were persisted to an on-disk SQLite file.
     expect(existsSync(join(DATA_DIR, 'events.db'))).toBe(true);
+
+    // The Imported cleanup removes the now-empty candidate staging directory. It is dispatched
+    // around the same time the status turns Fulfilled, so poll briefly for the directory to vanish.
+    const stagingDir = candidateStagingDir(STAGING_DIR, IDENTITY);
+    const deadline = Date.now() + 10_000;
+    while (existsSync(stagingDir) && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+    expect(existsSync(stagingDir)).toBe(false);
   });
 });


### PR DESCRIPTION
## What & why

Restructures the private `AcquisitionState` into a **per-phase discriminated union** so invalid states are unrepresentable (a standing project goal). This removes 14 non-null assertions from `decide`/`react` — the existing phase guards now narrow the union for free — and, in the process, closes a set of real **staging-cleanup leaks** the old wide-state model was hiding.

Designed and researched under OpenSpec change `acquisition-state-phase-union` (archived with this PR). The totality semantics follow the decider-pattern literature (Dudycz, Chassaing, Emmett, Equinox): a fold should never throw.

## Changes

- **State union** — one variant per phase over shared `Progress`/`Requested`/`Targeted` bases; each variant carries exactly the fields valid in that phase.
- **`evolve` is a total, tolerant fold** — an event that doesn't fit the current phase is ignored (a corrupt/edited history degrades to a foldable state instead of throwing); protocol violations surface as typed rejections on the next command. Verified by a table-driven cartesian test (every event × every non-matching phase).
- **`react` narrows post-state** with `[]` fallbacks; the doc-comment now states the real contract (it receives the aggregate's *current* folded state, since the reactor folds the whole stream).
- **Staging-cleanup fixes** — staged files are now discarded on import conflict, on cancellation once the transfer has settled, and after a successful import (removing the empty candidate dir). Cancelling an in-flight download deliberately does **not** clean up (the source may still be writing) — a documented seam for a future transfer-abort change.
- **Honest terminal snapshots** — `currentCandidate` is absent on terminal acquisitions instead of leaking a stale in-flight candidate; the successful candidate remains available via the `imported` history entry.

## Behavior deltas (intentional)

- `AcquisitionStatusView.currentCandidate` is now `undefined` for terminal (incl. Fulfilled) acquisitions. Schema-compatible (field stays optional); info preserved in `history`.
- Staged files no longer leak on conflict/cancel/import.

## Testing

- `pnpm check` green: **543 unit tests at 100% coverage** (statements/branches/functions/lines), plus contract and release-tooling suites.
- Out-of-process Docker e2e green (3 tests), including a new assertion that the candidate staging directory is removed after a real filesystem import.
- No public-contract change: commands, events, `DomainError`, `Effect`, `AcquisitionPhase`, and the OpenAPI/MCP surfaces are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
