### PR TITLE
docs(openspec): propose the importer-integration changes

### DIFF
--- a/openspec/changes/acquisition-outbound-events/.openspec.yaml
+++ b/openspec/changes/acquisition-outbound-events/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/acquisition-outbound-events/design.md
+++ b/openspec/changes/acquisition-outbound-events/design.md
@@ -1,0 +1,50 @@
+## Context
+
+music-importer (sibling repo, bootstrapped 2026-07-19) will consume "a release was deposited" facts to trigger imports. The coupling design was settled after a literature survey (Newman, Evans, Fowler/Robinson CDC, Bellemare, Hohpe, CloudEvents/Standard Webhooks): producer-owned event schemas, tolerant-reader consumers, no shared contracts package, webhooks as the broker-less transport. This repo already has every mechanical ingredient: an event-sourced store with global ordering, checkpointed durable consumers (the reactor), and zod-first contracts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Publish `acquisition.fulfilled` reliably (at-least-once, ordered, restart-safe) to configured HTTP subscribers, with authenticity and idempotency conveyed per Standard Webhooks.
+- Own the outbound contract: schema in this repo, validated outbound, additive-only forever, published as generated JSON Schema + frozen fixtures other repos can test against.
+- Zero behavior change when no subscriber is configured; zero knowledge of any specific consumer.
+
+**Non-Goals:**
+
+- No broker (MQTT/Kafka) — transport is swappable later behind the publisher seam if fan-out ever demands it.
+- No consumer-side anything (music-importer's intake adapter lives in its repo).
+- No event types beyond `acquisition.fulfilled` in this change — the catalog grows additively.
+- No delivery guarantees beyond at-least-once (consumers deduplicate by `webhook-id`/acquisition id).
+
+## Decisions
+
+### D1 — The event store is the outbox; the publisher is a checkpointed consumer
+
+No dual-write problem exists here by construction: domain events are already durably appended before anything else happens, so the publisher is simply another checkpointed consumer of the global stream (exactly the reactor's shape, with its own consumer name). It folds nothing and decides nothing: it filters for events that have a published mapping (`AcquisitionFulfilled`, joined with its stream's context for the payload), renders the outbound payload, delivers, and advances its checkpoint only on success. Crash anywhere → redelivery from the checkpoint. This is the transactional-outbox pattern with zero new infrastructure.
+
+### D2 — One publisher checkpoint, per-delivery retries, bounded then parked
+
+Delivery failures retry in-process with capped exponential backoff; a subscriber that stays down does not advance the checkpoint, so the events redeliver on the next cycle/restart — the same convergence posture as the reactor. Deliveries to multiple subscribers are independent per URL (one slow subscriber must not starve another → per-subscriber checkpoints, keyed `webhook:<url-hash>`). Ordering is preserved per subscriber (deliver in global-seq order; do not skip ahead past an undelivered event) because the consumer contract is easier to reason about ordered, and the volume (a handful of fulfillments) makes head-of-line blocking irrelevant.
+
+### D3 — Fat, self-contained payloads in the producer's own language
+
+The payload carries acquisition id, target (with MusicBrainz release id, artist/title metadata), fulfilled candidate identity, deposited location, and file listing — a consumer can act with no callback. The vocabulary is this tool's ubiquitous language ("acquisition", "candidate", "fulfilled"); consumers translate at their own ACLs (the settled anti-corruption posture — there is deliberately no "neutral" vocabulary to co-own). Optional fields carry explicit defaults in the schema, so absent-field behavior lives in the contract, not in receiver code (Hohpe's optional-field trap).
+
+### D4 — Standard Webhooks envelope and evolution rules
+
+Body `{type: 'acquisition.fulfilled', timestamp, data}`; headers `webhook-id` (deterministic: consumer idempotency key, derived from global seq + subscriber), `webhook-timestamp`, `webhook-signature` (HMAC-SHA256 over id.timestamp.body with the configured secret). Evolution: **additive-only within a type; a breaking change is a new `type`**. CI mechanizes the rule: zod schemas → generated JSON Schema, diffed against the committed previous version, failing on non-additive change; frozen payload fixtures are committed and never deleted (old-version events legitimately arrive after deploys via retries).
+
+### D5 — Config-dormant; secrets and URLs from the environment
+
+`WEBHOOK_URLS` (comma-separated) and `WEBHOOK_SECRET` via config (12-factor). Unset → the publisher does not start; nothing else changes. Misconfigured (URLs without secret) → startup fails loudly rather than publishing unsigned.
+
+## Risks / Trade-offs
+
+- **[Payload from folded context]** `AcquisitionFulfilled` alone doesn't carry the target/candidate detail; the publisher folds the stream (cheap, same as projections) to render the payload. → Render at delivery time from the stream prefix — deterministic and replay-safe.
+- **[Slow/dead subscriber]** Blocks its own checkpoint indefinitely. → By design (convergence over loss); per-subscriber isolation keeps others unaffected; log loudly.
+- **[Schema-diff gate false confidence]** JSON Schema diffing catches structure, not semantics. → Frozen fixtures + consumer contract tests (in consumer repos) cover meaning; the gate is one layer, not the whole story.
+
+## Open Questions
+
+- Whether `webhook-id` derivation should include the event's stream version vs global seq only — decide in implementation with the idempotency tests.

