### PR TITLE
fix(slskd): fully tear down abandoned candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [2.2.2](https://github.com/jgchk/music-downloader/compare/v2.2.1...v2.2.2) (2026-07-18)
+
+
+### Bug Fixes
+
+* **slskd:** fully tear down abandoned candidates ([b150fe1](https://github.com/jgchk/music-downloader/commit/b150fe1fb5b1dca858b3d26c2638d9696dd4c971))
+
 ## [2.2.1](https://github.com/jgchk/music-downloader/compare/v2.2.0...v2.2.1) (2026-07-18)
 
 

--- a/openspec/changes/archive/2026-07-18-slskd-abandon-full-teardown/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-18-slskd-abandon-full-teardown/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/archive/2026-07-18-slskd-abandon-full-teardown/design.md
+++ b/openspec/changes/archive/2026-07-18-slskd-abandon-full-teardown/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The `slskd-resource-ledger` change made the app steward every slskd resource it creates: `SlskdDownload.doDownload` records each transfer write-ahead, captures its GUID on poll, and on every terminal outcome calls `removeOwned(username, mine, ownedKeys)` (`download.ts`) to cancel+remove the transfers and `markRemoved` their ledger rows. A startup `SourceResourceSweep` (`sweep.ts`) finishes removals still owed for acquisitions that have folded terminal, via `SlskdResourceRemover` (`resource-remover.ts`). Both call `client.delIfPresent(`…/{id}?remove=true`)`, which the ledger change described as "cancel+remove atomically" — but the slskd 0.22.5 source shows it is **not** atomic (see D1).
+
+A live v2.2.1 acquisition (Daft Punk – RAM) exposed that this holds only for *terminal* transfers. The first candidate stalled at ~76% with files 04–13 still in flight; the app abandoned it. What survived:
+
+1. **10 `Completed, Cancelled` transfer records in slskd's UI.** `removeOwned` does its `?remove=true` pass over `mine`, then unconditionally `markRemoved`s every `ownedKeys` row. For the in-flight transfers, `?remove=true` **cancelled** them (→ `Completed, Cancelled`) but did **not** remove the record — yet the ledger row was marked removed anyway, so `ledger.allLive()` no longer returns them and the sweep never retries. The record is stranded. The successful candidate, by contrast, was all-`Succeeded` (terminal) when `removeOwned` ran, so `?remove=true` removed each cleanly — which is why only the abandoned candidate lingers.
+2. **≈706 MB of orphaned FLACs in staging.** Files 01–03 had *completed* before the stall; slskd moved them into `/app/downloads` (the shared staging dir). The abandon path returns `{ kind: 'failed' }` with no files; the domain, in `Downloading` state, mints `CandidateRejected` with `files = stagedFilesOf(Downloading) = []`, so `discardStaging([])` cleans nothing. (`?remove=true` removes the transfer *record*, not the on-disk file — confirmed by the successful import, which moved the still-present staged files after `removeOwned` ran.)
+
+Both stem from one blind spot: at the moment a candidate is abandoned, its transfers are a mix of completed and in-flight, and neither the ledger nor the domain reconciles that mix — the ledger assumes removal succeeded, and the domain assumes nothing was staged.
+
+## Goals / Non-Goals
+
+**Goals:**
+- An abandoned/aborted candidate leaves **no lingering source transfer record** — cancelled in-flight transfers are removed once terminal, or left live in the ledger so the sweep converges them.
+- An abandoned/aborted candidate leaves **no staged residue** — files the source already completed are cleaned from the shared staging volume.
+- Keep teardown best-effort and idempotent: it must never fail a working download, and a redelivered/retried teardown must converge, not error or double-clean.
+- Keep the pure domain I/O-free; keep the slskd adapter free of direct filesystem deletes (staging is the library adapter's concern, D13).
+
+**Non-Goals:**
+- No change to the *successful* teardown path (already clean) beyond sharing the confirm-removal helper.
+- No re-derivation of slskd's on-disk layout — the completed-file subset is resolved from the events API, exactly as the completed path already does.
+- No new source dependency, no public-API contract change.
+
+## Decisions
+
+### D1 — Two-step teardown: cancel, wait for terminal, then remove — and confirm before marking the ledger row removed
+
+**Confirmed against slskd 0.22.5 source.** `DELETE …/{id}?remove=true` is *not* atomic. The controller (`TransfersController.cs:82-92`) runs `Downloads.TryCancel(guid)` then, if `remove`, `Downloads.Remove(guid)` — two sequential calls. `TryCancel` only fires the cancellation token and returns (`DownloadService.cs:619`); the transfer transitions to `Completed | Cancelled` **asynchronously**, later, in the download task's `OperationCanceledException` catch (`DownloadService.cs:372`). `Remove` is **guarded on the terminal flag** — `if (!transfer.State.HasFlag(TransferStates.Completed)) throw new InvalidOperationException(...)` (`DownloadService.cs:598`) — and is a **soft delete** (sets `Removed = true`; touches no file on disk). So `?remove=true` on an *in-flight* transfer cancels it but the synchronous `Remove` hits a still-non-terminal state, throws, and never sets `Removed`; the record lingers as `Completed, Cancelled`. (The controller only catches `NotFoundException`, so that throw even surfaces as a 500 — which our `delIfPresent` re-raises and `removeOwned`'s per-transfer `try/catch` swallows, exactly reproducing the observed lingering records.) A *second* `?remove=true` once the transfer is terminal passes the guard and removes it.
+
+Therefore teardown is **two-step**: cancel the transfer (`?remove=false` for an active one, to avoid the spurious 500), **poll until it carries the `Completed` flag**, then `?remove=true` to soft-delete the record. Already-terminal (e.g. `Completed, Succeeded`) transfers skip straight to the remove. Change both `removeOwned` and `SlskdResourceRemover.remove` to this, bounded by a small number of rounds, and **`markRemoved` a row only once its transfer is confirmed absent from the poll**. Rows not confirmed gone within the bound stay live in the ledger — the **startup sweep** retries them next boot (by then terminal, hence removable), restoring the safety net the ledger change intended.
+
+*Why keep the sweep fallback rather than loop until gone.* Teardown must not block on a flaky/slow async transition; leaving unconfirmed rows live hands them to the sweep, which is exactly the mechanism for "removals we still owe". *Why `?remove=false` for the active cancel.* It avoids the guaranteed-500 that `?remove=true` throws on a non-terminal transfer; the removal is issued on the confirmed-terminal re-poll.
+
+### D2 — Report the abandoned candidate's already-completed files, and clean them through the domain
+
+At abandon time the adapter can see which of `mine` are `Completed, Succeeded`; it resolves their source-reported staged paths via the **same events resolver the completed path uses** (`resolveStagedPaths`), and returns them on the failed outcome: `DownloadResult` gains `{ kind: 'failed'; reason; files?: readonly DownloadedFile[] }`. `RecordDownloadFailed` carries those files; `decide` stamps them onto the `CandidateRejected` it already mints in `rejectAndAdvance`; `react`'s `Cleanup` (already files-carrying, D3) hands them to `LibraryPort.discardStaging`, which removes exactly those files and prunes the emptied leaf dir. The slskd adapter never touches the filesystem — cleanup stays the library adapter's job.
+
+*Why thread through the domain rather than delete in the adapter.* The dependency rule keeps staging under the filesystem `LibraryPort` (D13); the slskd adapter is a `DownloadPort`. Reporting-then-cleaning reuses the exact D3 path already proven for rejected/imported candidates, so there is one cleanup mechanism, not two. *Additivity.* The new event/command field is optional; legacy history upcasts to `[]` (a no-op cleanup), consistent with the D3 fields already added.
+
+### D3 — Resolve the completed subset best-effort; never let cleanup reporting fail the abandon
+
+Resolving staged paths hits the events API and can lag or error. On the abandon path that must not turn a clean "failed, reason=Stalled" into an infra fault (which would wedge the retry loop on a already-doomed candidate). So the completed-subset resolution is best-effort: on any error it yields no files (the outcome is still `failed` with its real reason), and the orphaned files fall to a future staging reconciliation rather than blocking the retry. The record-removal confirm (D1) is likewise best-effort with the sweep as the backstop.
+
+## Risks / Trade-offs
+
+- **[slskd cancel/remove semantics — CONFIRMED from source]** ~~Assumed from observation~~ — resolved by reading slskd 0.22.5 (`TransfersController.cs:82`, `DownloadService.cs:372/598/619`): removal is guarded on the `Completed` flag and cancellation is async, so a two-step teardown is definitively required (see D1). No longer a risk; the implementation follows the confirmed mechanism. A live probe could add belt-and-suspenders confirmation but is not needed.
+- **[Async transition timing]** The `Completed, Cancelled` transition lands asynchronously after `TryCancel`, so the re-poll may need a brief wait before the record is removable. → The bounded poll loop (with the existing poll interval) absorbs this; anything still not terminal within the bound falls to the sweep.
+- **[Extra polls on the abandon path]** The confirm loop adds a bounded number of transfer polls per abandon. → Abandon is already the slow, off-happy-path outcome; the bound keeps it small, and the sweep absorbs anything left.
+- **[Partial-file resolution lag]** The completed subset may not yet be in the events log at abandon time. → Best-effort (D3): unresolved files are simply not cleaned now; a follow-up staging reconciliation (out of scope here) or the next run's sweep-adjacent cleanup can retire them. No orphan is *worse* than today.
+- **[Additive event field]** Another optional field on `CandidateRejected`/the failure command. → Consistent with the D3 fields; upcast to `[]`; covered by the totality/upcast tests already in place.
+
+## Open Questions
+
+- Should orphaned staged files that could not be resolved at abandon time be swept by a periodic **staging reconciliation** (list the staging volume, drop anything not owned by a live acquisition), rather than only cleaned inline? That would also retire pre-existing orphans (like the live-run residue). Proposed as a possible follow-up, not required for this change's core guarantee.

--- a/openspec/changes/archive/2026-07-18-slskd-abandon-full-teardown/proposal.md
+++ b/openspec/changes/archive/2026-07-18-slskd-abandon-full-teardown/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+A live production acquisition (v2.2.1) revealed that when a multi-file candidate is **abandoned mid-download** (a stall, a queue timeout, or a cancellation), the app tears it down only partially. Two kinds of residue survive, both from the same cause — the domain and the ledger never learn the true state of an in-flight candidate's transfers at the moment it is dropped:
+
+- **Lingering source records.** slskd's `DELETE …?remove=true` on an *in-flight* transfer only **cancels** it (→ `Completed, Cancelled`); the record is not removed in that call (removal lands only once a transfer is terminal). But `removeOwned` marks the ledger row removed **unconditionally** right after, so the startup sweep's `allLive()` never returns it — the cancelled record is stranded in slskd's UI forever (verified live: 10 `Completed, Cancelled` rows from the abandoned peer).
+- **Orphaned staged files.** Files that *completed* before the abandon were moved by the source into the shared staging dir. The domain never saw a `DownloadCompleted` for the abandoned candidate, so its `CandidateRejected` carries no files and `discardStaging([])` is a no-op — leaving partial FLACs (≈706 MB in the live run) orphaned on the staging volume. (`?remove=true` removes the transfer *record*, not the file.)
+
+This is the `slskd-resource-ledger` stewardship path (shipped separately), surfaced by the `slskd-report-staged-location` E2E; a successful candidate is torn down cleanly, so the gap is specific to the abandoned/aborted path.
+
+## What Changes
+
+- The transfer-removal teardown (`removeOwned` / abort / abandon) **confirms** each owned transfer is actually gone from the source before marking its ledger row removed: after the cancel pass it re-polls and re-issues `?remove=true` for any now-terminal record still present, bounded and idempotent. Rows not confirmed gone stay live, so the **startup sweep retries them** (by then terminal, hence removable) instead of being falsely marked done.
+- An abandoned/aborted candidate's **already-completed files** are cleaned from staging: the adapter resolves the completed subset's source-reported locations (the same events resolution the completed path uses) and reports them on the failed outcome, so the domain's existing `discardStaging` removes them — no orphaned partial files.
+- No new source dependency; no public-API contract change. A small domain/event addition threads the abandoned candidate's partial staged files to cleanup, mirroring the D3 pattern already used for rejected/imported candidates.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `source-resource-stewardship`: a transfer cancelled while in-flight must be **removed** from the source, not left as a lingering cancelled record; the ledger row is marked removed only once the source confirms the record is gone, so the startup sweep converges any that linger.
+- `download-management`: an abandoned or aborted candidate's files that the source had already completed into staging must be cleaned up, not orphaned — cleanup targets the source-reported locations of that partial set.
+
+## Impact
+
+- `src/adapters/slskd/download.ts` — `removeOwned` gains a confirm-and-retry removal loop; `abandon`/`doAbort`/the doomed-failure path resolve the completed-file subset and surface it for cleanup.
+- `src/adapters/slskd/resource-remover.ts` — the sweep's removal likewise confirms the record is gone before the sweep marks the row removed (shared teardown semantics).
+- `src/application/ports/outbound-ports.ts` — `DownloadResult`'s `failed` variant carries the abandoned candidate's partial staged files.
+- `src/domain/acquisition/{commands,decide,events}.ts` — `RecordDownloadFailed` / `CandidateRejected` thread those partial files so `discardStaging` cleans them (additive, D3-style; legacy history upcasts to none).
+- `src/application/acquisition/interpreter.ts` — passes the partial files from the failed outcome into the command.
+- Tests across the above plus a contract/E2E assertion that an abandoned candidate leaves no lingering source record and no staged residue.

--- a/openspec/changes/archive/2026-07-18-slskd-abandon-full-teardown/specs/download-management/spec.md
+++ b/openspec/changes/archive/2026-07-18-slskd-abandon-full-teardown/specs/download-management/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: An abandoned candidate's already-completed files are cleaned from staging
+
+When a candidate is abandoned or aborted mid-download (a stall, a queue timeout, or a cancellation), the system SHALL clean up the files the source had already completed into staging before the candidate stopped, targeting the source-reported locations of that completed subset, so no partial staged files are orphaned. The cleanup SHALL reuse the same staging-removal path a rejected candidate uses. Resolving the completed subset SHALL be best-effort: if it cannot be resolved, the system SHALL still report the abandonment as a failure with its original reason rather than turning it into an infrastructure fault.
+
+#### Scenario: Partial completed files are cleaned when a multi-file candidate is abandoned
+
+- **GIVEN** a multi-file candidate where some files completed into staging and others were still in flight when the candidate stalled or was cancelled
+- **WHEN** the candidate is abandoned
+- **THEN** the already-completed files are removed from staging at their source-reported locations, leaving no partial residue
+- **AND** the abandonment is still reported as a failure with its original reason
+
+#### Scenario: An unresolvable completed subset does not fail the abandonment
+
+- **GIVEN** a candidate is abandoned but the source has not yet reported the locations of the files it already completed
+- **WHEN** the system tears the candidate down
+- **THEN** the outcome is still a failure with its original reason, not an infrastructure fault
+- **AND** no partial file is left imported or mistaken for a completed download

--- a/openspec/changes/archive/2026-07-18-slskd-abandon-full-teardown/specs/source-resource-stewardship/spec.md
+++ b/openspec/changes/archive/2026-07-18-slskd-abandon-full-teardown/specs/source-resource-stewardship/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Transfer records are removed from the source once settled
+The system SHALL remove its transfers' tracked records from the source after the transfers settle, on every settlement path — completion, failure, policy abandonment, and cancellation — marking the ledger entries removed, so records from a previous attempt can never contaminate a later attempt's outcome. When a transfer is still in flight at teardown, cancelling it MAY leave a terminal-but-still-tracked record at the source; the system SHALL confirm the record is actually gone — removing the now-terminal record if it persists — before marking its ledger entry removed. A ledger entry whose record cannot be confirmed removed SHALL be left live so the startup sweep converges it, rather than marked removed. Removal of an already-absent record SHALL be a tolerated no-op.
+
+#### Scenario: Records are removed after a completed download
+- **WHEN** a candidate's transfers all complete and the outcome is reported
+- **THEN** the transfers' records are removed from the source and their ledger entries marked removed
+
+#### Scenario: A later attempt sees only its own transfers
+- **GIVEN** a candidate that was attempted before, whose settled records were removed
+- **WHEN** the same candidate is enqueued again by a later acquisition
+- **THEN** the new attempt's outcome reflects only the new transfers
+
+#### Scenario: An abandoned candidate's in-flight transfers leave no lingering record
+- **GIVEN** a candidate abandoned (stalled, queue-timed-out, or cancelled) with some transfers still in flight
+- **WHEN** its teardown cancels those transfers at the source
+- **THEN** each cancelled transfer's now-terminal record is removed from the source, leaving no lingering cancelled record
+- **AND** a ledger entry whose record is not confirmed gone is left live so the startup sweep retires it, rather than being marked removed

--- a/openspec/changes/archive/2026-07-18-slskd-abandon-full-teardown/tasks.md
+++ b/openspec/changes/archive/2026-07-18-slskd-abandon-full-teardown/tasks.md
@@ -1,0 +1,28 @@
+## 1. Verify slskd cancel/remove semantics (spike) — RESOLVED
+
+- [x] 1.1 ~~Confirm slskd's `?remove=true` semantics.~~ **Resolved by reading slskd 0.22.5 source** (see design D1): `TransfersController.cs:82` calls `TryCancel` then a guarded `Remove`; `Remove` throws unless `State.HasFlag(Completed)` (`DownloadService.cs:598`) and is a soft delete (record only, no file touched); the cancel→`Completed, Cancelled` transition is async (`DownloadService.cs:372`). ⇒ a single `?remove=true` on an in-flight transfer cancels-but-doesn't-remove (and 500s); a two-step "cancel → poll-to-terminal → remove" is required. No live probe needed.
+
+## 2. Confirm the source record is gone before marking the ledger removed (D1)
+
+- [x] 2.1 Write failing tests in `download.test.ts` for `removeOwned`: after the `?remove=true` cancel pass over in-flight transfers, it re-polls the user's transfers and re-issues `?remove=true` for any of ours still present (now terminal), bounded; it `markRemoved`s a row **only** once its transfer is absent, and leaves a row live when the record cannot be confirmed gone. Cover: all-succeeded (removed first pass, no re-poll needed), mixed in-flight (cancel → re-poll → remove), and give-up-after-bound (row left live, no `markRemoved`).
+- [x] 2.2 Implement the confirm-and-retry removal loop in `download.ts` `removeOwned`, keeping it best-effort (a source fault never fails a settled/abandoned outcome) and idempotent.
+- [x] 2.3 Write failing tests for `SlskdResourceRemover.remove` (`resource-remover.test.ts`) applying the same confirm semantics for the sweep arm; implement so `sweep.ts` only marks a row removed once the record is confirmed gone (an unconfirmed row stays live for the next boot).
+
+## 3. Clean the abandoned candidate's already-completed files (D2/D3)
+
+- [x] 3.1 Write failing tests that `DownloadResult`'s `failed` variant carries the abandoned candidate's partial staged files, and that the adapter resolves the `Completed, Succeeded` subset of `mine` via the events resolver on the abandon / doomed-failure / abort paths and reports them.
+- [x] 3.2 Implement the adapter change in `download.ts` (`abandon`, the `hasFailure` doom path, `doAbort`): resolve the completed subset's source-reported paths (reusing `resolveStagedPaths`) and put them on the failed outcome. Keep it best-effort (D3): a resolution error yields `failed` with no files, never an infra fault.
+- [x] 3.3 Update `outbound-ports.ts` `DownloadResult` (`failed` gains `files?: readonly DownloadedFile[]`) and `commands.ts` `RecordDownloadFailed` (gains `files?`); write failing tests.
+- [x] 3.4 Write failing `decide`/`state`/`acquisition.test.ts` cases: `decide` stamps the failed command's partial files onto the `CandidateRejected` minted in `rejectAndAdvance`, so `react`'s `Cleanup` carries them; fields additive/optional with an upcast default for legacy history.
+- [x] 3.5 Implement 3.3–3.4 through `commands`/`decide`/`events`; keep the pure core I/O-free and the slskd adapter free of filesystem deletes.
+- [x] 3.6 Update `interpreter.ts` to thread `result.files` from a failed download into `RecordDownloadFailed`; write failing tests.
+
+## 4. E2E / contract fidelity
+
+- [x] 4.1 Add an in-process (`composition/e2e.test.ts`) or out-of-process scenario for an abandoned multi-file candidate with a completed subset: assert the completed files are discarded from staging (no residue) and the failed outcome keeps its reason.
+- [x] 4.2 Add a stub/assertion that an abandoned candidate's in-flight transfers are confirmed removed (no lingering `Completed, Cancelled` record) — the source double is queried for residual transfer records after teardown.
+
+## 5. Gate
+
+- [x] 5.1 Run `pnpm check` (format → lint → typecheck → build → test w/ 100% coverage) and resolve any gaps.
+- [x] 5.2 Update `download.ts` / `resource-remover.ts` / adapter doc comments: teardown confirms record removal before marking the ledger, and an abandoned candidate's already-completed files are cleaned via the domain's `discardStaging`; note the sweep as the backstop for unconfirmed removals.

--- a/openspec/specs/download-management/spec.md
+++ b/openspec/specs/download-management/spec.md
@@ -92,3 +92,21 @@ The system SHALL report each file of a completed download at the location the so
 - **GIVEN** a candidate whose downloaded files were staged at the source-reported location and then rejected by validation
 - **WHEN** staging-cleanup runs for that candidate
 - **THEN** it removes the files at that same reported location, leaving no staged residue
+
+### Requirement: An abandoned candidate's already-completed files are cleaned from staging
+
+When a candidate is abandoned or aborted mid-download (a stall, a queue timeout, or a cancellation), the system SHALL clean up the files the source had already completed into staging before the candidate stopped, targeting the source-reported locations of that completed subset, so no partial staged files are orphaned. The cleanup SHALL reuse the same staging-removal path a rejected candidate uses. Resolving the completed subset SHALL be best-effort: if it cannot be resolved, the system SHALL still report the abandonment as a failure with its original reason rather than turning it into an infrastructure fault.
+
+#### Scenario: Partial completed files are cleaned when a multi-file candidate is abandoned
+
+- **GIVEN** a multi-file candidate where some files completed into staging and others were still in flight when the candidate stalled or was cancelled
+- **WHEN** the candidate is abandoned
+- **THEN** the already-completed files are removed from staging at their source-reported locations, leaving no partial residue
+- **AND** the abandonment is still reported as a failure with its original reason
+
+#### Scenario: An unresolvable completed subset does not fail the abandonment
+
+- **GIVEN** a candidate is abandoned but the source has not yet reported the locations of the files it already completed
+- **WHEN** the system tears the candidate down
+- **THEN** the outcome is still a failure with its original reason, not an infrastructure fault
+- **AND** no partial file is left imported or mistaken for a completed download

--- a/openspec/specs/source-resource-stewardship/spec.md
+++ b/openspec/specs/source-resource-stewardship/spec.md
@@ -48,7 +48,7 @@ The system SHALL delete its search from the source after collecting responses, b
 - **THEN** the search is deleted from the source, stopping it, and the harvested candidates are still returned
 
 ### Requirement: Transfer records are removed from the source once settled
-The system SHALL remove its transfers' tracked records from the source after the transfers settle, on every settlement path — completion, failure, policy abandonment, and cancellation — marking the ledger entries removed, so records from a previous attempt can never contaminate a later attempt's outcome. Removal of an already-absent record SHALL be a tolerated no-op.
+The system SHALL remove its transfers' tracked records from the source after the transfers settle, on every settlement path — completion, failure, policy abandonment, and cancellation — marking the ledger entries removed, so records from a previous attempt can never contaminate a later attempt's outcome. When a transfer is still in flight at teardown, cancelling it MAY leave a terminal-but-still-tracked record at the source; the system SHALL confirm the record is actually gone — removing the now-terminal record if it persists — before marking its ledger entry removed. A ledger entry whose record cannot be confirmed removed SHALL be left live so the startup sweep converges it, rather than marked removed. Removal of an already-absent record SHALL be a tolerated no-op.
 
 #### Scenario: Records are removed after a completed download
 - **WHEN** a candidate's transfers all complete and the outcome is reported
@@ -58,6 +58,12 @@ The system SHALL remove its transfers' tracked records from the source after the
 - **GIVEN** a candidate that was attempted before, whose settled records were removed
 - **WHEN** the same candidate is enqueued again by a later acquisition
 - **THEN** the new attempt's outcome reflects only the new transfers
+
+#### Scenario: An abandoned candidate's in-flight transfers leave no lingering record
+- **GIVEN** a candidate abandoned (stalled, queue-timed-out, or cancelled) with some transfers still in flight
+- **WHEN** its teardown cancels those transfers at the source
+- **THEN** each cancelled transfer's now-terminal record is removed from the source, leaving no lingering cancelled record
+- **AND** a ledger entry whose record is not confirmed gone is left live so the startup sweep retires it, rather than being marked removed
 
 ### Requirement: A startup sweep converges the system's own unfinished removals
 The system SHALL, at startup and before reacting to events, find ledger entries still live whose owning acquisition is terminal, remove the corresponding resources from the source (cancelling first if still active), and mark the entries removed. Entries owned by non-terminal acquisitions SHALL be left untouched. A failure on one entry SHALL NOT stop the sweep; unconverged entries remain live for the next startup.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "description": "An extensible, event-sourced music downloader.",
   "type": "module",

--- a/src/adapters/slskd/download.test.ts
+++ b/src/adapters/slskd/download.test.ts
@@ -275,7 +275,12 @@ describe('SlskdDownload', () => {
 
     const result = await adapter.download(ACQ, candidate, policy(1000, 1000), () => undefined);
 
-    expect(result._unsafeUnwrap()).toEqual({ kind: 'failed', reason: 'TransferError' });
+    // 01 completed before the doom, so its staged path is surfaced for cleanup (default events stub).
+    expect(result._unsafeUnwrap()).toEqual({
+      kind: 'failed',
+      reason: 'TransferError',
+      files: [{ name: '01.flac', path: stagedPath('01.flac') }],
+    });
   });
 
   it('normalizes an offline peer to a peer-unavailable outcome', async () => {
@@ -290,39 +295,64 @@ describe('SlskdDownload', () => {
 
     const result = await adapter.download(ACQ, candidate, policy(1000, 1000), () => undefined);
 
-    expect(result._unsafeUnwrap()).toEqual({ kind: 'failed', reason: 'PeerUnavailable' });
+    // Neither file completed, so there is nothing staged to clean up.
+    expect(result._unsafeUnwrap()).toEqual({
+      kind: 'failed',
+      reason: 'PeerUnavailable',
+      files: [],
+    });
   });
 
-  it('abandons a stalled transfer once the stall timeout elapses', async () => {
-    const { adapter, deletes } = downloader({
-      polls: [
-        poll([
-          transfer('01.flac', { state: 'InProgress', size: 100, bytesTransferred: 50 }),
-          transfer('02.flac', { state: 'InProgress', size: 100, bytesTransferred: 0 }),
-        ]),
-      ],
+  it('abandons a stalled transfer, cancelling then confirming its records removed', async () => {
+    const inFlight = poll([
+      transfer('01.flac', { state: 'InProgress', size: 100, bytesTransferred: 50 }),
+      transfer('02.flac', { state: 'InProgress', size: 100, bytesTransferred: 0 }),
+    ]);
+    const cancelled = poll([
+      transfer('01.flac', { state: 'Completed, Cancelled' }),
+      transfer('02.flac', { state: 'Completed, Cancelled' }),
+      { id: 'foreign', filename: '@@a\\Other\\9.flac', state: 'InProgress' }, // another candidate
+      { id: 'nameless', state: 'InProgress' }, // a transfer with no filename
+    ]);
+    const { adapter, deletes, ledger } = downloader({
+      // Two identical in-flight polls advance the clock to the stall; the teardown then re-polls a
+      // cancelled-terminal set, and a final empty poll confirms the records are gone.
+      polls: [inFlight, inFlight, cancelled, poll([])],
     });
 
     const result = await adapter.download(ACQ, candidate, policy(50, 100000), () => undefined);
 
-    expect(result._unsafeUnwrap()).toEqual({ kind: 'failed', reason: 'Stalled' });
-    expect(deletes).toHaveLength(2);
+    expect(result._unsafeUnwrap()).toEqual({ kind: 'failed', reason: 'Stalled', files: [] });
+    // Each transfer is cancelled (remove=false), then removed once terminal (remove=true).
+    expect(deletes).toEqual([
+      'http://localhost:5030/api/v0/transfers/downloads/u1/01.flac?remove=false',
+      'http://localhost:5030/api/v0/transfers/downloads/u1/02.flac?remove=false',
+      'http://localhost:5030/api/v0/transfers/downloads/u1/01.flac?remove=true',
+      'http://localhost:5030/api/v0/transfers/downloads/u1/02.flac?remove=true',
+    ]);
+    expect(ledger.removed).toHaveLength(2); // both confirmed gone
   });
 
   it('abandons a hopelessly-queued transfer once the queue wait elapses', async () => {
-    const { adapter, deletes } = downloader({
-      polls: [
-        poll([
-          transfer('01.flac', { state: 'Queued, Remotely', size: 100, placeInQueue: 4 }),
-          { filename: '@@a\\Album\\02.flac', state: 'Queued, Remotely', size: 100 }, // no id
-        ]),
-      ],
+    const queued = poll([
+      transfer('01.flac', { state: 'Queued, Remotely', size: 100, placeInQueue: 4 }),
+      { filename: '@@a\\Album\\02.flac', state: 'Queued, Remotely', size: 100 }, // no id
+    ]);
+    const { adapter, deletes, ledger } = downloader({
+      // Two identical queued polls advance the clock past the queue wait; the teardown then finds
+      // the cancelled transfers already gone on its re-poll.
+      polls: [queued, queued, poll([])],
     });
 
     const result = await adapter.download(ACQ, candidate, policy(100000, 50), () => undefined);
 
-    expect(result._unsafeUnwrap()).toEqual({ kind: 'failed', reason: 'QueueTimeout' });
-    expect(deletes).toHaveLength(2);
+    expect(result._unsafeUnwrap()).toEqual({ kind: 'failed', reason: 'QueueTimeout', files: [] });
+    // Both queued (non-terminal) transfers are cancelled; the re-poll then finds them gone.
+    expect(deletes).toEqual([
+      'http://localhost:5030/api/v0/transfers/downloads/u1/01.flac?remove=false',
+      'http://localhost:5030/api/v0/transfers/downloads/u1/?remove=false',
+    ]);
+    expect(ledger.removed).toHaveLength(2);
   });
 
   it('surfaces live progress while transferring and completes on the next poll', async () => {
@@ -425,22 +455,105 @@ describe('SlskdDownload', () => {
           transfer('01.flac', { state: 'Completed, Errored', size: 100, bytesTransferred: 0 }),
           transfer('02.flac', { state: 'InProgress', size: 100, bytesTransferred: 30 }),
         ]),
+        // The teardown re-poll: the failed file is already gone; the cancelled one is now terminal.
+        poll([transfer('02.flac', { state: 'Completed, Cancelled' })]),
+        poll([]),
       ],
     });
 
     // Generous policy timeouts: the failure — not a stall — is what ends the download.
     const result = await adapter.download(ACQ, candidate, policy(100000, 100000), () => undefined);
 
-    expect(result._unsafeUnwrap()).toEqual({ kind: 'failed', reason: 'TransferError' });
-    // Both the failed file and the still-in-flight one are cancelled and removed.
+    // Neither file succeeded, so there is no partial subset to clean.
+    expect(result._unsafeUnwrap()).toEqual({ kind: 'failed', reason: 'TransferError', files: [] });
+    // The failed file (terminal) is removed at once; the in-flight one is cancelled then removed.
     expect(deletes).toEqual([
       'http://localhost:5030/api/v0/transfers/downloads/u1/01.flac?remove=true',
+      'http://localhost:5030/api/v0/transfers/downloads/u1/02.flac?remove=false',
       'http://localhost:5030/api/v0/transfers/downloads/u1/02.flac?remove=true',
     ]);
     expect(ledger.removed).toHaveLength(2);
   });
 
-  it('still completes when removing a settled record fails at the source', async () => {
+  it('leaves a row live when a cancelled transfer never turns removable', async () => {
+    // A single in-flight poll that never settles: every re-poll sees the same non-terminal state.
+    const inFlight = poll([
+      transfer('01.flac', { state: 'InProgress', size: 100, bytesTransferred: 50 }),
+      transfer('02.flac', { state: 'InProgress', size: 100, bytesTransferred: 0 }),
+    ]);
+    const { adapter, deletes, ledger } = downloader({ polls: [inFlight] });
+
+    const result = await adapter.download(ACQ, candidate, policy(50, 100000), () => undefined);
+
+    expect(result._unsafeUnwrap()).toEqual({ kind: 'failed', reason: 'Stalled', files: [] });
+    // Cancelled each round but never confirmed terminal, so no row is marked removed — the startup
+    // sweep converges them next boot. Only cancels (remove=false) are ever issued.
+    expect(deletes.every((url) => url.endsWith('?remove=false'))).toBe(true);
+    expect(ledger.removed).toHaveLength(0);
+  });
+
+  it('reports the completed subset when a candidate is doomed mid-download', async () => {
+    const { adapter } = downloader({
+      polls: [
+        poll([
+          transfer('01.flac', { state: 'Completed, Succeeded', size: 100, bytesTransferred: 100 }),
+          transfer('02.flac', { state: 'Completed, Errored', size: 100, bytesTransferred: 0 }),
+        ]),
+        poll([]),
+      ],
+      events: [eventsPage([{ id: '01.flac', local: localOf('01.flac') }])],
+    });
+
+    const result = await adapter.download(ACQ, candidate, policy(100000, 100000), () => undefined);
+
+    // The already-staged file is surfaced for cleanup; the reported reason is the original failure.
+    expect(result._unsafeUnwrap()).toEqual({
+      kind: 'failed',
+      reason: 'TransferError',
+      files: [{ name: '01.flac', path: stagedPath('01.flac') }],
+    });
+  });
+
+  it('still fails without files when the completed subset cannot be resolved (best-effort)', async () => {
+    const { adapter } = downloader({
+      polls: [
+        poll([
+          transfer('01.flac', { state: 'Completed, Succeeded', size: 100, bytesTransferred: 100 }),
+          transfer('02.flac', { state: 'Completed, Errored', size: 100, bytesTransferred: 0 }),
+        ]),
+        poll([]),
+      ],
+      events: [eventsPage([])], // the events log never reports the completed file's location
+    });
+
+    const result = await adapter.download(ACQ, candidate, policy(100000, 100000), () => undefined);
+
+    // Resolution failing does not turn the doomed failure into an infra fault — just no files.
+    expect(result._unsafeUnwrap()).toEqual({
+      kind: 'failed',
+      reason: 'TransferError',
+      files: [],
+    });
+  });
+
+  it('skips a completed file whose transfer id was never captured', async () => {
+    const { adapter } = downloader({
+      polls: [
+        poll([
+          { filename: '@@a\\Album\\01.flac', state: 'Completed, Succeeded' }, // succeeded, but no id
+          transfer('02.flac', { state: 'Completed, Errored', size: 100, bytesTransferred: 0 }),
+        ]),
+        poll([]),
+      ],
+    });
+
+    const result = await adapter.download(ACQ, candidate, policy(100000, 100000), () => undefined);
+
+    // Without an id the staged path cannot be resolved, so it is left out rather than mis-reported.
+    expect(result._unsafeUnwrap()).toEqual({ kind: 'failed', reason: 'TransferError', files: [] });
+  });
+
+  it('still completes when removing a settled record fails, leaving the rows for the sweep', async () => {
     const { adapter, ledger } = downloader({
       deleteStatus: 500, // the cancel+remove DELETE errors, but the download already succeeded
       polls: [bothSucceeded],
@@ -450,8 +563,9 @@ describe('SlskdDownload', () => {
     const result = await adapter.download(ACQ, candidate, policy(1000, 1000), () => undefined);
 
     expect(result._unsafeUnwrap().kind).toBe('completed');
-    // The ledger rows are still marked removed; the sweep will retire the leftover source records.
-    expect(ledger.removed).toHaveLength(2);
+    // The records were never confirmed gone, so the rows stay live for the startup sweep to retire —
+    // never falsely marked removed while a record lingers at the source (the bug this change fixes).
+    expect(ledger.removed).toHaveLength(0);
   });
 
   it('completes even when ledger bookkeeping fails, leaving the ledger untouched', async () => {
@@ -464,26 +578,110 @@ describe('SlskdDownload', () => {
     expect(ledger.created).toEqual([]);
   });
 
+  it('drives an abandoned candidate’s in-flight transfers to fully removed at the source', async () => {
+    // A stateful slskd double modelling the real cancel/remove guard (design D1): `?remove=true` on a
+    // non-terminal transfer 500s; `?remove=false` cancels it (→ Completed, Cancelled); `?remove=true`
+    // on a terminal transfer deletes the record. After teardown, no residual record must remain.
+    const store = new Map<string, Record<string, unknown>>([
+      [
+        '01.flac',
+        {
+          id: '01.flac',
+          filename: '@@a\\Album\\01.flac',
+          state: 'InProgress',
+          size: 100,
+          bytesTransferred: 50,
+        },
+      ],
+      [
+        '02.flac',
+        {
+          id: '02.flac',
+          filename: '@@a\\Album\\02.flac',
+          state: 'InProgress',
+          size: 100,
+          bytesTransferred: 0,
+        },
+      ],
+    ]);
+    const http: HttpClient = {
+      send: ({ method, url }) => {
+        if (method === 'DELETE') {
+          const match = /downloads\/u1\/([^?]*)\?remove=(true|false)/.exec(url)!;
+          const id = decodeURIComponent(match[1]!);
+          const transfer = store.get(id);
+          if (transfer === undefined) return Promise.resolve({ status: 404, body: '' });
+          const terminal = String(transfer.state).toLowerCase().includes('completed');
+          if (match[2] === 'true') {
+            if (!terminal) return Promise.resolve({ status: 500, body: 'not terminal' });
+            store.delete(id);
+          } else {
+            transfer.state = 'Completed, Cancelled';
+          }
+          return Promise.resolve({ status: 204, body: '' });
+        }
+        return Promise.resolve(poll([...store.values()]));
+      },
+    };
+    const ledger = new FakeResourceLedger();
+    const adapter = new SlskdDownload(
+      silentLogger(),
+      ledger,
+      { stagingRoot: STAGING, pollIntervalMs: 1 },
+      new SlskdClient(http),
+      fakeTimer(),
+    );
+
+    const result = await adapter.download(ACQ, candidate, policy(1, 100000), () => undefined);
+
+    expect(result._unsafeUnwrap()).toMatchObject({ kind: 'failed', reason: 'Stalled' });
+    // The source double is queried for residual records after teardown — none linger.
+    expect(store.size).toBe(0);
+    expect(ledger.removed).toHaveLength(2);
+  });
+
   describe('abort', () => {
-    it('cancels and removes the candidate’s transfers, tolerating missing ids and filenames', async () => {
-      const { adapter, deletes } = downloader({
+    it('cancels the candidate’s transfers, tolerating missing ids, then confirms them gone', async () => {
+      const { adapter, deletes, ledger } = downloader({
         polls: [
           poll([
             transfer('01.flac', { state: 'InProgress', size: 100, bytesTransferred: 50 }),
-            { filename: '@@a\\Album\\02.flac', state: 'Queued, Remotely' }, // ours, but no id
+            { filename: '@@a\\Album\\02.flac' }, // ours, but no id and no state yet
             { id: 'x', state: 'InProgress' }, // no filename → not one of ours
             { id: 'other', filename: '@@a\\Other\\99.flac', state: 'InProgress' }, // another dir
           ]),
+          poll([]), // the teardown re-poll: both cancelled transfers are gone
         ],
       });
 
       const result = await adapter.abort(ACQ, candidate);
 
-      expect(result._unsafeUnwrap()).toBeUndefined();
+      expect(result._unsafeUnwrap()).toEqual([]); // nothing had completed into staging
+      // In-flight transfers are cancelled (remove=false); the re-poll then finds them gone.
       expect(deletes).toEqual([
-        'http://localhost:5030/api/v0/transfers/downloads/u1/01.flac?remove=true',
-        'http://localhost:5030/api/v0/transfers/downloads/u1/?remove=true',
+        'http://localhost:5030/api/v0/transfers/downloads/u1/01.flac?remove=false',
+        'http://localhost:5030/api/v0/transfers/downloads/u1/?remove=false',
       ]);
+      expect(ledger.removed).toHaveLength(2);
+    });
+
+    it('reports the subset already completed into staging so it can be cleaned', async () => {
+      const { adapter, ledger } = downloader({
+        polls: [
+          poll([
+            transfer('01.flac', { state: 'Completed, Succeeded' }), // already staged
+            transfer('02.flac', { state: 'InProgress' }), // still in flight when cancelled
+          ]),
+          poll([]), // both gone after teardown
+        ],
+        events: [eventsPage([{ id: '01.flac', local: localOf('01.flac') }])],
+      });
+
+      const result = await adapter.abort(ACQ, candidate);
+
+      // The completed file's source-reported staged path is returned for the domain to discard.
+      expect(result._unsafeUnwrap()).toEqual([{ name: '01.flac', path: stagedPath('01.flac') }]);
+      expect(ledger.removed).toHaveLength(2);
     });
 
     it('is a no-op when the candidate has no transfers left', async () => {
@@ -491,7 +689,7 @@ describe('SlskdDownload', () => {
 
       const result = await adapter.abort(ACQ, candidate);
 
-      expect(result._unsafeUnwrap()).toBeUndefined();
+      expect(result._unsafeUnwrap()).toEqual([]);
       expect(deletes).toEqual([]);
     });
 

--- a/src/adapters/slskd/download.ts
+++ b/src/adapters/slskd/download.ts
@@ -21,7 +21,12 @@ import { slskdEventsSchema, slskdOptionsSchema, slskdTransfersSchema } from './s
 import { resolveStagedPaths } from './staged-location.js';
 import { realTimer } from './timer.js';
 import type { Timer } from './timer.js';
-import { aggregate, flattenDownloads } from './transfers.js';
+import {
+  aggregate,
+  flattenDownloads,
+  isTransferComplete,
+  isTransferSucceeded,
+} from './transfers.js';
 import type { SlskdTransfer } from './transfers.js';
 
 /**
@@ -35,13 +40,21 @@ import type { SlskdTransfer } from './transfers.js';
  * `DownloadFileComplete` events (`localFilename`, correlated by `transfer.id`) and re-rooted onto
  * `STAGING_ROOT` — so the library adapter imports (or `discardStaging`s) real, existing paths rather
  * than a location recomputed from candidate identity (design D1/D2). The staged location is never
- * derived from slskd's OS / destination template / sanitizer; those are slskd's alone.
+ * derived from slskd's OS / destination template / sanitizer; those are slskd's alone. On an abandoned
+ * or doomed candidate the *already-completed* subset is resolved the same way and reported on the
+ * failed outcome, so the domain's `discardStaging` cleans those partial files rather than orphaning
+ * them (design D2). Resolving that subset is best-effort (D3): a lag or fault yields no files, never
+ * an infra fault — the adapter itself never touches the filesystem.
  *
- * Every transfer is recorded in the ownership ledger write-ahead (before enqueue) and its record is
- * removed from slskd on every terminal outcome — completed, failed, doomed, or abandoned — so records
- * from one attempt can never contaminate a later attempt's outcome (D: source-resource stewardship).
- * Ledger bookkeeping is best-effort: the adapter's own correctness rests on the in-memory owned set
- * and the live slskd payload, so a ledger fault degrades sweep coverage but never a working download.
+ * Every transfer is recorded in the ownership ledger write-ahead (before enqueue) and torn down on
+ * every terminal outcome — completed, failed, doomed, or abandoned — so records from one attempt can
+ * never contaminate a later attempt's outcome (D: source-resource stewardship). Because slskd's remove
+ * is guarded on the terminal flag, teardown is two-step: an in-flight transfer is cancelled, re-polled
+ * until terminal, then removed, and a ledger row is marked removed **only** once its record is
+ * confirmed gone (design D1). A row not confirmed within the bound stays live so the startup sweep
+ * retires it — the backstop for unconfirmed removals. Ledger bookkeeping is best-effort: the adapter's
+ * own correctness rests on the in-memory owned set and the live slskd payload, so a ledger fault
+ * degrades sweep coverage but never a working download.
  *
  * Deployment prerequisites (out of this codebase, tracked in the deploy repo): `STAGING_ROOT` must
  * point at the same volume as slskd's downloads directory, and slskd must run as `PUID/PGID=1000`
@@ -54,11 +67,25 @@ const SLSKD_SOURCE = 'slskd';
 const EVENTS_PAGE_LIMIT = 100;
 /** How many times to re-poll the events log for an id whose completion event still lags. */
 const MAX_EVENT_POLLS = 5;
+/**
+ * How many cancel→poll→remove rounds teardown attempts before leaving an unconfirmed transfer to the
+ * startup sweep (design D1). Cancellation transitions a transfer to terminal asynchronously, so a
+ * small bound absorbs that lag without blocking a settled/abandoned outcome on a flaky transition.
+ */
+const MAX_REMOVE_ROUNDS = 3;
 
 export interface SlskdDownloadConfig extends SlskdConfig {
   /** Root under which each candidate's files are staged (shared with the filesystem library). */
   readonly stagingRoot: string;
 }
+
+/** The remote filename half of a transfer ledger key (`${username}|${filename}`). */
+function filenameOfKey(key: SourceResourceKey): string {
+  return key.resourceKey.slice(key.resourceKey.indexOf('|') + 1);
+}
+
+/** A transfer we own: narrowed to a known `filename` (the poll filters foreign/filenameless ones). */
+type OwnedTransfer = SlskdTransfer & { readonly filename: string };
 
 export class SlskdDownload implements DownloadPort {
   private readonly client: SlskdClient;
@@ -136,11 +163,13 @@ export class SlskdDownload implements DownloadPort {
         return { kind: 'completed', files };
       }
       if (status.hasFailure) {
-        // One failed file dooms the candidate: cancel the rest (via the `?remove=true` sweep below)
-        // and report the original failure, not the cancellation it triggers.
+        // One failed file dooms the candidate: cancel the rest (confirming their records are gone)
+        // and report the original failure, not the cancellation it triggers. Files that succeeded
+        // before the doom are reported so their staging is cleaned (design D2).
         this.logger.warn({ username, reason: status.failureReason }, 'slskd download failed');
+        const files = await this.completedStagedFiles(mine, candidate);
         await this.removeOwned(username, mine, ownedKeys);
-        return { kind: 'failed', reason: status.failureReason };
+        return { kind: 'failed', reason: status.failureReason, files };
       }
 
       const now = this.timer.now();
@@ -149,10 +178,10 @@ export class SlskdDownload implements DownloadPort {
         lastProgressAt = now;
       }
       if (status.allQueued && now - start >= policy.maxQueueWaitMs) {
-        return this.abandon(username, mine, ownedKeys, 'QueueTimeout');
+        return this.abandon(username, mine, ownedKeys, 'QueueTimeout', candidate);
       }
       if (!status.allQueued && now - lastProgressAt >= policy.stallTimeoutMs) {
-        return this.abandon(username, mine, ownedKeys, 'Stalled');
+        return this.abandon(username, mine, ownedKeys, 'Stalled', candidate);
       }
       await this.timer.sleep(this.pollIntervalMs);
     }
@@ -163,13 +192,19 @@ export class SlskdDownload implements DownloadPort {
    * cancellation). Called when a downloading acquisition is cancelled; idempotent, so a transfer
    * already settled or absent is tolerated and a redelivered abort is safe.
    */
-  abort(acquisitionId: string, candidate: Candidate): ResultAsync<void, InfraError> {
+  abort(
+    acquisitionId: string,
+    candidate: Candidate,
+  ): ResultAsync<readonly DownloadedFile[], InfraError> {
     return ResultAsync.fromPromise(this.doAbort(acquisitionId, candidate), (cause) =>
       infraError('slskd.abort', String(cause), cause),
     );
   }
 
-  private async doAbort(acquisitionId: string, candidate: Candidate): Promise<void> {
+  private async doAbort(
+    acquisitionId: string,
+    candidate: Candidate,
+  ): Promise<readonly DownloadedFile[]> {
     const { username } = candidate.identity;
     const filenames = candidate.files.map((file) =>
       remoteFilename(candidate.identity.path, file.name),
@@ -179,46 +214,125 @@ export class SlskdDownload implements DownloadPort {
       this.transferKey(acquisitionId, username, filename),
     );
     const payload = slskdTransfersSchema.parse(await this.client.get(this.downloadsPath(username)));
-    const mine = flattenDownloads(payload).filter((transfer) =>
-      wanted.has(transfer.filename ?? ''),
+    const mine = flattenDownloads(payload).filter(
+      (transfer): transfer is OwnedTransfer =>
+        transfer.filename !== undefined && wanted.has(transfer.filename),
     );
     this.logger.debug({ username, count: mine.length }, 'aborting slskd download');
+    // Resolve the already-completed subset before removal (the events log outlives the record), so
+    // the caller can clean its staging even though the domain never saw a completion (design D2).
+    const files = await this.completedStagedFiles(mine, candidate);
     await this.removeOwned(username, mine, ownedKeys);
-  }
-
-  /** Report a policy abandonment: cancel + remove the owned transfers, then surface the reason. */
-  private async abandon(
-    username: string,
-    mine: readonly SlskdTransfer[],
-    ownedKeys: readonly SourceResourceKey[],
-    reason: DownloadFailureReason,
-  ): Promise<DownloadResult> {
-    this.logger.warn({ username, reason }, 'abandoning slskd download');
-    await this.removeOwned(username, mine, ownedKeys);
-    return { kind: 'failed', reason };
+    return files;
   }
 
   /**
-   * Cancel + remove each present owned transfer (`?remove=true`) and mark the ledger rows removed.
-   * Best-effort: the outcome is already decided, so a removal fault (or a record slskd already
-   * dropped) must never turn a settled download into an error — the sweep retires any leftover.
+   * Report a policy abandonment: cancel + confirm-remove the owned transfers, then surface the
+   * reason together with the subset the source already completed into staging, so its files are
+   * cleaned via the domain (design D2).
+   */
+  private async abandon(
+    username: string,
+    mine: readonly OwnedTransfer[],
+    ownedKeys: readonly SourceResourceKey[],
+    reason: DownloadFailureReason,
+    candidate: Candidate,
+  ): Promise<DownloadResult> {
+    this.logger.warn({ username, reason }, 'abandoning slskd download');
+    const files = await this.completedStagedFiles(mine, candidate);
+    await this.removeOwned(username, mine, ownedKeys);
+    return { kind: 'failed', reason, files };
+  }
+
+  /**
+   * Tear down each owned transfer at the source, then mark a ledger row removed **only** once its
+   * record is confirmed gone (design D1). Best-effort: the outcome is already decided, so a removal
+   * fault (or a record slskd already dropped) never turns a settled download into an error. A record
+   * not confirmed gone within the bound leaves its ledger row live, so the startup sweep converges it
+   * (rather than the old bug of marking it removed while a cancelled record lingered at the source).
    */
   private async removeOwned(
     username: string,
-    mine: readonly SlskdTransfer[],
+    mine: readonly OwnedTransfer[],
     ownedKeys: readonly SourceResourceKey[],
   ): Promise<void> {
-    for (const transfer of mine) {
-      try {
-        await this.client.delIfPresent(
-          `${this.downloadsPath(username)}/${encodeURIComponent(transfer.id ?? '')}?remove=true`,
-        );
-      } catch (err) {
-        this.logger.warn({ err, username }, 'failed to remove a settled slskd transfer');
-      }
-    }
-    for (const key of ownedKeys)
+    const wanted = new Set(ownedKeys.map((key) => filenameOfKey(key)));
+    const stillPresent = await this.teardownTransfers(username, mine, wanted);
+    for (const key of ownedKeys) {
+      if (stillPresent.has(filenameOfKey(key))) continue; // unconfirmed — leave live for the sweep
       await this.record(this.ledger.markRemoved(key), 'mark transfer removed');
+    }
+  }
+
+  /**
+   * Cancel each present transfer and remove its record once terminal, confirming the record is gone
+   * (design D1). slskd's synchronous remove is guarded on the `Completed` flag, so an in-flight
+   * transfer is cancelled with `?remove=false` (a `?remove=true` would 500), then re-polled until it
+   * carries the flag and removed with `?remove=true`; an already-terminal transfer is removed on the
+   * first pass with no re-poll. Bounded by {@link MAX_REMOVE_ROUNDS}; returns the filenames still
+   * present at the source when the bound is hit, so the caller keeps their ledger rows live.
+   */
+  private async teardownTransfers(
+    username: string,
+    present: readonly OwnedTransfer[],
+    wanted: ReadonlySet<string>,
+  ): Promise<Set<string>> {
+    let current = present;
+    for (let round = 1; ; round++) {
+      const unconfirmed: OwnedTransfer[] = [];
+      for (const transfer of current) {
+        const terminal = isTransferComplete(transfer);
+        try {
+          await this.client.delIfPresent(
+            `${this.downloadsPath(username)}/${encodeURIComponent(transfer.id ?? '')}?remove=${terminal}`,
+          );
+          if (!terminal) unconfirmed.push(transfer); // cancelled — must re-poll to confirm removal
+        } catch (err) {
+          this.logger.warn({ err, username }, 'failed to tear down a slskd transfer');
+          unconfirmed.push(transfer);
+        }
+      }
+      if (unconfirmed.length === 0) return new Set(); // every terminal record removed cleanly
+      if (round >= MAX_REMOVE_ROUNDS)
+        return new Set(unconfirmed.map((transfer) => transfer.filename));
+      await this.timer.sleep(this.pollIntervalMs);
+      current = await this.pollMine(username, wanted);
+      if (current.length === 0) return new Set(); // the cancelled records transitioned and are gone
+    }
+  }
+
+  /** Re-poll the user's downloads, narrowed to the transfers this teardown owns. */
+  private async pollMine(username: string, wanted: ReadonlySet<string>): Promise<OwnedTransfer[]> {
+    const payload = slskdTransfersSchema.parse(await this.client.get(this.downloadsPath(username)));
+    return flattenDownloads(payload).filter(
+      (transfer): transfer is OwnedTransfer =>
+        transfer.filename !== undefined && wanted.has(transfer.filename),
+    );
+  }
+
+  /**
+   * Resolve the staged locations of the transfers that succeeded before the candidate was abandoned
+   * or doomed, so the domain can clean them (design D2). Best-effort (D3): a resolution fault (the
+   * events log lagging, a bad options body) yields no files rather than turning the settled failure
+   * into an infra fault — the orphaned files fall to a later reconciliation instead of wedging retry.
+   */
+  private async completedStagedFiles(
+    mine: readonly OwnedTransfer[],
+    candidate: Candidate,
+  ): Promise<readonly DownloadedFile[]> {
+    const completed = mine.filter(
+      (transfer) => isTransferSucceeded(transfer) && transfer.id !== undefined,
+    );
+    if (completed.length === 0) return [];
+    try {
+      return await this.stagedFiles(completed, candidate);
+    } catch (err) {
+      this.logger.warn(
+        { err, username: candidate.identity.username },
+        'could not resolve the abandoned candidate’s completed files',
+      );
+      return [];
+    }
   }
 
   /** Attach each newly-seen transfer's slskd GUID to its ledger row, so the sweep can delete it. */

--- a/src/adapters/slskd/resource-remover.test.ts
+++ b/src/adapters/slskd/resource-remover.test.ts
@@ -1,23 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { silentLogger } from '../../application/__fixtures__/fakes.js';
 import type { SourceResource } from '../../application/ports/resource-ledger-port.js';
-import type { HttpClient, HttpRequest, HttpResponse } from '../support/http.js';
+import type { HttpClient, HttpResponse } from '../support/http.js';
 import { SlskdClient } from './client.js';
 import { SlskdResourceRemover } from './resource-remover.js';
-
-function remover(handler: (request: HttpRequest) => HttpResponse): {
-  remover: SlskdResourceRemover;
-  requests: HttpRequest[];
-} {
-  const requests: HttpRequest[] = [];
-  const http: HttpClient = {
-    send: (request) => {
-      requests.push(request);
-      return Promise.resolve(handler(request));
-    },
-  };
-  return { remover: new SlskdResourceRemover(silentLogger(), new SlskdClient(http)), requests };
-}
+import type { Timer } from './timer.js';
 
 const ok: HttpResponse = { status: 204, body: '' };
 const search: SourceResource = {
@@ -35,57 +22,150 @@ const transfer = (resourceId?: string): SourceResource => ({
   acquisitionId: 'acq-1',
 });
 
-function transferPayload(files: readonly unknown[]): HttpResponse {
+function payload(files: readonly unknown[]): HttpResponse {
   return { status: 200, body: JSON.stringify({ username: 'u1', directories: [{ files }] }) };
+}
+const gone = payload([]);
+const present = (state: string, id = 'live-id'): HttpResponse =>
+  payload([{ id, filename: '@@a\\Album\\01.flac', state }]);
+
+function fakeTimer(): Timer {
+  let current = 0;
+  return {
+    now: () => current,
+    sleep: (ms) => {
+      current += ms;
+      return Promise.resolve();
+    },
+  };
+}
+
+/** A remover whose GET (transfer-poll) responses are drained in order (last one repeats). */
+function remover(
+  gets: HttpResponse[],
+  deleteStatus = 204,
+): {
+  remover: SlskdResourceRemover;
+  deletes: string[];
+  getCount: () => number;
+} {
+  const deletes: string[] = [];
+  const queue = [...gets];
+  let getCount = 0;
+  const http: HttpClient = {
+    send: ({ method, url }) => {
+      if (method === 'DELETE') {
+        deletes.push(url);
+        return Promise.resolve({ status: deleteStatus, body: '' });
+      }
+      getCount += 1;
+      const next = queue.length > 1 ? queue.shift()! : (queue[0] ?? gone);
+      return Promise.resolve(next);
+    },
+  };
+  return {
+    remover: new SlskdResourceRemover(silentLogger(), new SlskdClient(http), fakeTimer(), 10),
+    deletes,
+    getCount: () => getCount,
+  };
 }
 
 describe('SlskdResourceRemover', () => {
-  it('deletes a search by its id', async () => {
-    const { remover: r, requests } = remover(() => ok);
+  it('deletes a search by its id and reports it confirmed gone', async () => {
+    const { remover: r, deletes } = remover([ok]);
 
-    (await r.remove(search))._unsafeUnwrap();
+    expect((await r.remove(search))._unsafeUnwrap()).toBe(true);
+    expect(deletes).toEqual(['http://localhost:5030/api/v0/searches/s1']);
+  });
 
-    expect(requests).toMatchObject([
-      { method: 'DELETE', url: 'http://localhost:5030/api/v0/searches/s1' },
+  it('removes an already-terminal transfer on the first pass and confirms it gone', async () => {
+    const { remover: r, deletes } = remover([present('Completed, Succeeded'), gone]);
+
+    expect((await r.remove(transfer('live-id')))._unsafeUnwrap()).toBe(true);
+    expect(deletes).toEqual([
+      'http://localhost:5030/api/v0/transfers/downloads/u1/live-id?remove=true',
     ]);
   });
 
-  it('cancels and removes a transfer by its captured id, without a lookup', async () => {
-    const { remover: r, requests } = remover(() => ok);
+  it('cancels an in-flight transfer, then removes it once it turns terminal', async () => {
+    const { remover: r, deletes } = remover([
+      present('InProgress'), // cancel-only (remove=false)
+      present('Completed, Cancelled'), // now terminal — remove it
+      gone, // confirmed gone
+    ]);
 
-    (await r.remove(transfer('guid-9')))._unsafeUnwrap();
-
-    expect(requests).toMatchObject([
-      {
-        method: 'DELETE',
-        url: 'http://localhost:5030/api/v0/transfers/downloads/u1/guid-9?remove=true',
-      },
+    expect((await r.remove(transfer('live-id')))._unsafeUnwrap()).toBe(true);
+    expect(deletes).toEqual([
+      'http://localhost:5030/api/v0/transfers/downloads/u1/live-id?remove=false',
+      'http://localhost:5030/api/v0/transfers/downloads/u1/live-id?remove=true',
     ]);
   });
 
   it('looks a transfer up by filename when its id was never captured', async () => {
-    const { remover: r, requests } = remover((request) =>
-      request.method === 'GET'
-        ? transferPayload([{ id: 'live-id', filename: '@@a\\Album\\01.flac' }])
-        : ok,
-    );
+    const { remover: r, deletes } = remover([present('Completed, Succeeded'), gone]);
 
-    (await r.remove(transfer()))._unsafeUnwrap();
-
-    expect(requests.map((request) => request.method)).toEqual(['GET', 'DELETE']);
-    expect(requests[1]!.url).toContain('/transfers/downloads/u1/live-id?remove=true');
+    expect((await r.remove(transfer()))._unsafeUnwrap()).toBe(true);
+    expect(deletes).toEqual([
+      'http://localhost:5030/api/v0/transfers/downloads/u1/live-id?remove=true',
+    ]);
   });
 
-  it('no-ops a transfer that is already gone from the source', async () => {
-    const { remover: r, requests } = remover(() => transferPayload([]));
+  it('falls back to the captured GUID when the polled record omits its id', async () => {
+    // The transfer is found by filename but the payload carries no id; remove by the captured GUID.
+    const noId = payload([{ filename: '@@a\\Album\\01.flac', state: 'Completed, Succeeded' }]);
+    const { remover: r, deletes } = remover([noId, gone]);
 
-    (await r.remove(transfer()))._unsafeUnwrap();
+    expect((await r.remove(transfer('guid-9')))._unsafeUnwrap()).toBe(true);
+    expect(deletes).toEqual([
+      'http://localhost:5030/api/v0/transfers/downloads/u1/guid-9?remove=true',
+    ]);
+  });
 
-    expect(requests.map((request) => request.method)).toEqual(['GET']); // nothing left to DELETE
+  it('removes an idless transfer at the bare path when no GUID was ever captured', async () => {
+    const noId = payload([{ filename: '@@a\\Album\\01.flac', state: 'Completed, Succeeded' }]);
+    const { remover: r, deletes } = remover([noId, gone]);
+
+    expect((await r.remove(transfer()))._unsafeUnwrap()).toBe(true);
+    expect(deletes).toEqual(['http://localhost:5030/api/v0/transfers/downloads/u1/?remove=true']);
+  });
+
+  it('locates a transfer by its captured GUID when the polled filename differs', async () => {
+    // slskd renamed the file on disk, so match on the captured id rather than the filename.
+    const renamed = payload([
+      { id: 'guid-9', filename: '@@a\\Album\\renamed.flac', state: 'Completed, Succeeded' },
+    ]);
+    const { remover: r, deletes } = remover([renamed, gone]);
+
+    expect((await r.remove(transfer('guid-9')))._unsafeUnwrap()).toBe(true);
+    expect(deletes).toEqual([
+      'http://localhost:5030/api/v0/transfers/downloads/u1/guid-9?remove=true',
+    ]);
+  });
+
+  it('no-ops when only another tenant’s transfer is present', async () => {
+    // A foreign transfer (different filename, no captured id to match) is left untouched.
+    const foreign = payload([{ id: 'x', filename: '@@a\\Other\\9.flac', state: 'InProgress' }]);
+    const { remover: r, deletes, getCount } = remover([foreign]);
+
+    expect((await r.remove(transfer()))._unsafeUnwrap()).toBe(true);
+    expect(deletes).toEqual([]); // nothing of ours to remove
+    expect(getCount()).toBe(1);
+  });
+
+  it('reports a lingering transfer unconfirmed after the retry bound', async () => {
+    const { remover: r, deletes } = remover([present('InProgress')]); // never transitions
+
+    // Cancelled each round but never terminal, so it is left for the next boot's sweep.
+    expect((await r.remove(transfer('live-id')))._unsafeUnwrap()).toBe(false);
+    expect(deletes).toEqual([
+      'http://localhost:5030/api/v0/transfers/downloads/u1/live-id?remove=false',
+      'http://localhost:5030/api/v0/transfers/downloads/u1/live-id?remove=false',
+      'http://localhost:5030/api/v0/transfers/downloads/u1/live-id?remove=false',
+    ]);
   });
 
   it('surfaces a transport fault as an InfraError', async () => {
-    const { remover: r } = remover(() => ({ status: 500, body: 'boom' }));
+    const { remover: r } = remover([ok], 500);
 
     const result = await r.remove(search);
 

--- a/src/adapters/slskd/resource-remover.ts
+++ b/src/adapters/slskd/resource-remover.ts
@@ -8,49 +8,95 @@ import type {
 import type { Logger } from '../../application/logging/logger.js';
 import { SlskdClient } from './client.js';
 import { slskdTransfersSchema } from './schemas.js';
-import { flattenDownloads } from './transfers.js';
+import { realTimer } from './timer.js';
+import type { Timer } from './timer.js';
+import { flattenDownloads, isTransferComplete } from './transfers.js';
+import type { SlskdTransfer } from './transfers.js';
+
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+/** Cancel→poll→remove rounds before leaving an unconfirmed transfer to the next boot's sweep (D1). */
+const MAX_REMOVE_ROUNDS = 3;
 
 /**
  * The slskd arm of the startup sweep (D: source-resource stewardship): removes a resource the app
- * recorded in the ownership ledger. A search is deleted by its id; a transfer is cancelled+removed by
- * its slskd GUID, falling back to a filename lookup when the GUID was never captured (a crash before
- * the first poll). Deleting something already gone is a tolerated no-op, so the sweep is idempotent.
+ * recorded in the ownership ledger. A search is deleted by its id. A transfer is torn down with the
+ * two-step confirm teardown (design D1): an in-flight transfer is cancelled (`?remove=false`, since
+ * slskd's synchronous remove is guarded on the `Completed` flag and would 500), re-polled until it
+ * carries the flag, then removed (`?remove=true`); an already-terminal transfer is removed directly.
+ * A GUID captured before a crash locates the transfer alongside its filename. `remove` resolves to
+ * whether the record is *confirmed gone*: a transfer still lingering after the bound resolves `false`
+ * so the sweep leaves its ledger row live to retry next boot. Deleting something already gone is a
+ * tolerated no-op, so the sweep is idempotent.
  */
 export class SlskdResourceRemover implements SourceResourceRemover {
+  private readonly pollIntervalMs: number;
+
   constructor(
     private readonly logger: Logger,
     private readonly client: SlskdClient = new SlskdClient(),
-  ) {}
+    private readonly timer: Timer = realTimer,
+    pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS,
+  ) {
+    this.pollIntervalMs = pollIntervalMs;
+  }
 
-  remove(resource: SourceResource): ResultAsync<void, InfraError> {
+  remove(resource: SourceResource): ResultAsync<boolean, InfraError> {
     return ResultAsync.fromPromise(this.doRemove(resource), (cause) =>
       infraError('slskd.resource-remove', String(cause), cause),
     );
   }
 
-  private async doRemove(resource: SourceResource): Promise<void> {
+  private async doRemove(resource: SourceResource): Promise<boolean> {
     if (resource.kind === 'search') {
       this.logger.debug({ id: resource.resourceKey }, 'sweeping slskd search');
       await this.client.delIfPresent(
         `/api/v0/searches/${encodeURIComponent(resource.resourceKey)}`,
       );
-      return;
+      return true; // a search is removed synchronously — nothing to confirm across a transition
     }
     const separator = resource.resourceKey.indexOf('|');
     const username = resource.resourceKey.slice(0, separator);
     const filename = resource.resourceKey.slice(separator + 1);
-    const id = resource.resourceId ?? (await this.lookupTransferId(username, filename));
-    if (id === undefined) return; // the transfer is already gone from the source
-    this.logger.debug({ username, id }, 'sweeping slskd transfer');
-    await this.client.delIfPresent(
-      `/api/v0/transfers/downloads/${encodeURIComponent(username)}/${encodeURIComponent(id)}?remove=true`,
-    );
+    return this.teardownTransfer(username, filename, resource.resourceId);
   }
 
-  private async lookupTransferId(username: string, filename: string): Promise<string | undefined> {
+  /**
+   * Cancel + remove the transfer, confirming its record is gone (design D1). Returns `true` once the
+   * transfer is absent from a re-poll, `false` if it still lingers after {@link MAX_REMOVE_ROUNDS}.
+   */
+  private async teardownTransfer(
+    username: string,
+    filename: string,
+    capturedId: string | undefined,
+  ): Promise<boolean> {
+    let current = await this.findTransfer(username, filename, capturedId);
+    for (let round = 1; ; round++) {
+      if (current === undefined) return true; // confirmed gone
+      const terminal = isTransferComplete(current);
+      const id = current.id ?? capturedId ?? '';
+      this.logger.debug({ username, id, terminal }, 'sweeping slskd transfer');
+      await this.client.delIfPresent(
+        `/api/v0/transfers/downloads/${encodeURIComponent(username)}/${encodeURIComponent(id)}?remove=${terminal}`,
+      );
+      if (round >= MAX_REMOVE_ROUNDS) break;
+      await this.timer.sleep(this.pollIntervalMs);
+      current = await this.findTransfer(username, filename, capturedId);
+    }
+    return (await this.findTransfer(username, filename, capturedId)) === undefined;
+  }
+
+  /** Find our transfer in the user's downloads, by filename or the GUID captured before a crash. */
+  private async findTransfer(
+    username: string,
+    filename: string,
+    capturedId: string | undefined,
+  ): Promise<SlskdTransfer | undefined> {
     const payload = slskdTransfersSchema.parse(
       await this.client.get(`/api/v0/transfers/downloads/${encodeURIComponent(username)}`),
     );
-    return flattenDownloads(payload).find((transfer) => transfer.filename === filename)?.id;
+    return flattenDownloads(payload).find(
+      (transfer) =>
+        transfer.filename === filename || (capturedId !== undefined && transfer.id === capturedId),
+    );
   }
 }

--- a/src/adapters/slskd/transfers.ts
+++ b/src/adapters/slskd/transfers.ts
@@ -31,6 +31,20 @@ function statusOf(state: string): TransferStatus {
   return 'transferring';
 }
 
+/**
+ * Whether a transfer has reached slskd's terminal `Completed` flag — the guard slskd's synchronous
+ * record removal is gated on (design D1). A terminal transfer can be removed (`?remove=true`); an
+ * in-flight one must first be cancelled and left to transition before its record can be removed.
+ */
+export function isTransferComplete(transfer: SlskdTransfer): boolean {
+  return (transfer.state ?? '').toLowerCase().includes('completed');
+}
+
+/** Whether a transfer completed *successfully* — its file is staged and can be resolved (D2). */
+export function isTransferSucceeded(transfer: SlskdTransfer): boolean {
+  return statusOf(transfer.state ?? '') === 'succeeded';
+}
+
 /** Translate a Soulseek failure into the domain's source-agnostic reason (D10). */
 export function reasonFromTransfer(transfer: SlskdTransfer): DownloadFailureReason {
   const text = `${transfer.state ?? ''} ${transfer.exception ?? ''}`.toLowerCase();

--- a/src/application/acquisition/interpreter.test.ts
+++ b/src/application/acquisition/interpreter.test.ts
@@ -145,7 +145,7 @@ describe('interpretEffect — download', () => {
   it('aborts an in-flight transfer and rejects the pending candidate on cancellation', async () => {
     const candidate = matchingCandidate('a');
     await seed([...selectedHistory([candidate]), { type: 'AcquisitionCancelled' }]);
-    const abort = vi.fn(() => okAsync(undefined));
+    const abort = vi.fn(() => okAsync([]));
     const ports = stubPorts({ download: { download: vi.fn(), abort } });
 
     await interpretEffect(deps(ports), 'acq-1', { type: 'AbortDownload', candidate });
@@ -153,6 +153,43 @@ describe('interpretEffect — download', () => {
     expect(abort).toHaveBeenCalledWith('acq-1', candidate);
     // The settlement rejects the pending candidate; the acquisition stays cancelled.
     expect(appendedTypes()).toContain('CandidateRejected');
+  });
+
+  it('threads a failed download’s partial files into the rejection for cleanup', async () => {
+    await seed(selectedHistory([matchingCandidate('a')]));
+    const ports = stubPorts({
+      download: {
+        download: vi.fn(() =>
+          okAsync({ kind: 'failed' as const, reason: 'Stalled' as const, files: sampleFiles }),
+        ),
+        abort: vi.fn(),
+      },
+    });
+    await interpretEffect(deps(ports), 'acq-1', {
+      type: 'Download',
+      candidate: matchingCandidate('a'),
+      policy: DEFAULT_DOWNLOAD_POLICY,
+    });
+    const rejected = store.all().find((entry) => entry.type === 'CandidateRejected')?.event as
+      Extract<AcquisitionEvent, { type: 'CandidateRejected' }> | undefined;
+    expect(rejected?.files).toEqual(sampleFiles);
+  });
+
+  it('cleans an aborted candidate’s already-completed files reported by the abort', async () => {
+    const candidate = matchingCandidate('a');
+    await seed([...selectedHistory([candidate]), { type: 'AcquisitionCancelled' }]);
+    const abort = vi.fn(() => okAsync(sampleFiles));
+    const discardStaging = vi.fn(() => okAsync(undefined));
+    const ports = stubPorts({
+      download: { download: vi.fn(), abort },
+      library: { import: vi.fn(), discardStaging },
+    });
+
+    await interpretEffect(deps(ports), 'acq-1', { type: 'AbortDownload', candidate });
+
+    const rejected = store.all().find((entry) => entry.type === 'CandidateRejected')?.event as
+      Extract<AcquisitionEvent, { type: 'CandidateRejected' }> | undefined;
+    expect(rejected?.files).toEqual(sampleFiles);
   });
 
   it('propagates an abort infrastructure fault without appending', async () => {

--- a/src/application/acquisition/interpreter.ts
+++ b/src/application/acquisition/interpreter.ts
@@ -75,7 +75,7 @@ export function interpretEffect(
             acquisitionId,
             result.kind === 'completed'
               ? { type: 'RecordDownloadCompleted', files: result.files }
-              : { type: 'RecordDownloadFailed', reason: result.reason },
+              : { type: 'RecordDownloadFailed', reason: result.reason, files: result.files },
           ),
         );
 
@@ -110,11 +110,14 @@ export function interpretEffect(
     case 'AbortDownload':
       // Stop the in-flight transfer, then feed the settlement back as a failed outcome. `decide`
       // turns it into the pending candidate's rejection (staging cleanup follows via `react`); the
-      // reported reason is immaterial there, so a plain `Cancelled` stands in.
-      return ports.download
-        .abort(acquisitionId, effect.candidate)
-        .andThen(() =>
-          applyCommand(deps, acquisitionId, { type: 'RecordDownloadFailed', reason: 'Cancelled' }),
-        );
+      // reported reason is immaterial there, so a plain `Cancelled` stands in. The abort reports the
+      // subset the source already completed into staging, so its files are cleaned too (design D2).
+      return ports.download.abort(acquisitionId, effect.candidate).andThen((files) =>
+        applyCommand(deps, acquisitionId, {
+          type: 'RecordDownloadFailed',
+          reason: 'Cancelled',
+          files,
+        }),
+      );
   }
 }

--- a/src/application/acquisition/reactor.test.ts
+++ b/src/application/acquisition/reactor.test.ts
@@ -32,7 +32,7 @@ function stubPorts(overrides: Partial<EffectPorts> = {}): EffectPorts {
     search: { search: vi.fn(() => okAsync([])) },
     download: {
       download: vi.fn(() => okAsync({ kind: 'failed' as const, reason: 'Stalled' as const })),
-      abort: vi.fn(() => okAsync(undefined)),
+      abort: vi.fn(() => okAsync([])),
     },
     probe: { probe: vi.fn() },
     library: { import: vi.fn(), discardStaging: vi.fn(() => okAsync(undefined)) },
@@ -193,7 +193,7 @@ describe('Reactor.process', () => {
       download: {
         download: vi.fn(),
         abort: vi.fn(() =>
-          abortHealthy ? okAsync(undefined) : errAsync(infraError('slskd.abort', 'down')),
+          abortHealthy ? okAsync([]) : errAsync(infraError('slskd.abort', 'down')),
         ),
       },
       library: { import: vi.fn(), discardStaging },
@@ -262,7 +262,7 @@ describe('Reactor.process — reacts against the state as of the event (prefix f
     const ports = stubPorts({
       download: {
         download: vi.fn(() => okAsync({ kind: 'completed' as const, files: sampleFiles })),
-        abort: vi.fn(() => okAsync(undefined)),
+        abort: vi.fn(() => okAsync([])),
       },
     });
     await reactor(ports).process(selected);

--- a/src/application/acquisition/sweep.test.ts
+++ b/src/application/acquisition/sweep.test.ts
@@ -16,17 +16,27 @@ const resource = (acquisitionId: string): SourceResource => ({
   acquisitionId,
 });
 
-/** A remover that records what it removed and can be told to fail for specific acquisitions. */
-function fakeRemover(): SourceResourceRemover & { removed: SourceResource[]; fail: Set<string> } {
+/**
+ * A remover that records what it removed and can be told to fail (an infra fault) or to report a
+ * record as *not confirmed gone* (`unconfirmed`) for specific acquisitions.
+ */
+function fakeRemover(): SourceResourceRemover & {
+  removed: SourceResource[];
+  fail: Set<string>;
+  unconfirmed: Set<string>;
+} {
   const removed: SourceResource[] = [];
   const fail = new Set<string>();
+  const unconfirmed = new Set<string>();
   return {
     removed,
     fail,
+    unconfirmed,
     remove(target: SourceResource) {
       if (fail.has(target.acquisitionId)) return errAsync(infraError('remove', 'boom'));
+      if (unconfirmed.has(target.acquisitionId)) return okAsync(false);
       removed.push(target);
-      return okAsync(undefined);
+      return okAsync(true);
     },
   };
 }
@@ -88,6 +98,18 @@ describe('SourceResourceSweep', () => {
     // acq-a's removal failed so its row stays live; acq-b was removed and marked.
     expect(remover.removed.map((r) => r.acquisitionId)).toEqual(['acq-b']);
     expect(await liveAcquisitionIds()).toEqual(['acq-a']);
+  });
+
+  it('leaves a row live when its record is not yet confirmed gone', async () => {
+    await seed('acq-lingering', true);
+    const remover = fakeRemover();
+    remover.unconfirmed.add('acq-lingering');
+
+    await sweep(remover).run();
+
+    // The cancelled record has not transitioned to removable — its row stays live for the next boot.
+    expect(remover.removed).toEqual([]);
+    expect(await liveAcquisitionIds()).toEqual(['acq-lingering']);
   });
 
   it('logs and stops when the ledger cannot be read', async () => {

--- a/src/application/acquisition/sweep.ts
+++ b/src/application/acquisition/sweep.ts
@@ -56,6 +56,15 @@ export class SourceResourceSweep {
       );
       return;
     }
+    if (!removed.value) {
+      // The record was cancelled but has not yet transitioned to removable — leave the row live so
+      // the next boot's sweep converges it (design D1), rather than marking a lingering record gone.
+      this.deps.logger.debug(
+        { acquisitionId },
+        'sweep: record not yet confirmed gone; will retry next boot',
+      );
+      return;
+    }
     const marked = await this.deps.ledger.markRemoved(resource);
     if (marked.isErr()) {
       this.deps.logger.warn({ err: marked.error, acquisitionId }, 'sweep: markRemoved failed');

--- a/src/application/ports/outbound-ports.ts
+++ b/src/application/ports/outbound-ports.ts
@@ -52,7 +52,14 @@ export interface DownloadProgress {
 
 export type DownloadResult =
   | { readonly kind: 'completed'; readonly files: readonly DownloadedFile[] }
-  | { readonly kind: 'failed'; readonly reason: DownloadFailureReason };
+  | {
+      readonly kind: 'failed';
+      readonly reason: DownloadFailureReason;
+      // Files the source had already completed into staging before the candidate was abandoned or
+      // doomed. Threaded through the domain so staging-cleanup removes them (design D2); best-effort,
+      // so an unresolvable subset simply yields none rather than failing the outcome (D3).
+      readonly files?: readonly DownloadedFile[];
+    };
 
 export interface DownloadPort {
   download(
@@ -67,8 +74,15 @@ export interface DownloadPort {
    * acquisition stops downloading rather than running to completion (D: cancellation). Idempotent:
    * transfers already settled or absent are tolerated, so a redelivered abort is safe. The
    * `acquisitionId` scopes the transfers to the ones this acquisition owns in the ledger.
+   *
+   * Returns the files the source had already completed into staging before the abort, so the caller
+   * can thread them into the settlement for staging-cleanup (design D2). Best-effort: an unresolvable
+   * subset yields none rather than failing the abort (D3).
    */
-  abort(acquisitionId: string, candidate: Candidate): ResultAsync<void, InfraError>;
+  abort(
+    acquisitionId: string,
+    candidate: Candidate,
+  ): ResultAsync<readonly DownloadedFile[], InfraError>;
 }
 
 // --- AudioProbePort (first adapter: ffmpeg) ----------------------------------------------------

--- a/src/application/ports/resource-ledger-port.ts
+++ b/src/application/ports/resource-ledger-port.ts
@@ -42,7 +42,11 @@ export interface ResourceLedgerStore {
 /**
  * Removes a recorded resource from the source (cancel-if-active, then delete). The startup sweep's
  * source-specific arm — the slskd adapter implements it — so the sweep itself stays source-agnostic.
+ *
+ * Resolves to whether the record is *confirmed gone*: cancelling an in-flight transfer only makes it
+ * removable once it transitions to terminal, so a still-lingering record resolves `false` and the
+ * sweep leaves its ledger row live to retry next boot, rather than marking a lingering record removed.
  */
 export interface SourceResourceRemover {
-  remove(resource: SourceResource): ResultAsync<void, InfraError>;
+  remove(resource: SourceResource): ResultAsync<boolean, InfraError>;
 }

--- a/src/composition/e2e.test.ts
+++ b/src/composition/e2e.test.ts
@@ -47,6 +47,9 @@ const PROBES: Record<string, ProbedAudio> = {
 };
 const COMPLETED: DownloadResult = { kind: 'completed', files: DOWNLOADED_FILES };
 const FAILED: DownloadResult = { kind: 'failed', reason: 'Stalled' };
+/** Files the source had already completed into staging when a multi-file candidate was abandoned. */
+const PARTIAL_FILES = [{ path: 'staging/partial-01.flac', name: '01.flac' }];
+const ABANDONED: DownloadResult = { kind: 'failed', reason: 'Stalled', files: PARTIAL_FILES };
 const IMPORTED: ImportResult = { kind: 'imported', location: '/library/Radiohead/Kid A (2000)' };
 const CONFLICT: ImportResult = { kind: 'conflict', location: '/library/Radiohead/Kid A (2000)' };
 
@@ -88,7 +91,7 @@ function wire(opts: E2eOptions) {
         }
         return okAsync(result);
       },
-      abort: () => okAsync(undefined),
+      abort: () => okAsync([]),
     },
     probe: { probe: (path) => okAsync(PROBES[path]!) },
     library: { import: () => okAsync(opts.importResult), discardStaging },
@@ -186,6 +189,31 @@ describe('acquisition E2E', () => {
     expect(view.attempts).toBe(2);
     expect(view.rejectedCount).toBe(1);
     expect(view.history.some((entry) => entry.kind === 'download-failed')).toBe(true);
+  });
+
+  it('discards an abandoned candidate’s completed subset, keeping its failure reason', async () => {
+    const { w, app } = await startHttp({
+      searchByRound: (round) =>
+        round === 1 ? [candidateWithSpeed('a', 200), candidateWithSpeed('b', 100)] : [],
+      downloadByUser: { a: ABANDONED, b: COMPLETED },
+      importResult: IMPORTED,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/acquisitions',
+      payload: SUBMIT_BODY,
+    });
+    const id = res.json<{ acquisitionId: string }>().acquisitionId;
+    await settle(w, id, 'Fulfilled');
+
+    // The abandoned candidate's already-completed files are discarded from staging — no residue —
+    // via the same cleanup path a rejected candidate uses (D2).
+    await vi.waitFor(() => {
+      expect(w.discardStaging).toHaveBeenCalledWith(PARTIAL_FILES);
+    });
+    // The abandonment was still recorded as a failure with its reason, not swallowed.
+    expect(w.status.get(id)!.history.some((entry) => entry.kind === 'download-failed')).toBe(true);
   });
 
   it('exhausts when every candidate fails and re-search finds nothing', async () => {

--- a/src/domain/acquisition/acquisition.test.ts
+++ b/src/domain/acquisition/acquisition.test.ts
@@ -324,6 +324,22 @@ describe('Acquisition.execute — cleanup events carry the staged files (D3)', (
     expect(eventOf(events, 'CandidateRejected').files).toEqual([]);
   });
 
+  it('stamps an abandoned download’s already-completed files onto its rejection', () => {
+    // The domain never saw a completion for the abandoned candidate; the adapter reports the partial
+    // subset on the failed command, and `decide` stamps it onto the rejection for cleanup (D2).
+    const events = Acquisition.fromHistory(selectedHistory([a, matchingCandidate('b')]))
+      .execute({ type: 'RecordDownloadFailed', reason: 'Stalled', files: sampleFiles })
+      ._unsafeUnwrap();
+    expect(eventOf(events, 'CandidateRejected').files).toEqual(sampleFiles);
+  });
+
+  it('stamps an aborted candidate’s completed files onto the cancelled-settlement rejection', () => {
+    const events = Acquisition.fromHistory(cancelledHistory)
+      .execute({ type: 'RecordDownloadFailed', reason: 'Cancelled', files: sampleFiles })
+      ._unsafeUnwrap();
+    expect(eventOf(events, 'CandidateRejected').files).toEqual(sampleFiles);
+  });
+
   it('stamps the imported candidate’s staged files onto the Imported event', () => {
     const events = Acquisition.fromHistory(importingHistory([a]))
       .execute({ type: 'RecordImported', location: '/library/x' })

--- a/src/domain/acquisition/commands.ts
+++ b/src/domain/acquisition/commands.ts
@@ -18,7 +18,14 @@ export type AcquisitionCommand =
   | { readonly type: 'RecordMetadataFailed' }
   | { readonly type: 'RecordSearchResults'; readonly candidates: readonly Candidate[] }
   | { readonly type: 'RecordDownloadCompleted'; readonly files: readonly DownloadedFile[] }
-  | { readonly type: 'RecordDownloadFailed'; readonly reason: DownloadFailureReason }
+  | {
+      readonly type: 'RecordDownloadFailed';
+      readonly reason: DownloadFailureReason;
+      // The already-completed staged files of the abandoned/aborted candidate, reported by the
+      // adapter so `decide` can stamp them onto the rejection for cleanup (design D2). Optional:
+      // a download that failed before staging (or with an unresolvable subset) carries none.
+      readonly files?: readonly DownloadedFile[];
+    }
   | { readonly type: 'RecordValidationPassed'; readonly verdict: ValidationVerdict }
   | { readonly type: 'RecordValidationFailed'; readonly verdict: ValidationVerdict }
   | { readonly type: 'RecordImported'; readonly location: string }

--- a/src/domain/acquisition/decide.ts
+++ b/src/domain/acquisition/decide.ts
@@ -82,14 +82,19 @@ function stagedFilesOf(state: AcquisitionState): readonly DownloadedFile[] {
   return 'downloadedFiles' in state ? state.downloadedFiles : [];
 }
 
-/** After a candidate fails, reject it and decide the next move in one batch. */
+/**
+ * After a candidate fails, reject it and decide the next move in one batch. `files` are the rejected
+ * candidate's staged files to clean up (via `react`): the source-reported partial subset for a failed
+ * download (the domain never saw them staged), or the folded `downloadedFiles` for a failed validation.
+ */
 function rejectAndAdvance(
   state: DownloadingState | ValidatingState,
   failure: AcquisitionEvent,
+  files: readonly DownloadedFile[],
 ): readonly AcquisitionEvent[] {
   return [
     failure,
-    { type: 'CandidateRejected', candidate: state.current.identity, files: stagedFilesOf(state) },
+    { type: 'CandidateRejected', candidate: state.current.identity, files },
     selectNext(state),
   ];
 }
@@ -99,8 +104,11 @@ function rejectAndAdvance(
  * are cleaned up (via `react`), leaving the acquisition cancelled. Fires exactly once — a later
  * duplicate settlement folds to no `pending` and is absorbed by the terminal-state tolerance above.
  */
-function settleCancelled(pending: Candidate): readonly AcquisitionEvent[] {
-  return [{ type: 'CandidateRejected', candidate: pending.identity }];
+function settleCancelled(
+  pending: Candidate,
+  files: readonly DownloadedFile[],
+): readonly AcquisitionEvent[] {
+  return [{ type: 'CandidateRejected', candidate: pending.identity, files }];
 }
 
 export function decide(command: AcquisitionCommand, state: AcquisitionState): Decision {
@@ -145,7 +153,7 @@ export function decide(command: AcquisitionCommand, state: AcquisitionState): De
 
     case 'RecordDownloadCompleted':
       if (state.phase === 'Cancelled' && state.pending !== undefined)
-        return ok(settleCancelled(state.pending));
+        return ok(settleCancelled(state.pending, command.files));
       if (isTerminal(state)) return ok([]);
       if (state.phase !== 'Downloading') return err(illegal(command.type, state));
       return ok([
@@ -154,15 +162,19 @@ export function decide(command: AcquisitionCommand, state: AcquisitionState): De
 
     case 'RecordDownloadFailed':
       if (state.phase === 'Cancelled' && state.pending !== undefined)
-        return ok(settleCancelled(state.pending));
+        return ok(settleCancelled(state.pending, command.files ?? []));
       if (isTerminal(state)) return ok([]);
       if (state.phase !== 'Downloading') return err(illegal(command.type, state));
       return ok(
-        rejectAndAdvance(state, {
-          type: 'DownloadFailed',
-          candidate: state.current.identity,
-          reason: command.reason,
-        }),
+        rejectAndAdvance(
+          state,
+          {
+            type: 'DownloadFailed',
+            candidate: state.current.identity,
+            reason: command.reason,
+          },
+          command.files ?? [],
+        ),
       );
 
     case 'RecordValidationPassed':
@@ -176,11 +188,15 @@ export function decide(command: AcquisitionCommand, state: AcquisitionState): De
       if (isTerminal(state)) return ok([]);
       if (state.phase !== 'Validating') return err(illegal(command.type, state));
       return ok(
-        rejectAndAdvance(state, {
-          type: 'ValidationFailed',
-          candidate: state.current.identity,
-          verdict: command.verdict,
-        }),
+        rejectAndAdvance(
+          state,
+          {
+            type: 'ValidationFailed',
+            candidate: state.current.identity,
+            verdict: command.verdict,
+          },
+          stagedFilesOf(state),
+        ),
       );
 
     case 'RecordImported':


### PR DESCRIPTION
## Why

A live v2.2.1 acquisition (Daft Punk – RAM) exposed that an **abandoned** multi-file candidate is only partially torn down, leaving two kinds of residue:

- **Lingering source records** — `?remove=true` on an *in-flight* transfer only *cancels* it (→ `Completed, Cancelled`); slskd's synchronous remove is guarded on the terminal flag, so the record isn't removed. But the ledger row was marked removed anyway, so the startup sweep never retried it (10 stranded records observed).
- **Orphaned staged files** — files that *completed* before the abandon were moved into staging, but the domain never saw a `DownloadCompleted`, so `discardStaging([])` cleaned nothing (~706 MB of orphaned FLACs).

## What changed

- **Confirm-before-mark teardown (D1):** cancel an in-flight transfer (`?remove=false`), re-poll until terminal, then remove it (`?remove=true`); a ledger row is marked removed **only** once its record is confirmed gone. Unconfirmed rows stay live so the startup sweep converges them. Applied to `removeOwned`, `abort`/`abandon`/doom paths, and the sweep's `SlskdResourceRemover`.
- **Partial-file cleanup (D2/D3):** the adapter resolves the already-completed subset's source-reported locations (same events resolver as the completed path) and reports them on the `failed` outcome; threaded additively through `RecordDownloadFailed` → `CandidateRejected` → `Cleanup` → `discardStaging`. Best-effort: an unresolvable subset yields no files, never an infra fault. The slskd adapter never touches the filesystem.

## Tests

- Reworked download / resource-remover / sweep / interpreter / reactor / domain tests for the new semantics; added a stateful-slskd-double test proving no residual records survive teardown, and an in-process E2E asserting an abandoned candidate's completed subset is discarded while its failure reason is preserved.
- Full gate green locally: format, lint, typecheck, build, **100% coverage** (666 unit), contract (41), release (18).

Spec deltas synced into `openspec/specs/` and the OpenSpec change archived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)