### PR TITLE
docs: state the docs-vs-OpenSpec altitude rule in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,3 +53,5 @@ Node · TypeScript (strict) · pnpm · neverthrow · zod · Fastify · pino · v
 - `openspec/` — change design, capability specs, and tasks (_what_ we're building).
 - `docs/development/` — the constitution (_how_ we build).
 - `src/{domain,application,adapters,interfaces,composition}` — the layers.
+
+**Keep the two at their right altitude.** `docs/development/*.md` is constitutional: durable, largely project-agnostic principles for _how_ we build. Write them without domain specifics — no aggregate names, no source names, no schemas. Code-level, project-specific design (the actual aggregate, ports, event schema, policies, endpoints) belongs in OpenSpec under `openspec/changes/<change>/`, which already carries that detail. If a development doc starts needing concrete design specifics, that's the signal it belongs in OpenSpec instead.


### PR DESCRIPTION
## What

Adds a short "Keep the two at their right altitude" paragraph under *Where things live* in `CLAUDE.md`.

## Why

The rule for how to write the development docs — `docs/development/*.md` stays constitutional and project-agnostic (no aggregate/source names, no schemas), while code-level design lives in OpenSpec under `openspec/changes/<change>/` — previously existed only in working notes. It governs every future edit to the constitution, so it belongs in-repo where any contributor (human or AI) editing the docs will see it.

Docs-only change: `version:prep --check` stays at 2.1.3 (no bump), prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)