--- a/openspec/changes/acquisition-outbound-events/proposal.md
+++ b/openspec/changes/acquisition-outbound-events/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+A fulfilled acquisition deposits validated files into the intake directory — and then nothing tells anyone. The new sibling service, music-importer, needs to learn "a release was deposited, here is where and what it is" near-instantly, without polling and without either tool knowing the other exists. More broadly, an event-sourced tool that keeps its facts private is only half a citizen of a composable ecosystem: the facts already exist on the stream; this change publishes the relevant ones.
+
+The contract posture follows the researched cross-tool standard for this ecosystem: **this repo owns the schemas of the events it emits**, validates them outbound, and publishes them as versioned artifacts (generated JSON Schema + frozen fixtures); consumers are tolerant readers behind their own anti-corruption layers. No shared package, no broker, no knowledge of any consumer.
+
+## What Changes
+
+- A **durable webhook publisher**: a new checkpointed consumer of the event store (the store *is* the transactional outbox — same machinery as the reactor and projections) that translates selected domain events into published event payloads and POSTs them to configured subscriber URLs. At-least-once delivery: the checkpoint advances only on acknowledged delivery, retries with backoff, and a restart redelivers anything unacknowledged.
+- The **first published event type: `acquisition.fulfilled`** — a self-contained ("fat") payload carrying the acquisition id, the resolved target (including its MusicBrainz release id), the fulfilled candidate's identity, and the deposited library location with its files — everything a consumer needs to act without a callback. The catalog is additive: future types (failures, verdict acks) join without breaking anything.
+- **Standard Webhooks envelope**: `{type, timestamp, data}` body with `webhook-id` / `webhook-timestamp` / `webhook-signature` (HMAC) headers, so any receiver gets idempotency keys and authenticity for free; a breaking payload change is expressed as a new event `type`, never a mutation.
+- **Producer-owned contract artifacts**: the outbound zod schemas live in `src/interfaces/contracts/events/` as the single source; CI generates JSON Schema from them and diffs against the last published version, failing on any non-additive change (the additive-only rule, mechanized); frozen fixtures of real payloads are committed and kept forever (webhook retries deliver old-version events after deploys).
+- **Config-dormant standalone mode**: subscriber URLs and the signing secret come from the environment; with none configured, the publisher idles and the tool behaves exactly as today.
+
+## Capabilities
+
+### New Capabilities
+
+- `outbound-events`: the published-event contract (ownership, envelope, payload, additive-only evolution) and the durable at-least-once publisher.
+
+### Modified Capabilities
+
+<!-- none — the publisher is a new, purely additive consumer of the existing stream -->
+
+## Impact
+
+- `src/interfaces/contracts/events/` — outbound event schemas (zod, single source) + payload mapping from domain events.
+- `src/application/` — the publisher as a checkpointed stream consumer (reusing the checkpoint store; its own consumer name).
+- `src/adapters/` — the webhook HTTP dispatcher (signing, retries/backoff) over the existing HTTP client seam.
+- `src/composition/` — config (`WEBHOOK_URLS`, `WEBHOOK_SECRET`), wiring, startup.
+- CI — JSON Schema generation + additive-only diff gate; fixture recording under `test/contract/`.
+- No public HTTP API surface change; no domain change.

