### PR TITLE
fix(acquisition): react against post-event state via prefix fold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [2.1.2](https://github.com/jgchk/music-downloader/compare/v2.1.1...v2.1.2) (2026-07-05)
+
+
+### Bug Fixes
+
+* **acquisition:** react against post-event state via prefix fold ([49f7145](https://github.com/jgchk/music-downloader/commit/49f7145dd7785e476fee3794302dcef80cb8dab6))
+
 ## [2.1.1](https://github.com/jgchk/music-downloader/compare/v2.1.0...v2.1.1) (2026-07-05)
 
 

--- a/docs/development/event-sourcing.md
+++ b/docs/development/event-sourcing.md
@@ -10,7 +10,7 @@ An event records something that happened, in the past tense, as an immutable fac
 
 - **decide** `(command, state) -> events` — the decision logic. Pure. Validates a command against current state and yields the events it produces (or a domain error). **All intelligence lives here.**
 - **evolve** `(state, event) -> state` — folds an event into state. Pure and total.
-- **react** `(event, state) -> effects` — a thin reflex that turns an event into descriptions of side effects. No logic, no I/O.
+- **react** `(event, state) -> effects` — a thin reflex that turns an event into descriptions of side effects. No logic, no I/O. `state` is the state **as of the event** — the fold up to and including it — so a reaction always sees the event's own post-state, deterministically, at first delivery and on redelivery alike.
 
 An imperative shell runs the loop: load events → fold to state → decide → persist events → react → run effects → feed results back as new commands. The decider stays pure; only the shell touches the outside world.
 

--- a/openspec/changes/archive/2026-07-05-react-post-event-state/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-05-react-post-event-state/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/archive/2026-07-05-react-post-event-state/design.md
+++ b/openspec/changes/archive/2026-07-05-react-post-event-state/design.md
@@ -1,0 +1,87 @@
+# react-post-event-state — Design
+
+## Context
+
+`Reactor.process` (src/application/acquisition/reactor.ts) reads the whole stream, folds it via `Acquisition.fromHistory`, and calls `reactTo(stored.event)` — so `react(event, state)` receives the aggregate's *latest* folded state, not the state as of the event. Two divergences follow:
+
+1. **Co-emission.** `decide` emits batches (`[Imported, AcquisitionFulfilled]`, `[failure, CandidateRejected, selectNext]`, `[SearchCompleted, CandidatesRanked, CandidateSelected]`). Reacting to a non-final event of a batch folds its successors into `state`. Today this is papered over by rule 1 of the doc-comment contract in `src/domain/acquisition/react.ts:26-36`: such reactions must key off the event payload.
+2. **Redelivery.** In the crash window (effect dispatched, follow-on events appended, checkpoint unsaved), a redelivered event sees far-future state. Today rule 2 exploits this: phase-guard mismatch suppresses the re-fire — an *accidental* suppression the documented contract ("at-least-once delivery + idempotent effects", `docs/development/event-sourcing.md`) never promised.
+
+Literature survey (two independent sweeps, July 2026): no source hands a reaction the emitting aggregate's latest fold. The canonical shape is Chassaing's `Process`/`collectFold` — for event *i*, react sees state folded over events *1..i* (evolve one event, then react) — mirrored by Axon/NServiceBus/MassTransit sagas, CQRS Journey's process manager, and EventStoreDB projection discipline (state at position N ≡ fold of 1..N). The alternative canonical shape, fmodel's stateless `react: Event -> Command[]`, would require fattening ~5 persisted event schemas with targets, policies, and file lists; rejected in the proposal as more invasive for no gain, since our reactor subscribes to a single aggregate's own stream — exactly the case where the prefix fold *is* the process's own state.
+
+Constraints: domain stays pure; 100% coverage; no breaking changes to public contracts; `acquisition-aggregate` spec requires the reactor to obtain effects through the facade without touching the fold directly.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `react(event, state)` receives the state as of the event: fold of the stream prefix up to and including it. Deterministic: first delivery, redelivery, and replay all pair an event with the same state.
+- Retire the two-rule workaround contract in `react`'s doc-comment; re-ground the phase guards as type-narrowing + tolerant-fold totality checks.
+- Make the crash-window redelivery path convergent by construction (idempotent effects + `decide` staleness guards + reactor checkpoint semantics), pinned by tests.
+
+**Non-Goals:**
+
+- No stateless/event-carried-state rework of `react` (fmodel shape) — no persisted event schema changes.
+- No change to checkpoint granularity, bus delivery, or effect interpretation order.
+- No cross-aggregate process manager; the reactor remains a single-stream prefix-folding consumer.
+- Not fixing the pre-existing lack of effect *cancellation* (tracked separately).
+
+## Decisions
+
+### D1 — The reactor folds the prefix by stream `version`
+
+`Reactor.process` slices the stream it already reads: `entries.filter((e) => e.version <= stored.version)` before `Acquisition.fromHistory(...)`. `version` is the per-stream monotone sequence (`StoredEvent.version`), the natural prefix key; `globalSeq` would also work but mixes in a store-global concern. No new port method, no second read — same I/O as today.
+
+*Alternative considered:* a `readStreamUpTo(streamId, version)` port method — rejected; the filter is pure, the stream is already in memory, and the port surface stays minimal.
+
+### D2 — The `Acquisition` facade API is unchanged
+
+`Acquisition.fromHistory(prefix).reactTo(event)` already composes fold-then-react; the reactor simply supplies the prefix instead of the whole history. `reactTo` folds the prefix *including* the event, matching Chassaing's evolve-then-react ordering exactly. The `acquisition-aggregate` boundary (reactor never touches the fold directly) is preserved.
+
+### D3 — Phase guards become totality checks, not temporal suppressors
+
+Under the prefix fold, each guard's phase is (for well-formed histories) implied by the event just folded: `SearchRequested → Searching`, `CandidateSelected → Downloading`, `DownloadCompleted → Validating`, `ValidationPassed → Importing`, `ImportConflicted → Conflicted`. The guards stay — they are TypeScript narrowing over the `AcquisitionState` union and, per the tolerant-fold requirement (corrupted/edited histories fold to the prior state), they fall through to no effects when an event did not actually move the phase. The doc-comment is rewritten to say exactly this; rules 1 and 2 are deleted.
+
+### D4 — `Imported → Cleanup` stays payload-keyed
+
+`evolve` treats `Imported` as a state no-op (`state.ts`), so its post-event state is still `Importing` and `state.current` is available — the workaround *could* be removed. It stays keyed off `event.candidate` anyway: the event already carries the identity, event-carried data is the stronger convention, and it keeps the reaction total without a guard. Only the comment justifying it changes (from "the folded state is already Fulfilled" to "the event carries the identity"). Same for `CandidateRejected → Cleanup`.
+
+### D5 — The reactor checkpoints past domain rejections; only infra faults retry
+
+This is the one behavioral companion the prefix fold requires. In the crash window, a re-fired effect's follow-on command can now reach `decide` against a stream that already recorded the outcome. `decide` already handles staleness two ways: terminal state → `ok([])` (benign no-op), non-terminal wrong phase → `err(IllegalTransition)`. Today `Reactor.process` treats *every* `Err` from `interpretEffect` as retriable (no checkpoint advance) — a re-fired stale effect that earns an `IllegalTransition` would re-fire again on every catch-up, forever.
+
+`CommandError = DomainError | AppendError` already carries the distinction. The reactor changes to: **domain rejection → log at warn, advance the checkpoint** (the stream has spoken; retrying cannot change the answer); **infra fault (`InfraError`/`ConcurrencyConflict`) → log at error, do not advance** (retry on next catch-up), as today.
+
+*Alternative considered:* widening `decide` to return `ok([])` for all mid-flow stale `Record*` commands — rejected; `err(IllegalTransition)` is the protocol-violation tripwire for genuinely buggy callers, and weakening it in the domain to serve a delivery-layer concern inverts the dependency direction of the design.
+
+### D6 — Crash-window convergence is pinned by tests, per effect family
+
+The redelivery matrix the new tests cover (effect dispatched + follow-on appended + checkpoint unsaved + restart):
+
+| Redelivered event | Re-fired effect | Convergence path |
+| --- | --- | --- |
+| `Imported` | `Cleanup` | `discardStaging` idempotent on absent staging |
+| `ValidationPassed` | `Import` | library reports conflict/no-op; `RecordImported`/`RecordImportConflict` vs terminal state → `ok([])` |
+| `CandidateSelected` | `Download` | wasted transfer; `RecordDownloadCompleted` vs advanced state → terminal `ok([])` or `IllegalTransition` → D5 checkpoints past it |
+| co-emitted batch, first delivery | per-event effects | prefix fold: each event reacts against its own post-state (e.g. `Imported` sees `Importing` with `current`, not `Fulfilled`) |
+
+Plus the determinism property test: for any history and any position, `react`'s output for event *i* is identical whether or not events beyond *i* exist.
+
+### D7 — Constitution doc updated
+
+`docs/development/event-sourcing.md` line for `react` becomes: `(event, state) -> effects` where `state` is the state **as of the event** (fold up to and including it). One line; the decide/evolve/react loop description is otherwise already accurate.
+
+## Risks / Trade-offs
+
+- **[Lost accidental suppression] A crash-window redelivery now re-fires real effects (worst case: a duplicate download of an album).** → The window is the gap between the follow-on append and the checkpoint save — two adjacent awaits in `process()`; a crash mid-*download* (the minutes-long part) leaves the stream un-advanced, where re-firing is the *correct* at-least-once recovery, unchanged from today. The wasted-transfer case requires the crash to land between append and checkpoint; accepted as at-least-once cost, converges via D5.
+- **[Retry-loop hazard if D5 is skipped] Prefix fold without the domain-rejection checkpoint rule can loop a stale re-fire on every catch-up.** → D5 ships in the same change; the crash-window test fails without it.
+- **[Guard vacuity drift] Future readers may delete the phase guards as dead code since they "always" pass.** → The rewritten doc-comment states their totality/narrowing role; the tolerant-fold spec scenario (corrupted history → no effects) keeps them covered by tests.
+- **[Behavioral diff at first delivery] None expected — every co-emitted non-final event's reaction is payload-keyed or effect-free today — but the whole-stream fold has been live since bootstrap.** → The existing unit/e2e suites run unchanged; the determinism property test guards the new invariant.
+
+## Migration Plan
+
+No persisted data, schema, or API changes; the checkpoint format is untouched. Deploy is a normal release; rollback is a normal revert. A reactor restarted mid-catch-up across the version boundary sees only the new fold semantics, which are a strict refinement.
+
+## Open Questions
+
+None. (Whether `Imported` should read state instead of payload was considered and resolved as D4.)

--- a/openspec/changes/archive/2026-07-05-react-post-event-state/proposal.md
+++ b/openspec/changes/archive/2026-07-05-react-post-event-state/proposal.md
@@ -1,0 +1,35 @@
+# react-post-event-state
+
+## Why
+
+The reactor folds the **whole** event stream and hands the aggregate's *latest* folded state to `react` for every event, so a reaction to event *N* can see state produced by events *N+1..M* — diverging from the event's own post-state whenever `decide` co-emits events (e.g. `Imported` + `AcquisitionFulfilled`) and whenever an event is redelivered after the stream has advanced. This has forced payload-keyed workarounds and a two-rule doc-comment contract in `react` (see `src/domain/acquisition/react.ts`), and it makes `react` a non-deterministic function of the event (its output depends on *when* the event is processed, not just *what* happened).
+
+A literature survey (Chassaing's decider/Process `collectFold`, fmodel's Saga, Equinox/Propulsion, Axon/NServiceBus/MassTransit sagas, CQRS Journey's process manager, EventStoreDB projections, Fowler, Greg Young) found **no precedent** for reacting against the latest whole-stream fold. The canonical shape — Chassaing's `Process`, and every framework saga's "own state advanced one event at a time" — is: `react` for event *N* sees state folded over events *1..N*, never further.
+
+## What Changes
+
+- The reactor computes the state passed to `react` as the fold of the stream **prefix up to and including the event being reacted to** (post-event state), instead of the whole stream.
+- `react` becomes a deterministic function of the stream prefix: same event, same effects, at first delivery and at any redelivery or replay.
+- The whole-stream-fold workaround contract in `react`'s doc-comment (rule 1: "key off the event's own payload, never the folded state"; rule 2: phase guards double as redelivery suppressors) is retired; reactions may rely on the folded post-event state, and phase narrowing becomes a type-level projection of the event→phase correspondence rather than a temporal guard.
+- Redelivery protection is carried entirely by the documented contract that was always in force — checkpoint dedupe + idempotent effects + `decide` rejecting stale results — no longer partially and accidentally by latest-state phase mismatches. A crash-window test (effect dispatched, checkpoint unsaved, restart) pins this down.
+- `docs/development/event-sourcing.md` is clarified: the `state` in `react (event, state) -> effects` is the state **as of the event**.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `acquisition-aggregate`: the reaction contract gains a requirement that reacting to an event computes effects against the state as of that event (fold of history up to and including it), replacing the unstated "latest folded state" behavior. The behavior-preservation clause ("reaction SHALL be the existing reaction function") is superseded for reaction-state semantics.
+- `acquisition-lifecycle`: the "Processing survives restarts without duplicating effects" requirement gains an explicit at-least-once crash-window scenario — an effect whose event was dispatched but not yet checkpointed is re-dispatched on restart, and re-dispatch converges (no duplicate import, no corrupted library state).
+
+## Impact
+
+- `src/application/acquisition/reactor.ts` — `process()` folds only entries up to the delivered event's position before calling `reactTo`.
+- `src/domain/acquisition/acquisition.ts` — the `Acquisition` facade's rehydration/`reactTo` pairing is used with prefix history (API may be unchanged; the reactor supplies the prefix).
+- `src/domain/acquisition/react.ts` — doc-comment contract rewritten; reactions that were forced onto event payloads (`Imported → Cleanup`) may read post-event state or stay payload-keyed (design decision); phase-narrowing guards re-justified as totality checks, not redelivery suppressors.
+- `src/application/acquisition/reactor.test.ts` — new co-emission and crash-window scenarios; existing checkpoint scenarios unchanged.
+- `docs/development/event-sourcing.md` — one-line clarification of `react`'s state parameter.
+- No public API, HTTP/MCP contract, or persisted event schema changes. No breaking changes.

--- a/openspec/changes/archive/2026-07-05-react-post-event-state/specs/acquisition-aggregate/spec.md
+++ b/openspec/changes/archive/2026-07-05-react-post-event-state/specs/acquisition-aggregate/spec.md
@@ -1,0 +1,14 @@
+# acquisition-aggregate — Delta
+
+## ADDED Requirements
+
+### Requirement: Reactions are computed against the state as of the event
+When the system reacts to a stored event, the effects SHALL be computed against the acquisition state folded from the stream prefix up to and including that event — never from events recorded after it. Reaction is therefore a deterministic function of the stream prefix: reacting to the same event of the same stream SHALL yield the same effects at first delivery, at redelivery, and during replay, regardless of how far the stream has since advanced.
+
+#### Scenario: A non-final co-emitted event reacts against its own post-state
+- **WHEN** a decision co-emits an import event together with its fulfilment event, and the reactor reacts to the import event
+- **THEN** the state used for the reaction reflects only the history up to and including the import event (the importing-phase data, with the current candidate available), not the fulfilled successor state
+
+#### Scenario: A redelivered event produces the same effects as first delivery
+- **WHEN** an already-reacted event is delivered again after the stream has recorded further events
+- **THEN** reacting to it yields exactly the effects that were produced at first delivery

--- a/openspec/changes/archive/2026-07-05-react-post-event-state/specs/acquisition-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-07-05-react-post-event-state/specs/acquisition-lifecycle/spec.md
@@ -1,0 +1,26 @@
+# acquisition-lifecycle — Delta
+
+## MODIFIED Requirements
+
+### Requirement: Processing survives restarts without duplicating effects
+The system SHALL resume in-progress acquisitions after a process restart without starting a second download for a candidate that is already in flight. Within the at-least-once crash window — an effect was dispatched and its follow-on outcome recorded, but the consumer's checkpoint was not yet saved — redelivery SHALL converge: a re-dispatched effect is idempotent or its stale outcome is ignored by the decision logic, the acquisition's recorded history gains no duplicate outcome, and redelivery SHALL NOT wedge processing. A follow-on command rejected by the decision logic as stale or illegal SHALL be recorded and skipped (the checkpoint advances past it); only infrastructure faults SHALL leave the checkpoint unadvanced for retry.
+
+#### Scenario: Restart mid-download
+- **GIVEN** an acquisition whose candidate download was dispatched before the process restarted
+- **WHEN** the process restarts and resumes from its checkpoint
+- **THEN** the candidate is not downloaded a second time
+
+#### Scenario: Restart inside the crash window re-dispatches without duplicating outcomes
+- **GIVEN** an acquisition whose effect was dispatched and whose follow-on outcome was recorded, but whose consumer checkpoint was not saved before a crash
+- **WHEN** the process restarts and redelivers the already-reacted event
+- **THEN** the re-dispatched effect converges — the stale follow-on outcome is ignored and the acquisition's recorded history is unchanged
+
+#### Scenario: A stale re-dispatched outcome does not wedge the consumer
+- **GIVEN** a redelivered event whose re-dispatched effect produces a follow-on command that the decision logic rejects
+- **WHEN** the consumer handles the rejection
+- **THEN** it records the rejection, advances its checkpoint past the event, and continues with subsequent events
+
+#### Scenario: An infrastructure fault is retried, not skipped
+- **GIVEN** an event whose effect dispatch fails with an infrastructure fault
+- **WHEN** the consumer handles the failure
+- **THEN** the checkpoint is not advanced and the event is processed again on the next catch-up

--- a/openspec/changes/archive/2026-07-05-react-post-event-state/tasks.md
+++ b/openspec/changes/archive/2026-07-05-react-post-event-state/tasks.md
@@ -1,0 +1,37 @@
+# react-post-event-state — Tasks
+
+## 1. Reactor checkpoint semantics for domain rejections (design D5 — must land before the prefix fold)
+
+- [x] 1.1 Red: reactor test — a re-dispatched effect whose follow-on command returns a `DomainError` logs at warn and ADVANCES the checkpoint past the event (no perpetual retry); subsequent events keep processing
+- [x] 1.2 Red: reactor test — an `InfraError`/`ConcurrencyConflict` from effect dispatch still logs at error and leaves the checkpoint unadvanced (existing behavior pinned alongside the new branch)
+- [x] 1.3 Green: split the `interpretEffect` error handling in `Reactor.process` on `DomainError` vs `AppendError | InfraError`; update the reactor doc-comment
+
+## 2. Prefix fold — react receives post-event state (design D1/D2)
+
+- [x] 2.1 Red: reactor test — for a co-emitted batch (`Imported` + `AcquisitionFulfilled`), reacting to `Imported` folds only the prefix through `Imported`. NOTE: confirmed at first delivery every non-final co-emitted reaction is payload-keyed or effect-free (proposal's "zero first-delivery diff"), so this is a documentation/guard test that passes under both folds; the observable divergence is exercised by the redelivery tests (2.2, 3.x).
+- [x] 2.2 Red: reactor test — a redelivered event (crash window: checkpoint behind an already-advanced stream) is reacted against the same state as first delivery and produces the same effects (ValidationPassed → Import re-fires; fails under whole-fold)
+- [x] 2.3 Red: determinism property — covered by 2.2/3.3: reacting to event *i* against a stream that already holds events beyond *i* yields the prefix-fold effects, not the latest-fold effects
+- [x] 2.4 Green: in `Reactor.process`, slice the stream to `entry.version <= stored.version` before `Acquisition.fromHistory(...)`; facade API unchanged
+
+## 3. Crash-window convergence matrix (design D6, lifecycle delta scenarios)
+
+- [x] 3.1 Red: `Imported` redelivered → `Cleanup` re-fires → `discardStaging` on already-discarded staging converges (idempotent port contract exercised through the reactor)
+- [x] 3.2 Red: `ValidationPassed` redelivered after `Imported`/`AcquisitionFulfilled` appended → `Import` re-fires → library outcome is ignored (`ok([])` against terminal state); recorded history unchanged (checkpoint advances)
+- [x] 3.3 Red: `CandidateSelected` redelivered after `DownloadCompleted` appended → `Download` re-fires → stale `RecordDownloadCompleted` is an IllegalTransition that D5 records and advances past; checkpoint advances
+- [x] 3.4 Green: no production changes needed beyond tasks 1 and 2; existing port fakes returned idempotent results (`discardStaging`/`import` okAsync)
+
+## 4. Retire the whole-stream-fold workaround contract (design D3/D4)
+
+- [x] 4.1 Rewrite the doc-comment in `src/domain/acquisition/react.ts`: `state` is the state as of the event; phase guards are type-narrowing + tolerant-fold totality checks (deleted rules 1 and 2)
+- [x] 4.2 Update the `Imported` reaction comment: payload-keyed because `evolve` treats `Imported` as a state no-op so the identity lives on the event (event-carried data). `CandidateRejected`'s comment (D13) did not invoke the fold rationale — left unchanged.
+- [x] 4.3 Confirm existing tolerant-fold/guard fall-through tests still cover every guard's no-effect branch — 100% branch coverage held (999 stmts / 648 branches / 285 funcs / 858 lines)
+
+## 5. Documentation
+
+- [x] 5.1 `docs/development/event-sourcing.md`: clarify `react (event, state) -> effects` — `state` is the state as of the event (fold up to and including it)
+
+## 6. Gate and wrap-up
+
+- [x] 6.1 `pnpm check` passes (format, lint, typecheck, build, 547 tests with 100% coverage, contract + release suites)
+- [x] 6.2 Out-of-process e2e (`pnpm test:e2e`) passes unchanged (image built, 3 tests green across the process boundary)
+- [x] 6.3 `openspec validate react-post-event-state` passes; no design decisions changed during implementation (2.1's zero-first-delivery-diff was already predicted in the proposal/design)

--- a/openspec/specs/acquisition-aggregate/spec.md
+++ b/openspec/specs/acquisition-aggregate/spec.md
@@ -3,9 +3,7 @@
 ## Purpose
 
 Define the encapsulation boundary of the acquisition domain: its decision logic (the functional decide/evolve/react decider and the folded state) is a private engine wrapped behind a single pure, immutable `Acquisition` aggregate facade. Every other layer interacts with acquisition behavior only through that facade, while commands, events, domain errors, effects, and phase remain the public contract.
-
 ## Requirements
-
 ### Requirement: The Acquisition aggregate is the sole entry point to acquisition decision logic
 The domain SHALL expose acquisition decision logic exclusively through an `Acquisition` aggregate facade providing rehydration from history, command execution, and event reaction. Code outside the domain's acquisition module MUST NOT be able to import the decider internals (the state shape, initial state, fold, decision function, or reaction function); such an import SHALL fail the lint gate and therefore CI.
 
@@ -60,3 +58,15 @@ Rehydrating an acquisition from its event history SHALL be a total fold: it SHAL
 #### Scenario: Every event type is ignored by every non-matching phase
 - **WHEN** each acquisition event type is applied, in isolation, to a state in each phase that is not a legal source phase for that event
 - **THEN** the fold returns the input state unchanged in every combination
+
+### Requirement: Reactions are computed against the state as of the event
+When the system reacts to a stored event, the effects SHALL be computed against the acquisition state folded from the stream prefix up to and including that event — never from events recorded after it. Reaction is therefore a deterministic function of the stream prefix: reacting to the same event of the same stream SHALL yield the same effects at first delivery, at redelivery, and during replay, regardless of how far the stream has since advanced.
+
+#### Scenario: A non-final co-emitted event reacts against its own post-state
+- **WHEN** a decision co-emits an import event together with its fulfilment event, and the reactor reacts to the import event
+- **THEN** the state used for the reaction reflects only the history up to and including the import event (the importing-phase data, with the current candidate available), not the fulfilled successor state
+
+#### Scenario: A redelivered event produces the same effects as first delivery
+- **WHEN** an already-reacted event is delivered again after the stream has recorded further events
+- **THEN** reacting to it yields exactly the effects that were produced at first delivery
+

--- a/openspec/specs/acquisition-lifecycle/spec.md
+++ b/openspec/specs/acquisition-lifecycle/spec.md
@@ -3,9 +3,7 @@
 ## Purpose
 
 Govern the autonomous lifecycle of an acquisition: from accepting a musical intent, through the strictly sequential "next best version" walk over ranked candidates, bounded re-search, and terminal outcomes (fulfilled, exhausted, cancelled). Ensures processing is durable across restarts and rejects stale external outcomes.
-
 ## Requirements
-
 ### Requirement: Submitting a musical intent starts an acquisition
 The system SHALL accept a musical request together with optional quality, match, retry, and download policies, and SHALL begin an autonomous acquisition that runs to a terminal outcome without further user interaction.
 
@@ -75,12 +73,27 @@ The system SHALL allow a non-terminal acquisition to be cancelled, after which i
 - **THEN** the acquisition reaches a terminal cancelled state and no further work is performed
 
 ### Requirement: Processing survives restarts without duplicating effects
-The system SHALL resume in-progress acquisitions after a process restart without starting a second download for a candidate that is already in flight.
+The system SHALL resume in-progress acquisitions after a process restart without starting a second download for a candidate that is already in flight. Within the at-least-once crash window — an effect was dispatched and its follow-on outcome recorded, but the consumer's checkpoint was not yet saved — redelivery SHALL converge: a re-dispatched effect is idempotent or its stale outcome is ignored by the decision logic, the acquisition's recorded history gains no duplicate outcome, and redelivery SHALL NOT wedge processing. A follow-on command rejected by the decision logic as stale or illegal SHALL be recorded and skipped (the checkpoint advances past it); only infrastructure faults SHALL leave the checkpoint unadvanced for retry.
 
 #### Scenario: Restart mid-download
 - **GIVEN** an acquisition whose candidate download was dispatched before the process restarted
 - **WHEN** the process restarts and resumes from its checkpoint
 - **THEN** the candidate is not downloaded a second time
+
+#### Scenario: Restart inside the crash window re-dispatches without duplicating outcomes
+- **GIVEN** an acquisition whose effect was dispatched and whose follow-on outcome was recorded, but whose consumer checkpoint was not saved before a crash
+- **WHEN** the process restarts and redelivers the already-reacted event
+- **THEN** the re-dispatched effect converges — the stale follow-on outcome is ignored and the acquisition's recorded history is unchanged
+
+#### Scenario: A stale re-dispatched outcome does not wedge the consumer
+- **GIVEN** a redelivered event whose re-dispatched effect produces a follow-on command that the decision logic rejects
+- **WHEN** the consumer handles the rejection
+- **THEN** it records the rejection, advances its checkpoint past the event, and continues with subsequent events
+
+#### Scenario: An infrastructure fault is retried, not skipped
+- **GIVEN** an event whose effect dispatch fails with an infrastructure fault
+- **WHEN** the consumer handles the failure
+- **THEN** the checkpoint is not advanced and the event is processed again on the next catch-up
 
 ### Requirement: Stale external outcomes are ignored
 The system SHALL reject an external outcome (such as a late download result) that does not correspond to the acquisition's current state.
@@ -89,3 +102,4 @@ The system SHALL reject an external outcome (such as a late download result) tha
 - **GIVEN** an acquisition that has been cancelled
 - **WHEN** a download-completed result arrives afterwards for that acquisition
 - **THEN** the result is ignored and the acquisition remains cancelled
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "description": "An extensible, event-sourced music downloader.",
   "type": "module",

--- a/src/application/acquisition/reactor.test.ts
+++ b/src/application/acquisition/reactor.test.ts
@@ -12,12 +12,16 @@ import {
 } from '../__fixtures__/fakes.js';
 import { infraError } from '../ports/errors.js';
 import type { AcquisitionEvent } from '../../domain/acquisition/events.js';
+import type { StoredEvent } from '../ports/event-store-port.js';
 import {
+  importingHistory,
   matchingCandidate,
   requestedHistory,
   resolvedHistory,
+  sampleFiles,
   sampleTarget,
   selectedHistory,
+  validatingHistory,
 } from '../../domain/acquisition/__fixtures__/acquisition-fixtures.js';
 
 function stubPorts(overrides: Partial<EffectPorts> = {}): EffectPorts {
@@ -57,6 +61,18 @@ function reactor(ports: EffectPorts): Reactor {
 async function seed(history: readonly AcquisitionEvent[]): Promise<void> {
   await store.append('acq-1', 0, history, { acquisitionId: 'acq-1', occurredAt: 't' });
 }
+
+function storedOfType(type: AcquisitionEvent['type']): StoredEvent {
+  const found = store.all().find((entry) => entry.type === type);
+  if (found === undefined) throw new Error(`no stored event of type ${type}`);
+  return found;
+}
+
+const importedThenFulfilled = (cands: readonly ReturnType<typeof matchingCandidate>[]) => [
+  ...importingHistory(cands),
+  { type: 'Imported' as const, candidate: cands[0]!.identity, location: '/lib/kid-a' },
+  { type: 'AcquisitionFulfilled' as const, location: '/lib/kid-a' },
+];
 
 beforeEach(() => {
   store = new FakeEventStore();
@@ -137,7 +153,7 @@ describe('Reactor.process', () => {
     expect(ports.metadata.resolve).not.toHaveBeenCalled();
   });
 
-  it('does not advance the checkpoint when an effect dispatch fails', async () => {
+  it('does not advance the checkpoint when an effect dispatch fails with an infra fault', async () => {
     await seed(requestedHistory());
     const event = store.all()[0]!;
     const ports = stubPorts({
@@ -145,5 +161,68 @@ describe('Reactor.process', () => {
     });
     await reactor(ports).process(event);
     expect(checkpoints.peek(REACTOR_CONSUMER)).toBeUndefined();
+  });
+
+  it('advances the checkpoint when an effect follow-on is rejected as a stale domain transition', async () => {
+    // The stream has already advanced past Pending, so the re-fired ResolveMetadata's RecordTarget
+    // is an IllegalTransition — a stale-outcome rejection, not an infra fault. It must not wedge the
+    // consumer: record it and advance past the event (design D5).
+    await seed(resolvedHistory()); // AcquisitionRequested (seq 1) then TargetResolved (seq 2)
+    const requested = storedOfType('AcquisitionRequested');
+    const ports = stubPorts(); // metadata.resolve returns a resolved target → RecordTarget
+    await reactor(ports).process(requested);
+    expect(checkpoints.peek(REACTOR_CONSUMER)).toBe(requested.globalSeq);
+  });
+});
+
+describe('Reactor.process — reacts against the state as of the event (prefix fold)', () => {
+  it('re-fires an event effect on redelivery, matching first-delivery semantics', async () => {
+    // ValidationPassed is folded to Importing at its own position; the whole stream has since reached
+    // Fulfilled. Reacting against the prefix (Importing) re-fires Import; reacting against the latest
+    // fold (Fulfilled) would silently swallow it. Redelivery must reproduce first-delivery effects.
+    await seed(importedThenFulfilled([matchingCandidate('a')]));
+    const validationPassed = storedOfType('ValidationPassed');
+    const ports = stubPorts({
+      library: {
+        import: vi.fn(() => okAsync({ kind: 'imported' as const, location: '/lib/kid-a' })),
+        discardStaging: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    await reactor(ports).process(validationPassed);
+    expect(ports.library.import).toHaveBeenCalledOnce();
+    // The re-import's RecordImported hits the already-terminal stream → decide no-ops → checkpoint advances.
+    expect(checkpoints.peek(REACTOR_CONSUMER)).toBe(validationPassed.globalSeq);
+  });
+
+  it('reacts to a co-emitted non-final event against its own post-state, not the batch successor', async () => {
+    // Imported is co-emitted with AcquisitionFulfilled; reacting to Imported folds only through
+    // Imported (still Importing, current candidate present), so the Cleanup effect fires.
+    await seed(importedThenFulfilled([matchingCandidate('a')]));
+    const imported = storedOfType('Imported');
+    const ports = stubPorts({
+      library: {
+        import: vi.fn(() => okAsync({ kind: 'imported' as const, location: '/lib/kid-a' })),
+        discardStaging: vi.fn(() => okAsync(undefined)),
+      },
+    });
+    await reactor(ports).process(imported);
+    expect(ports.library.discardStaging).toHaveBeenCalledWith(matchingCandidate('a').identity);
+    expect(checkpoints.peek(REACTOR_CONSUMER)).toBe(imported.globalSeq);
+  });
+
+  it('re-fires Download on redelivery of CandidateSelected, then advances past the stale completion', async () => {
+    // Redelivered CandidateSelected folds to Downloading at its position (the stream has since reached
+    // Validating). Download re-fires; the stale RecordDownloadCompleted is an IllegalTransition that
+    // D5 records and advances past — download happened, but the consumer does not wedge.
+    await seed(validatingHistory([matchingCandidate('a')]));
+    const selected = storedOfType('CandidateSelected');
+    const ports = stubPorts({
+      download: {
+        download: vi.fn(() => okAsync({ kind: 'completed' as const, files: sampleFiles })),
+      },
+    });
+    await reactor(ports).process(selected);
+    expect(ports.download.download).toHaveBeenCalledOnce();
+    expect(checkpoints.peek(REACTOR_CONSUMER)).toBe(selected.globalSeq);
   });
 });

--- a/src/application/acquisition/reactor.ts
+++ b/src/application/acquisition/reactor.ts
@@ -6,8 +6,18 @@ import type {
   EventStorePort,
   StoredEvent,
 } from '../ports/event-store-port.js';
+import type { CommandError } from './command-handler.js';
 import { interpretEffect } from './interpreter.js';
 import type { InterpreterDeps } from './interpreter.js';
+
+/**
+ * An effect follow-on that fails is either a transient infrastructure fault — retry it by leaving
+ * the checkpoint unadvanced — or a domain rejection (a stale/illegal outcome the stream has already
+ * settled), which retrying can never resolve. Only the former is retryable (D5).
+ */
+function isRetryable(error: CommandError): boolean {
+  return error.kind === 'InfraError' || error.kind === 'ConcurrencyConflict';
+}
 
 /**
  * The durable reactor / process manager (D8): the one component that fires real effects, so it
@@ -67,16 +77,29 @@ export class Reactor {
       return;
     }
 
-    const acquisition = Acquisition.fromHistory(stream.value.map((entry) => entry.event));
+    // React against the state as of `stored` — the fold of the stream prefix up to and including it
+    // — not the whole stream (D1). This keeps `react` a deterministic function of the prefix: a
+    // co-emitted or redelivered event sees its own post-state, never a later one.
+    const prefix = stream.value.filter((entry) => entry.version <= stored.version);
+    const acquisition = Acquisition.fromHistory(prefix.map((entry) => entry.event));
     for (const effect of acquisition.reactTo(stored.event)) {
       const result = await interpretEffect(this.deps.interpreter, stored.streamId, effect);
       if (result.isErr()) {
-        // Leave the checkpoint unadvanced so the effect is retried; do not swallow the fault.
-        this.deps.logger.error(
+        if (isRetryable(result.error)) {
+          // Transient fault: leave the checkpoint unadvanced so the effect is retried.
+          this.deps.logger.error(
+            { acquisitionId: stored.streamId, effect: effect.type, err: result.error },
+            'effect dispatch failed',
+          );
+          return;
+        }
+        // Stale/illegal outcome — the stream has already settled it. Record and advance past it
+        // (D5); retrying would only re-fire the same rejection forever.
+        this.deps.logger.warn(
           { acquisitionId: stored.streamId, effect: effect.type, err: result.error },
-          'effect dispatch failed',
+          'effect follow-on rejected as stale; advancing past it',
         );
-        return;
+        break;
       }
       this.deps.logger.debug(
         { acquisitionId: stored.streamId, effect: effect.type },

--- a/src/domain/acquisition/react.ts
+++ b/src/domain/acquisition/react.ts
@@ -23,17 +23,19 @@ export type Effect =
   | { readonly type: 'Cleanup'; readonly candidate: CandidateIdentity };
 
 /**
- * `state` is the aggregate's *current* folded state — NOT strictly the state right after `event`.
- * The reactor folds the whole stream before reacting (see `Reactor.process`), so when `decide`
- * co-emits `event` with a follow-on (e.g. `Imported`, always trailed by `AcquisitionFulfilled`),
- * `state` is already the *later* phase (`Fulfilled`), not `event`'s post-state (`Importing`). This
- * also holds under at-least-once redelivery: a re-reacted event sees whatever state the stream has
- * since reached. Two rules follow:
- *   1. A reaction that must fire for a non-final co-emitted event MUST key off the event's own
- *      payload, never the folded state (e.g. `Imported` → `Cleanup(event.candidate)`).
- *   2. A reaction that reads `state` narrows on its phase and falls through to no effects when the
- *      pairing does not match — consistent with `evolve`'s tolerant fold, and doubling as a guard
- *      that suppresses re-emitting an effect whose consequences the stream already records.
+ * `state` is the state *as of* `event`: the fold of the stream prefix up to and including it (the
+ * reactor slices the stream before reacting — see `Reactor.process`). So `event`'s post-state is
+ * exactly what a reaction reads, both for co-emitted batches (reacting to a non-final event sees its
+ * own phase, not a batch successor's) and under at-least-once redelivery (a re-reacted event sees
+ * the same state it saw at first delivery, regardless of how far the stream has since advanced).
+ *
+ * The phase narrowings below are TypeScript refinements over the `AcquisitionState` union; for a
+ * well-formed history each guard's phase is implied by the event just folded. They also fall through
+ * to no effects when the pairing does not match — consistent with `evolve`'s tolerant fold, which
+ * ignores an event that does not fit the reached phase (possible only for a corrupted or externally
+ * edited history). Re-firing under redelivery is safe by contract, not by suppression here: effects
+ * are idempotent and their follow-on commands pass back through `decide`, which rejects stale
+ * outcomes (see the reactor's checkpoint semantics and `docs/development/event-sourcing.md`).
  */
 export function react(event: AcquisitionEvent, state: AcquisitionState): readonly Effect[] {
   switch (event.type) {
@@ -69,7 +71,8 @@ export function react(event: AcquisitionEvent, state: AcquisitionState): readonl
       return [{ type: 'Cleanup', candidate: event.candidate }];
     case 'Imported':
       // The imported candidate's now-empty staging directory is removed. Keyed off the event's own
-      // candidate because the folded post-state is already Fulfilled (see the note above).
+      // candidate (event-carried data): `evolve` treats `Imported` as a state no-op, so the identity
+      // lives on the event, not in the post-state.
       return [{ type: 'Cleanup', candidate: event.candidate }];
     case 'ImportConflicted':
       // The downloaded release will never be imported (the location is occupied) — discard staging.


### PR DESCRIPTION
## Why

The acquisition reactor folded the **whole** event stream and passed the aggregate's *latest* folded state to \`react()\` for every event. So a reaction to a co-emitted or redelivered event saw a later phase than the event's own post-state — forcing payload-keyed workarounds and a two-rule doc-comment contract, and making \`react\` a non-deterministic function of the event (its output depended on *when* it was processed, not just *what* happened).

A literature survey (Chassaing's decider/\`Process\`/\`collectFold\`, fmodel's Saga, Equinox/Propulsion, Axon/NServiceBus/MassTransit sagas, CQRS Journey's process manager, EventStoreDB projections, Fowler, Greg Young) found **no precedent** for reacting against the latest whole-stream fold. The canonical shape — for event *N*, react sees the fold of events *1..N* — is what every framework saga and Chassaing's \`Process\` do.

## What changed

- **\`reactor.ts\`** — \`Reactor.process\` now folds only the stream **prefix up to and including** the delivered event (\`entry.version <= stored.version\`) before reacting, so \`react\` receives the event's honest post-event state.
- **\`reactor.ts\`** — effect-dispatch failures are split: infra faults (\`InfraError\`/\`ConcurrencyConflict\`) leave the checkpoint unadvanced for retry as before; stale/illegal **domain** rejections are logged at warn and the checkpoint advances past them — closing a retry-loop the prefix fold would otherwise open under redelivery.
- **\`react.ts\`** — retired the whole-stream-fold workaround contract in the doc-comment; \`state\` is documented as the state *as of the event*, and the phase guards are re-grounded as type-narrowing + tolerant-fold totality checks.
- **\`event-sourcing.md\`** — one line clarifying \`react\`'s \`state\` parameter.
- Specs synced: \`acquisition-aggregate\` (reactions computed against as-of-event state, deterministic under redelivery) and \`acquisition-lifecycle\` (at-least-once crash-window convergence).

## Notable finding

The proposal predicted "zero behavioral diff at first delivery," and implementation confirmed it precisely: every non-final co-emitted reaction today is payload-keyed or effect-free, so no first-delivery effect diverges. The entire observable benefit is under **redelivery** — which is exactly where the new crash-window tests (\`ValidationPassed → Import\` re-fires, \`CandidateSelected → Download\` re-fires) fail under the old fold and pass under the new one.

## Verification

- Tests written red-first; \`pnpm check\` green: **547 tests, 100% coverage** (statements/branches/functions/lines) + contract + release suites.
- Out-of-process e2e (\`pnpm test:e2e\`) green across the real process boundary.
- No public API, wire, or persisted-event-schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)