### PR TITLE
fix(web): load root .env in dev via kit.env.dir + $env/dynamic/private

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ coverage/
 *.log
 *.sqlite
 *.sqlite-*
+# Event-store SQLite files (module data dirs) — created by local dev/runtime
+*.db
+*.db-*
 .DS_Store
 .env
 .env.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.0.1](https://github.com/jgchk/music-downloader/compare/v3.0.0...v3.0.1) (2026-07-22)
+
+
+### Bug Fixes
+
+* **web:** load root .env in dev via kit.env.dir + $env/dynamic/private ([4fb0ec9](https://github.com/jgchk/music-downloader/commit/4fb0ec9e4ab5124a9b5e838a876d3bb2bcece8d7))
+
 ## [3.0.0](https://github.com/jgchk/music-downloader/compare/v2.5.1...v3.0.0) (2026-07-21)
 
 One product: [music-importer](https://github.com/jgchk/music-importer)'s history and capabilities are merged into this repository as a modular monolith — two bounded-context packages (`packages/downloader`, `packages/importer`) integrating through durable in-process catch-up subscriptions, one SvelteKit web interface, one process, one image. Implements `openspec/changes/merge-modular-monolith`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "description": "An extensible, event-sourced music downloader and importer — a modular monolith.",
   "type": "module",

--- a/packages/web/src/hooks.server.test.ts
+++ b/packages/web/src/hooks.server.test.ts
@@ -3,6 +3,7 @@ import type { RequestEvent, ResolveOptions } from '@sveltejs/kit';
 
 const bootRuntimes = vi.fn(() => Promise.resolve());
 const facadesOf = vi.fn(() => ({ downloader: {}, importer: {} }));
+vi.mock('$env/dynamic/private', () => ({ env: { LIBRARY_ROOT: '/library' } }));
 vi.mock('$lib/server/runtime.js', () => ({
   bootRuntimes: (...args: unknown[]) => bootRuntimes(...(args as [])),
   facadesOf: () => facadesOf(),
@@ -14,6 +15,8 @@ describe('server hooks', () => {
   it('init boots the composed runtimes (awaited before any request is served)', async () => {
     await init();
     expect(bootRuntimes).toHaveBeenCalledOnce();
+    // Boots from SvelteKit's runtime env (which carries `.env` in dev), not an empty process.env.
+    expect(bootRuntimes).toHaveBeenCalledWith({ LIBRARY_ROOT: '/library' });
   });
 
   it('handle injects the facades into locals for every server route', async () => {

--- a/packages/web/src/hooks.server.ts
+++ b/packages/web/src/hooks.server.ts
@@ -1,4 +1,5 @@
 import type { Handle, ServerInit } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
 import { bootRuntimes, facadesOf } from '$lib/server/runtime.js';
 
 /**
@@ -9,7 +10,10 @@ import { bootRuntimes, facadesOf } from '$lib/server/runtime.js';
  * the daemon lives behind $lib/server.
  */
 export const init: ServerInit = async () => {
-  await bootRuntimes();
+  // Boot from SvelteKit's runtime env, not process.env: in dev, vite/SvelteKit loads `.env`
+  // into `$env/dynamic/private` (and NOT into process.env), so the composed config surface is
+  // only visible here. Under adapter-node in production this reflects the real process env.
+  await bootRuntimes(env);
 };
 
 export const handle: Handle = ({ event, resolve }) => {

--- a/packages/web/svelte.config.js
+++ b/packages/web/svelte.config.js
@@ -6,6 +6,11 @@ const config = {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter(),
+    // The product's ONE config surface (`.env`) lives at the monorepo root, but dev/build run
+    // with cwd = packages/web. SvelteKit loads `.env` from `kit.env.dir` (its own knob — NOT
+    // vite's envDir), which defaults to cwd; point it at the root so `$env/dynamic/private`
+    // actually carries the composed config. Without this, every required var reads undefined.
+    env: { dir: '../../' },
   },
 };
 


### PR DESCRIPTION
## Problem

`pnpm dev` failed at boot with every required config var undefined:

```
invalid configuration — LIBRARY_ROOT: ... undefined; STAGING_ROOT: ... undefined;
INTAKE_ROOT: ... undefined; BEETS_CONFIG: ... undefined
```

…even though the repo-root `.env` sets them. Local dev was broken for anyone post-merge.

## Root cause (two compounding issues)

1. **`init` booted from `process.env`.** `hooks.server.ts` called `bootRuntimes()` with the implicit `process.env` default, but vite/SvelteKit dev never populate `process.env` from `.env` — only the `$env/*` modules get it.
2. **SvelteKit uses its own env dir, not vite's.** It loads `.env` via `loadEnv(mode, kit.env.dir, '')` — `kit.env.dir` defaults to cwd (`packages/web`), so the root `.env` (the product's single config surface) was invisible. Vite's `envDir` is a separate, ineffective knob here.

## Fix

- `svelte.config.js` — `kit.env.dir: '../../'` so `.env` loads from the monorepo root.
- `hooks.server.ts` — boot from `$env/dynamic/private` (correct in dev; reflects real process env under adapter-node in prod).
- `hooks.server.test.ts` — mock `$env/dynamic/private` and assert boot receives it.
- `.gitignore` — ignore the module event-store `*.db` files local dev writes under `packages/web/data/` (existing pattern only covered `*.sqlite`).

## Verification

- Ran `pnpm dev` end-to-end: boots **HTTP 200**, both module runtimes up, `beets configuration validated`.
- Gate: prettier ✓, eslint 0 errors ✓, `svelte-check` 0 errors ✓, 140 web tests pass ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)