--- a/openspec/changes/acquisition-outbound-events/specs/outbound-events/spec.md
+++ b/openspec/changes/acquisition-outbound-events/specs/outbound-events/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Fulfilled acquisitions are published to configured webhook subscribers
+
+The system SHALL publish an `acquisition.fulfilled` event to every configured subscriber URL when an acquisition reaches fulfilment, carrying a self-contained payload — the acquisition id, the resolved target including its MusicBrainz release id, the fulfilled candidate's identity, and the deposited library location with its files — so a consumer can act without calling back. With no subscribers configured, the system SHALL behave exactly as it does today.
+
+#### Scenario: A deposit is announced
+
+- **WHEN** an acquisition is fulfilled and a subscriber is configured
+- **THEN** the subscriber receives an `acquisition.fulfilled` payload naming the deposited location, the target's MusicBrainz release id, and the files
+
+#### Scenario: Standalone mode is unchanged
+
+- **GIVEN** no subscriber URLs configured
+- **WHEN** acquisitions run to fulfilment
+- **THEN** no delivery is attempted and no behavior differs from before this capability existed
+
+### Requirement: Delivery is durable, ordered, and at-least-once
+
+The system SHALL deliver published events through a durable checkpointed consumer of the event store: a delivery is retried with bounded backoff, a subscriber's checkpoint advances only on acknowledged delivery, undelivered events survive restarts and redeliver, and each subscriber receives events in stream order. Subscribers SHALL be isolated: one unreachable subscriber does not affect delivery to another. Each delivery SHALL carry a stable idempotency id so redeliveries are detectable by the receiver.
+
+#### Scenario: A crash between append and delivery loses nothing
+
+- **GIVEN** an acquisition fulfilled moments before a process crash
+- **WHEN** the system restarts
+- **THEN** the event is delivered from the checkpoint as if the crash had not happened
+
+#### Scenario: A redelivered event is identifiable
+
+- **GIVEN** a delivery whose acknowledgement was lost
+- **WHEN** the event is delivered again
+- **THEN** it carries the same idempotency id as the first attempt
+
+#### Scenario: One dead subscriber does not starve another
+
+- **GIVEN** two configured subscribers, one unreachable
+- **WHEN** events are published
+- **THEN** the reachable subscriber keeps receiving them while the unreachable one's checkpoint holds for retry
+
+### Requirement: Published events follow the Standard Webhooks envelope and are signed
+
+Deliveries SHALL use the Standard Webhooks conventions: a `{type, timestamp, data}` body and `webhook-id`, `webhook-timestamp`, and `webhook-signature` (HMAC) headers, signed with a configured secret. The system SHALL refuse to start with subscribers configured but no signing secret.
+
+#### Scenario: A receiver can verify authenticity
+
+- **WHEN** a delivery arrives at a subscriber
+- **THEN** its signature verifies against the shared secret and the id/timestamp headers it carries
+
+#### Scenario: Unsigned publishing is impossible
+
+- **GIVEN** subscriber URLs configured without a signing secret
+- **WHEN** the system starts
+- **THEN** startup fails with a precise configuration error
+
+### Requirement: The outbound contract is producer-owned, additive-only, and published as artifacts
+
+The outbound event schemas SHALL live in this repository as the single contract source, validate every outgoing payload, and be published as generated JSON Schema plus frozen payload fixtures. Evolution SHALL be additive-only within an event type — verified in CI by diffing the generated schema against the last published version — and a breaking payload change SHALL be expressed as a new event type. Committed fixtures SHALL be kept permanently so compatibility is verifiable against every historical version.
+
+#### Scenario: A non-additive schema change fails CI
+
+- **GIVEN** an edit that removes or retypes a published payload field
+- **WHEN** the contract gate runs
+- **THEN** the build fails identifying the incompatible change
+
+#### Scenario: An outbound payload violating its schema never leaves the process
+
+- **GIVEN** a payload-rendering defect
+- **WHEN** the payload fails outbound validation
+- **THEN** the delivery is not attempted and the defect surfaces as an error

