### PR TITLE
fix(mcp): flatten submit_acquisition input schema for tool-use compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 coverage/
 .e2e-tmp/
+.playwright-mcp/
 *.log
 *.sqlite
 *.sqlite-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [2.4.2](https://github.com/jgchk/music-downloader/compare/v2.4.1...v2.4.2) (2026-07-20)
+
+
+### Bug Fixes
+
+* **mcp:** flatten submit_acquisition input schema for tool-use compatibility ([fba2f37](https://github.com/jgchk/music-downloader/commit/fba2f3746b48ccaf8662dd723374d852de7fdf8d))
+
 ## [2.4.1](https://github.com/jgchk/music-downloader/compare/v2.4.0...v2.4.1) (2026-07-19)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": true,
   "description": "An extensible, event-sourced music downloader.",
   "type": "module",

--- a/src/interfaces/mcp/server.test.ts
+++ b/src/interfaces/mcp/server.test.ts
@@ -19,6 +19,20 @@ interface CallToolResult {
   content: { type: string; text: string }[];
 }
 
+/** Recursively assert a JSON Schema contains no union keyword (unusable by Anthropic tool-use). */
+function assertNoUnionKeywords(schema: unknown): void {
+  if (Array.isArray(schema)) {
+    schema.forEach(assertNoUnionKeywords);
+    return;
+  }
+  if (schema === null || typeof schema !== 'object') return;
+  const record = schema as Record<string, unknown>;
+  for (const keyword of ['oneOf', 'anyOf', 'allOf']) {
+    expect(record[keyword], `schema must not contain ${keyword}`).toBeUndefined();
+  }
+  Object.values(record).forEach(assertNoUnionKeywords);
+}
+
 /** Parse the first (text) content of a resource read, sidestepping the text|blob content union. */
 function firstJson(res: { contents: unknown[] }): unknown {
   return JSON.parse((res.contents[0] as { text: string }).text);
@@ -61,7 +75,30 @@ describe('MCP server', () => {
     expect(submit?.inputSchema).toMatchObject({ type: 'object' });
   });
 
-  it('submits an acquisition and returns its id', async () => {
+  it('advertises submit_acquisition with a flat, union-free request schema', async () => {
+    const { tools } = await client.listTools();
+    const submit = tools.find((t) => t.name === 'submit_acquisition');
+    const schema = submit!.inputSchema as {
+      type: string;
+      properties: { request: { type: string; properties: Record<string, unknown> } };
+    };
+
+    // No oneOf/anyOf/allOf anywhere — Anthropic tool-use cannot consume unions.
+    assertNoUnionKeywords(schema);
+    // A flat top-level object whose `request` is itself a flat object with the discriminator field.
+    expect(schema.type).toBe('object');
+    expect(schema.properties.request.type).toBe('object');
+    expect(Object.keys(schema.properties.request.properties).sort()).toEqual([
+      'album',
+      'artist',
+      'kind',
+      'mbid',
+      'targetType',
+      'title',
+    ]);
+  });
+
+  it('submits a descriptor acquisition and returns its id', async () => {
     const result = (await client.callTool({
       name: 'submit_acquisition',
       arguments: descriptorArgs,
@@ -71,14 +108,68 @@ describe('MCP server', () => {
     expect(JSON.parse(result.content[0]!.text)).toEqual({ acquisitionId: 'acq-1' });
   });
 
-  it('reports invalid submit arguments as a tool error', async () => {
+  it('submits a descriptor acquisition carrying an optional album', async () => {
     const result = (await client.callTool({
       name: 'submit_acquisition',
-      arguments: { request: { kind: 'nope' } },
+      arguments: {
+        request: { kind: 'descriptor', targetType: 'track', artist: 'A', title: 'T', album: 'Alb' },
+      },
+    })) as CallToolResult;
+
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(result.content[0]!.text)).toEqual({ acquisitionId: 'acq-1' });
+  });
+
+  it('submits a musicbrainz acquisition and returns its id', async () => {
+    const result = (await client.callTool({
+      name: 'submit_acquisition',
+      arguments: { request: { kind: 'musicbrainz', targetType: 'album', mbid: 'mbid-1' } },
+    })) as CallToolResult;
+
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(result.content[0]!.text)).toEqual({ acquisitionId: 'acq-1' });
+  });
+
+  it('rejects a musicbrainz request missing its mbid with a specific error', async () => {
+    const result = (await client.callTool({
+      name: 'submit_acquisition',
+      arguments: { request: { kind: 'musicbrainz', targetType: 'album' } },
     })) as CallToolResult;
 
     expect(result.isError).toBe(true);
-    expect(result.content[0]!.text).toBe('invalid arguments');
+    expect(result.content[0]!.text).toBe('kind=musicbrainz requires mbid');
+  });
+
+  it('rejects a descriptor request missing artist/title with a specific error', async () => {
+    const result = (await client.callTool({
+      name: 'submit_acquisition',
+      arguments: { request: { kind: 'descriptor', targetType: 'album', title: 'T' } },
+    })) as CallToolResult;
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('kind=descriptor requires artist and title');
+  });
+
+  it('rejects a descriptor request missing only its title with a specific error', async () => {
+    const result = (await client.callTool({
+      name: 'submit_acquisition',
+      arguments: { request: { kind: 'descriptor', targetType: 'album', artist: 'A' } },
+    })) as CallToolResult;
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe('kind=descriptor requires artist and title');
+  });
+
+  it('reports malformed submit arguments as a tool error naming the problem', async () => {
+    const result = (await client.callTool({
+      name: 'submit_acquisition',
+      arguments: { request: { kind: 'nope', targetType: 'album' } },
+    })) as CallToolResult;
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).not.toBe('');
+    // The message names the offending field's allowed values rather than a bare "invalid arguments".
+    expect(result.content[0]!.text).toContain('musicbrainz');
   });
 
   it('reports an inconsistent policy as a tool error', async () => {

--- a/src/interfaces/mcp/server.ts
+++ b/src/interfaces/mcp/server.ts
@@ -26,8 +26,12 @@ import {
   requestToDomain,
   resolvePolicies,
   statusViewToDto,
-  submitAcquisitionRequestSchema,
 } from '../contracts/index.js';
+import {
+  submitAcquisitionToolDescription,
+  submitAcquisitionToolSchema,
+  toSubmitAcquisitionDto,
+} from './tool-schemas.js';
 
 /**
  * The MCP inbound adapter (D12): the same application use-cases, exposed idiomatically. Commands
@@ -78,8 +82,8 @@ export function buildMcpServer(deps: UseCaseDeps, logger: Logger, version: strin
     tools: [
       {
         name: 'submit_acquisition',
-        description: 'Submit an acquisition request; returns the acquisition id.',
-        inputSchema: z.toJSONSchema(submitAcquisitionRequestSchema),
+        description: submitAcquisitionToolDescription,
+        inputSchema: z.toJSONSchema(submitAcquisitionToolSchema),
       },
       {
         name: 'cancel_acquisition',
@@ -92,12 +96,14 @@ export function buildMcpServer(deps: UseCaseDeps, logger: Logger, version: strin
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
     if (name === 'submit_acquisition') {
-      const parsed = submitAcquisitionRequestSchema.safeParse(args);
-      if (!parsed.success) return toolError('invalid arguments');
-      const policies = resolvePolicies(parsed.data);
+      const parsed = submitAcquisitionToolSchema.safeParse(args);
+      if (!parsed.success)
+        return toolError(parsed.error.issues.map((issue) => issue.message).join('; '));
+      const dto = toSubmitAcquisitionDto(parsed.data);
+      const policies = resolvePolicies(dto);
       if (policies.isErr()) return toolError('InvalidPolicy');
       const result = await submitAcquisition(deps, {
-        request: requestToDomain(parsed.data.request),
+        request: requestToDomain(dto.request),
         policies: policies.value,
       });
       return result.match(

--- a/src/interfaces/mcp/tool-schemas.ts
+++ b/src/interfaces/mcp/tool-schemas.ts
@@ -1,0 +1,122 @@
+import { z } from 'zod';
+import {
+  downloadPolicySchema,
+  matchPolicySchema,
+  qualityPolicySchema,
+  retryPolicySchema,
+  targetTypeSchema,
+} from '../contracts/index.js';
+import type { AcquisitionRequestDto, SubmitAcquisitionRequestDto } from '../contracts/index.js';
+
+/**
+ * MCP-local tool schemas (D12). Anthropic tool-use / Claude Desktop cannot consume a JSON-Schema
+ * `oneOf`/`anyOf` union: the field silently degrades to type "any" and the model can no longer form
+ * valid arguments. So while the shared HTTP/OpenAPI contract models the acquisition request as a
+ * discriminated union (which REST clients handle fine), the MCP adapter advertises a *flat* request
+ * object — a `kind` discriminator plus optional per-variant fields — and enforces the
+ * "which fields are required for which kind" rule server-side with a refinement. The emitted JSON
+ * Schema therefore contains no union keyword at all. The flat input is translated back into the
+ * shared request DTO before it reaches the unchanged use-case path, so MCP behaviour is identical to
+ * HTTP for well-formed calls.
+ */
+
+/** Flat, union-free acquisition request for the `submit_acquisition` tool. */
+const flatRequestSchema = z
+  .object({
+    kind: z
+      .enum(['musicbrainz', 'descriptor'])
+      .describe(
+        'Which kind of request. "musicbrainz" identifies a release by MusicBrainz id (needs mbid). "descriptor" identifies it by artist/title text (needs artist and title).',
+      ),
+    targetType: targetTypeSchema.describe('Whether to acquire a full "album" or a single "track".'),
+    mbid: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('MusicBrainz release id. Required when kind="musicbrainz"; ignored otherwise.'),
+    artist: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Artist name. Required when kind="descriptor"; ignored otherwise.'),
+    title: z
+      .string()
+      .min(1)
+      .optional()
+      .describe('Release or track title. Required when kind="descriptor"; ignored otherwise.'),
+    album: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        'Optional album name to disambiguate a descriptor request (e.g. the album a track appears on).',
+      ),
+  })
+  .meta({
+    examples: [
+      { kind: 'descriptor', targetType: 'album', artist: 'Radiohead', title: 'In Rainbows' },
+      { kind: 'musicbrainz', targetType: 'album', mbid: '00000000-0000-0000-0000-000000000000' },
+    ],
+  })
+  .superRefine((request, ctx) => {
+    if (request.kind === 'musicbrainz') {
+      if (request.mbid === undefined) {
+        ctx.addIssue({ code: 'custom', message: 'kind=musicbrainz requires mbid', path: ['mbid'] });
+      }
+      return;
+    }
+    if (request.artist === undefined || request.title === undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'kind=descriptor requires artist and title',
+        path: [request.artist === undefined ? 'artist' : 'title'],
+      });
+    }
+  });
+
+/** Top-level input schema for the `submit_acquisition` tool: a flat request plus optional policies. */
+export const submitAcquisitionToolSchema = z.object({
+  request: flatRequestSchema,
+  qualityPolicy: qualityPolicySchema.optional(),
+  matchPolicy: matchPolicySchema.optional(),
+  retryPolicy: retryPolicySchema.optional(),
+  downloadPolicy: downloadPolicySchema.optional(),
+});
+
+export type SubmitAcquisitionToolInput = z.infer<typeof submitAcquisitionToolSchema>;
+
+/** Prose description advertised for the tool, spelling out the conditional requirements + examples. */
+export const submitAcquisitionToolDescription =
+  'Submit an acquisition request; returns the acquisition id. The `request` object is flat: set `kind` to choose how the release is identified and `targetType` to "album" or "track". ' +
+  'To grab an album by name: kind="descriptor", targetType="album", artist, title (album optional). ' +
+  'To grab it by MusicBrainz release id: kind="musicbrainz", targetType="album", mbid. ' +
+  'Rules enforced server-side: kind="musicbrainz" requires mbid; kind="descriptor" requires artist and title.';
+
+/** Translate the flat, refinement-validated request into the shared request DTO. */
+function toRequestDto(request: SubmitAcquisitionToolInput['request']): AcquisitionRequestDto {
+  if (request.kind === 'musicbrainz') {
+    // `mbid` is guaranteed present by the refinement for musicbrainz requests.
+    return { kind: 'musicbrainz', mbid: request.mbid!, targetType: request.targetType };
+  }
+  // `artist`/`title` are guaranteed present by the refinement for descriptor requests.
+  return {
+    kind: 'descriptor',
+    targetType: request.targetType,
+    artist: request.artist!,
+    title: request.title!,
+    ...(request.album !== undefined ? { album: request.album } : {}),
+  };
+}
+
+/** Translate the flat tool input into the shared submit DTO the use-case path already accepts. */
+export function toSubmitAcquisitionDto(
+  input: SubmitAcquisitionToolInput,
+): SubmitAcquisitionRequestDto {
+  return {
+    request: toRequestDto(input.request),
+    qualityPolicy: input.qualityPolicy,
+    matchPolicy: input.matchPolicy,
+    retryPolicy: input.retryPolicy,
+    downloadPolicy: input.downloadPolicy,
+  };
+}


### PR DESCRIPTION
## Problem

The MCP `submit_acquisition` tool advertised its `request` field as a JSON-Schema union (`oneOf` of a musicbrainz variant and a descriptor variant). Anthropic tool-use / Claude Desktop does not support `oneOf` — the field degrades to type "any", the model cannot form valid arguments, and calls fail with "invalid arguments".

## Fix (MCP interface only)

- New MCP-local **flat, union-free** input schema (`src/interfaces/mcp/tool-schemas.ts`): `request` is a single object `{ kind, targetType, mbid?, artist?, title?, album? }` with a `kind` discriminator plus optional per-variant fields. The emitted JSON Schema contains **no `oneOf`/`anyOf`/`allOf`** anywhere (asserted by a test that walks the schema).
- Server-side `superRefine` enforces the conditional requirements:
  - `kind=musicbrainz` ⇒ `mbid` required → error `kind=musicbrainz requires mbid`
  - `kind=descriptor` ⇒ `artist` + `title` required (`album` optional) → error `kind=descriptor requires artist and title`
- The CallTool handler now returns a **specific** error message naming the problem instead of a bare "invalid arguments", then translates the flat input back into the shared request DTO and reuses the **unchanged** `resolvePolicies` + `submitAcquisition` path. Behaviour is identical to today for well-formed calls.
- Tool + per-field descriptions spell out the rules and carry concrete usage examples (and a JSON-Schema `examples` keyword).

## Scope

The shared HTTP/OpenAPI contract, domain, and use-cases are **untouched** — REST clients handle `oneOf` fine and that contract is additive-only/contract-tested. Only the MCP adapter changed.

Also gitignores `.playwright-mcp/` (local tool artifacts).

`pnpm check` fully green (format, lint, typecheck, build, 100% coverage, contract, release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)