--- a/openspec/changes/acquisition-outbound-events/tasks.md
+++ b/openspec/changes/acquisition-outbound-events/tasks.md
@@ -1,0 +1,21 @@
+## 1. The outbound contract
+
+- [ ] 1.1 Write failing schema tests, then the `acquisition.fulfilled` zod schema in `src/interfaces/contracts/events/` (payload: acquisition id, target incl. MB release id + metadata, candidate identity, location, files; optional fields with explicit defaults) and the mapping from the folded stream to the payload.
+- [ ] 1.2 JSON Schema generation script + committed generated schema; CI gate diffing against the committed previous version, failing on non-additive change; wire into `check`/pipeline.
+- [ ] 1.3 Frozen payload fixtures under `test/contract/` (recorded from the mapping over fixture histories), kept permanently; contract tests parsing every fixture version with the current schema.
+
+## 2. The publisher
+
+- [ ] 2.1 Write failing tests for the checkpointed publisher consumer: filters mapped events, renders payloads from the stream prefix, advances a per-subscriber checkpoint only on acknowledged delivery, redelivers after restart, preserves order, isolates subscribers.
+- [ ] 2.2 Implement the publisher in `src/application/` reusing the checkpoint store (consumer name `webhook:<url-hash>`), with bounded-backoff retries and loud logging on a held checkpoint.
+- [ ] 2.3 Write failing tests, then the webhook dispatcher adapter (Standard Webhooks envelope, deterministic `webhook-id`, HMAC-SHA256 signature) over the existing HTTP client seam.
+
+## 3. Composition + config
+
+- [ ] 3.1 Config: `WEBHOOK_URLS` (list) + `WEBHOOK_SECRET`; dormant when unset; startup failure on URLs-without-secret; failing config tests first.
+- [ ] 3.2 Wire the publisher into the composition root after the sweep, alongside the reactor.
+
+## 4. Fidelity + gate
+
+- [ ] 4.1 In-process e2e: a fulfilled acquisition drives a delivery to a stub subscriber (assert envelope, signature, payload, idempotency id stability across a simulated redelivery).
+- [ ] 4.2 `pnpm check` + `pnpm test:e2e` green; doc comments on the publisher/dispatcher describing the outbox posture and the additive-only rule.

--- a/openspec/changes/fulfillment-external-verdict/.openspec.yaml
+++ b/openspec/changes/fulfillment-external-verdict/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/fulfillment-external-verdict/design.md
+++ b/openspec/changes/fulfillment-external-verdict/design.md
@@ -1,0 +1,46 @@
+## Context
+
+music-importer (sibling service) judges deposited releases with beets matching and will publish rejection verdicts for releases that fail it. The settled cross-tool posture: each tool owns its outbound event schemas; consumers are tolerant readers behind ACLs. This change is the downloader's consumer side of that loop plus the domain edge it triggers. The design was settled in discussion (2026-07-19), explicitly rejecting two alternatives: caller-supplied exclusion lists (externalizes the aggregate's rejected-set memory to callers) and a per-target blacklist store (rebuilds state the aggregate already knows how to hold).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A bad delivered candidate leads, without manual intervention, to the next-best candidate through the existing bounded ladder.
+- Keep the domain's language pure: "external validation failed", never "import".
+- Keep the loop safe: stale-guarded, idempotent, budget-bounded, and inert when unconfigured or when no verdict ever arrives.
+
+**Non-Goals:**
+
+- No positive-verdict handling or sealed/accepted state (additive later if a need appears; rejecting-after-accepting has no realistic flow today).
+- No revival window/timeout policy (the attempt budget bounds total activity; time-bounding can be added as policy later without model change).
+- No knowledge of music-importer: the receiver is a generic signed-verdict edge; its tolerant-reader schema names only what this domain needs.
+
+## Decisions
+
+### D1 — A late external validation failure, in the native language
+
+The adjudication is validation that ran outside the system, so the command is `RecordExternalValidationFailed` and the event `FulfillmentRejected` — distinct from `ValidationFailed` (which rejects an in-flight candidate during `Validating`) because it rejects a *delivered outcome*, and the phase narrative should say so. `decide` on `Fulfilled` with a matching candidate mints `[FulfillmentRejected, CandidateRejected, selectNext(...)]` — the exact `rejectAndAdvance` shape already used for download/validation failures, reusing the rejected set, working set, re-search rounds, and attempt bounds unchanged.
+
+### D2 — Fulfilled is stable-but-defeasible; convergence is preserved
+
+Terminality splits into two honest flavors: **absorbing** (`Exhausted`, `Cancelled`, `MetadataFailed`, `Conflicted` — no command revives them) and **stable-but-defeasible** (`Fulfilled` alone). Nothing operational needed "done forever": streams are kept indefinitely regardless, the sweep's resource cleanup at fulfilment is unaffected (a revival creates fresh resources), and `isTerminal` remains true for `Fulfilled` for all existing consumers — the revival is a single narrow exception inside `decide`, not a reclassification. Every revival spends the existing budgets, so total activity per acquisition stays provably bounded and the system still converges to an absorbing state on its own. No acknowledgement flow: self-determined terminality is preserved for the standalone tool.
+
+### D3 — The stale-guard: Fulfilled retains the judged candidate's identity
+
+`FulfilledState` today keeps only progress counters and the location; to guard verdicts it additionally retains the fulfilled candidate's identity and the ladder-resume context (target, policies, working set, request) — an internal fold-shape change, additive, no public contract impact. `decide` ignores a verdict whose candidate identity does not equal the retained one (the standard stale-outcome guard), which makes redelivery and double-revival convergent: after a revival the state is no longer `Fulfilled`, so a duplicate verdict no-ops through the existing terminal/phase guards. Legacy histories fold to a Fulfilled state with no retained candidate; verdicts against them are ignored — the correct degraded behavior for acquisitions fulfilled before this capability existed.
+
+### D4 — The receiver is a tolerant-reader edge behind the ACL
+
+A single webhook endpoint accepts Standard Webhooks-style deliveries: verify the HMAC signature and timestamp, dedupe by `webhook-id`, tolerantly parse **only** the fields this domain needs — acquisition id, candidate identity, a rejected verdict, optional reasons — ignoring everything else in the sender's payload (consumer-defined minimal schema; the sender's full schema is its own business). The parsed fact translates through the anti-corruption layer into `RecordExternalValidationFailed` and enters through the same command handler as every other command, where `decide`'s guards make redelivery safe end-to-end. Config-dormant: without `VERDICT_WEBHOOK_SECRET`, the route is not registered.
+
+## Risks / Trade-offs
+
+- **[Stale working set on revival]** The retained working set may be weeks old. → Acceptable: candidates are re-validated on download, and an empty/expired set falls through to the existing bounded re-search — the ladder's normal degradation path.
+- **[Fold-shape growth on Fulfilled]** Retaining the working set in a terminal state keeps more in memory per fold. → Negligible at this scale; the alternative (re-search-only revival) throws away useful ranking for no measurable saving.
+- **[Verdict for a revived-and-refulfilled acquisition]** A slow verdict could name candidate A after a revival already led to fulfilment with candidate B. → The stale-guard handles it: A ≠ retained B → ignored. A verdict against B is a legitimate new judgment and revives again, spending budget.
+- **[Endpoint abuse]** A public-ish POST that mutates state. → HMAC signature + timestamp window + id dedupe; unsigned/invalid requests are rejected before parsing.
+
+## Open Questions
+
+- Whether the receiver should also accept accepted-verdicts now and simply record them as inert facts (cheap forward-compat) or reject unknown verdict values (stricter) — lean stricter; additive to relax later.

--- a/openspec/changes/fulfillment-external-verdict/proposal.md
+++ b/openspec/changes/fulfillment-external-verdict/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Fulfilment is provisional and the model doesn't know it yet. The system's own validation (decode + duration match) can pass a candidate whose files a downstream adjudicator later judges unacceptable — music-importer's beets matching is exactly such an adjudicator ("this claims to be the release but a track is a corrupt stub"). Today a bad delivered candidate is a dead end: the acquisition sits terminal at Fulfilled, and getting a different version means manually re-submitting and hoping ranking picks differently — it won't, because the rejected-candidate knowledge lives nowhere.
+
+The retry machinery to handle this already exists: rejection → rejected set → next-best candidate → bounded re-search. This change adds the one missing edge: a **late-arriving external validation failure** that revives a fulfilled acquisition back into that ladder. In the tool's own ubiquitous language this is validation that ran outside the system — no importer concept enters the domain.
+
+## What Changes
+
+- A new command **`RecordExternalValidationFailed`** (acquisition id, the judged candidate's identity, reasons) and event **`FulfillmentRejected`**: on a Fulfilled acquisition whose fulfilled candidate matches, `decide` mints the rejection and re-enters the existing ladder (`CandidateRejected` → select next / re-search / exhaust). Every existing bound applies — revivals spend the same attempt and search-round budgets, so the system still converges to absorbing terminal states.
+- **`Fulfilled` becomes stable-but-defeasible**: still the happy resting state, still terminal for every purpose that exists today (sweep, cancellation of nothing, status), but no longer immune to this one command. The folded Fulfilled state retains the fulfilled candidate's identity (the stale-guard: a verdict naming any other candidate is ignored) and the context needed to resume the ladder. All other terminal states remain absorbing. No acknowledgement/sealing flow — a fulfilled acquisition that never hears a verdict rests at Fulfilled forever, exactly as today.
+- An **inbound verdict webhook receiver** on the HTTP surface: an edge adapter that accepts a signed webhook delivery, tolerantly reads only the fields it needs (acquisition id, candidate identity, verdict, reasons) from the sender's payload, translates through the anti-corruption layer into the native command, and converges idempotently on redelivery. Config-dormant: no receiver secret configured → the endpoint is not registered.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `acquisition-lifecycle`: fulfilment is stable-but-defeasible — an external validation failure for the fulfilled candidate revives the acquisition into the existing bounded retry ladder; stale or mismatched verdicts are ignored.
+- `public-api`: gains the inbound verdict webhook receiver (signed, tolerant-reader, idempotent, config-dormant).
+
+## Impact
+
+- `src/domain/acquisition/{commands,events,decide,state}.ts` — the command/event pair; `FulfilledState` retains candidate identity + resume context (fold-shape change, additive; legacy histories upcast with no retained candidate and simply cannot be revived — the correct degraded behavior).
+- `src/interfaces/http/` + `src/interfaces/contracts/` — the receiver endpoint, its tolerant-reader schema, signature verification.
+- `src/application/` — command plumbing (no new effects; the revival reuses Download/Search reactions as-is).
+- `src/composition/` — receiver config (`VERDICT_WEBHOOK_SECRET`).
+- Tests across decide/state/react totality, receiver contract + idempotency, and an e2e reviving a fulfilled acquisition into a second candidate.

--- a/openspec/changes/fulfillment-external-verdict/specs/acquisition-lifecycle/spec.md
+++ b/openspec/changes/fulfillment-external-verdict/specs/acquisition-lifecycle/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: A validated, imported download fulfils the acquisition
+
+The system SHALL mark an acquisition as fulfilled once a candidate has passed validation and been imported into the library. Fulfilment SHALL be stable but defeasible: it is the acquisition's resting state and terminal for every existing purpose, but an external validation failure reported for the fulfilled candidate SHALL reject that candidate and revive the acquisition into the existing retry ladder — selecting the next-best candidate, re-searching within bounds, or exhausting — spending the same attempt and search-round budgets as any other rejection, so total activity remains bounded and the acquisition still converges to an absorbing outcome. An acquisition that never receives such a report SHALL rest at fulfilled indefinitely. All other terminal states remain absorbing.
+
+#### Scenario: Successful acquisition
+
+- **GIVEN** an acquisition whose selected candidate passed validation
+- **WHEN** the candidate is imported into the library
+- **THEN** the acquisition reaches a terminal fulfilled state recording the library location
+
+#### Scenario: An external rejection revives the ladder
+
+- **GIVEN** a fulfilled acquisition whose working set still holds a next-best candidate
+- **WHEN** an external validation failure is reported for the fulfilled candidate
+- **THEN** the fulfilled candidate is rejected and the next-best candidate is selected for download
+- **AND** the rejection is recorded in the acquisition's history with its reasons
+
+#### Scenario: A revival can exhaust
+
+- **GIVEN** a fulfilled acquisition with no remaining candidates and no search budget
+- **WHEN** an external validation failure is reported for the fulfilled candidate
+- **THEN** the acquisition reaches the absorbing exhausted state
+
+#### Scenario: A mismatched or repeated verdict is ignored
+
+- **GIVEN** a fulfilled acquisition
+- **WHEN** an external validation failure names a candidate other than the fulfilled one, or arrives again after a revival already occurred
+- **THEN** the report is ignored and the acquisition's state is unchanged
+
+#### Scenario: Absorbing states cannot be revived
+
+- **GIVEN** an exhausted, cancelled, conflicted, or metadata-failed acquisition
+- **WHEN** an external validation failure is reported
+- **THEN** the report is ignored

--- a/openspec/changes/fulfillment-external-verdict/specs/public-api/spec.md
+++ b/openspec/changes/fulfillment-external-verdict/specs/public-api/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: External verdicts are received over a signed, idempotent webhook endpoint
+
+The system SHALL expose an inbound webhook endpoint that accepts external validation verdicts for delivered acquisitions: deliveries are verified against a configured shared secret (signature and timestamp) and deduplicated by delivery id; payloads are read tolerantly — only the acquisition id, candidate identity, verdict, and optional reasons this domain needs, ignoring unknown fields — and translated at the boundary into the native external-validation command. Redelivered or stale verdicts SHALL converge without error. With no receiver secret configured, the endpoint SHALL NOT be registered and the system behaves exactly as today.
+
+#### Scenario: A signed rejection verdict revives an acquisition
+
+- **GIVEN** a fulfilled acquisition and a configured receiver secret
+- **WHEN** a correctly signed verdict delivery rejects the fulfilled candidate
+- **THEN** the acquisition revives into the retry ladder and the endpoint acknowledges the delivery
+
+#### Scenario: An unsigned delivery is rejected before parsing
+
+- **WHEN** a delivery arrives with a missing or invalid signature
+- **THEN** it is rejected without any command being issued
+
+#### Scenario: A redelivered verdict converges
+
+- **GIVEN** a verdict delivery already processed
+- **WHEN** the same delivery arrives again
+- **THEN** it is acknowledged and the acquisition's state is unchanged
+
+#### Scenario: Unknown payload fields are ignored
+
+- **GIVEN** a sender whose payload carries fields this system does not use
+- **WHEN** the delivery is processed
+- **THEN** the extra fields are ignored and the verdict is handled normally

--- a/openspec/changes/fulfillment-external-verdict/tasks.md
+++ b/openspec/changes/fulfillment-external-verdict/tasks.md
@@ -1,0 +1,16 @@
+## 1. Domain: the revival edge
+
+- [ ] 1.1 Write failing `state.test.ts` cases: `FulfilledState` retains the fulfilled candidate's identity and ladder-resume context (target, policies, working set, request); legacy histories fold to Fulfilled with no retained candidate; `FulfillmentRejected` folds Fulfilled → the rejection path (then `CandidateRejected`/`selectNext` events fold as they already do); implement the fold changes.
+- [ ] 1.2 Write failing `decide`/`acquisition.test.ts` cases for `RecordExternalValidationFailed`: matching candidate on Fulfilled → `[FulfillmentRejected, CandidateRejected, selectNext]` (next-best, re-search, and exhaust variants); mismatched candidate → no-op; legacy no-retained-candidate → no-op; absorbing states → no-op; post-revival redelivery → no-op via existing phase guards; implement command + event + decide case.
+- [ ] 1.3 Verify `react` totality (`FulfillmentRejected` → no effects; the co-emitted `CandidateRejected` already drives cleanup, and `CandidateSelected`/`SearchRequested` already drive the revival's work); extend totality/upcast tests.
+
+## 2. The verdict receiver (interfaces)
+
+- [ ] 2.1 Write failing contract tests for the tolerant-reader verdict schema (acquisition id, candidate identity, verdict, optional reasons; unknown fields ignored) and Standard Webhooks verification (HMAC, timestamp window, `webhook-id` dedupe).
+- [ ] 2.2 Implement the receiver route + ACL translation into `RecordExternalValidationFailed` through the existing command handler; config-dormant registration (`VERDICT_WEBHOOK_SECRET`); failing inject tests first (signed-revives, unsigned-rejected, redelivery-converges).
+
+## 3. Composition + fidelity
+
+- [ ] 3.1 Config schema + wiring; startup log line stating whether the receiver is active.
+- [ ] 3.2 In-process e2e: fulfil an acquisition with two ranked candidates, deliver a signed rejection verdict, assert the second candidate downloads and the acquisition re-fulfils; assert a duplicate delivery changes nothing.
+- [ ] 3.3 `pnpm check` green; update `openspec/specs` deltas on archive; doc comments for the defeasible-Fulfilled model in `state.ts`/`decide.ts`.


### PR DESCRIPTION
Two OpenSpec proposals (docs only — no code) preparing music-downloader's side of the [music-importer](https://github.com/jgchk/music-importer) integration. Design settled in an extended exploration incl. research passes on beets internals and EDA contract-ownership literature.

## 1. `acquisition-outbound-events`

Publish producer-owned `acquisition.fulfilled` events over Standard Webhooks to configured subscribers:
- The event store **is** the transactional outbox — the publisher is one more checkpointed consumer (reactor-shaped), at-least-once, per-subscriber isolation, ordered.
- Fat, self-contained payloads in this tool's own language (acquisition id, target + MB release id, candidate identity, deposited location + files); consumers translate at their own ACLs.
- Additive-only contract mechanized in CI (zod → generated JSON Schema diff gate) + permanently-frozen payload fixtures.
- Config-dormant: no subscribers configured → identical behavior to today.

## 2. `fulfillment-external-verdict`

Fulfilled becomes **stable-but-defeasible**: a late external validation failure (e.g. a downstream import verdict: "this claims to be the release but a track is a corrupt stub") rejects the delivered candidate and revives the **existing** bounded retry ladder — next-best candidate, re-search, or exhaust — spending the same budgets, so convergence is preserved and all other terminal states stay absorbing.
- Native language only: `RecordExternalValidationFailed` → `FulfillmentRejected`; "import" never enters the domain.
- Stale-guarded (Fulfilled retains the judged candidate's identity), idempotent, no ACK/sealing flow.
- Received over a signed, tolerant-reader, config-dormant webhook endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)