### PR TITLE
feat(downloader): resolve acquisitions by MusicBrainz release-group id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.1.0](https://github.com/jgchk/music-downloader/compare/v3.0.1...v3.1.0) (2026-07-22)
+
+
+### Features
+
+* **downloader:** resolve acquisitions by MusicBrainz release-group id ([ed78b7f](https://github.com/jgchk/music-downloader/commit/ed78b7fb17bae016ad01e09250b9094b151c0d3e))
+
 ## [3.0.1](https://github.com/jgchk/music-downloader/compare/v3.0.0...v3.0.1) (2026-07-22)
 
 

--- a/openspec/changes/archive/2026-07-22-request-by-release-group-id/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-22-request-by-release-group-id/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/archive/2026-07-22-request-by-release-group-id/design.md
+++ b/openspec/changes/archive/2026-07-22-request-by-release-group-id/design.md
@@ -1,0 +1,77 @@
+## Context
+
+Metadata resolution turns a request into a canonical `Target` before any search or download. A `Target` (`domain/target/target.ts`) is invalid without a non-empty track manifest — track count and per-track durations are what `download-validation` checks against. A MusicBrainz **release group** is an abstract album identity with no track list; only its member **releases** (editions) carry tracks. So every resolution path ultimately fetches a concrete release: the descriptor path (`resolveReleaseByDescriptor`) searches, groups hits by release group, disambiguates to one group, orders that group's editions via `compareReleases`, and fetches releases until one yields a valid target; the direct path (`resolveReleaseById`) fetches one named release.
+
+There is no way to name a release group directly, even though it is the most precise "this album, any edition" identifier. This change adds that path. Because identity is *given* (the group id), the search / grouping / cross-group ambiguity guard are unnecessary — the work reduces to edition selection within a known group, which the codebase already does; the open questions are which edition is "representative" and what to do when none is confident.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Accept a MusicBrainz release-group MBID as a request and resolve it to a canonical target, additively (existing request kinds unchanged).
+- Pick a representative edition with a heuristic validated against real data, minimizing `WrongTrackCount` validation failures downstream.
+- Fail cleanly (unresolved) — never silently pick a bootleg — when no official edition exists.
+- Fix the partial-date edition-ordering defect that already degrades the live descriptor path.
+
+**Non-Goals:**
+- Recording/track-level release-group semantics (release groups are album identities; the track path is untouched).
+- Human-in-the-loop manual edition selection — deferred to the `manual-edition-selection` follow-up change, which upgrades the "no official edition" dead-end (D3) into a user choice. This change keeps the resolution outcome binary (`resolved | unresolved`).
+- Changing MusicBrainz as the metadata source or the `Target` shape.
+- A popularity/listen-count signal for "canonical edition" (MusicBrainz exposes none; modal track count is the proxy).
+
+## Decisions
+
+### D1 — A third `AcquisitionRequest` kind, resolved by a new adapter branch
+
+Add `{ kind: 'release-group'; mbid: string; targetType: 'album' }` to the `AcquisitionRequest` union. `targetType` is `'album'` only — a release group has no track analogue. `doResolve` gains a branch that calls a new `resolveReleaseByReleaseGroup(mbid)`, which fetches the group's editions via `GET /release?release-group={mbid}&inc=media+recordings&fmt=json&limit=100`, selects an edition, and reuses `resolveReleaseById` to fetch the full target. Reusing `resolveReleaseById` keeps a single code path for "release id → target" and its skip-on-unusable-data fall-through.
+
+**Alternative considered:** overload the existing `musicbrainz` kind and probe whether the MBID is a release or a group. Rejected — MBIDs are not type-tagged, so it would require an extra classifying request and make the caller's intent implicit. An explicit kind is clearer and cheaper.
+
+### D2 — Edition selection: modal track count, then Official, then earliest date; no title tier
+
+For this path, select among the group's **official** editions (a release-group request wants a canonical, official target; non-official-only groups are handled by D3):
+1. **Restrict to official editions.** If none exist, D3 applies.
+2. **Filter to the modal track count** — the total track count (sum of `media[].track-count`) held by the most *official* editions in the group. Computing the mode over official editions (rather than all editions) keeps the winner official by construction and avoids a modal count that no official edition has; for the simulation's mainstream albums the official mode equals the overall mode, so the validated 9/9 result is unaffected.
+3. Among those, earliest release date (see D4).
+4. Stable order as the final deterministic tiebreak.
+
+The exact-title tier of `compareReleases` is dropped: a bare group id carries no edition-title intent, so there is nothing to match against.
+
+Rationale is empirical. A simulation over 9 divergent-edition albums (real MusicBrainz data; script + raw JSON retained) compared candidates:
+- Plain "Official → earliest date": picked the modal-track-count edition in **7/9**, failing exactly the albums the picker must get right — *1989* (chose the 19-track deluxe over the 13-track standard) and *good kid, m.A.A.d city* (chose a 15-track vinyl over the 12-track standard).
+- Modal-track-count constraint added: **9/9**.
+
+The standard edition is pressed across the most regions/formats, so it dominates both the modal track count among MB editions and what users can actually find; matching it is the best available predictor of validation success.
+
+**Alternatives considered:** format preference (CD/Digital) — noisier and regionally biased; country preference (US/XW) — many canonical editions are `XE`/`XW`/regional, and it does not address track-count divergence; average track count — meaningless (fractional), not a real edition.
+
+### D3 — No official edition → unresolved (manual selection deferred)
+
+A release-group request whose group has **no official edition** resolves to `unresolved` (a clean metadata-resolution failure visible to the caller), rather than silently selecting a bootleg/promo. This matches the existing fail-safe philosophy (ambiguity / no-confident-match → unresolved) and keeps this change's resolution outcome binary. An empty group — no releases at all — is likewise `unresolved`, consistent with the direct path's 404 handling.
+
+**Follow-up:** the product intent is a human-in-the-loop choice here, captured in the `manual-edition-selection` change. It upgrades this dead-end to a `needsSelection` outcome carrying the candidate editions, an `AwaitingManualSelection` aggregate state, and a `SelectEdition` command whose resume reuses the direct-by-release-id path. That work is deliberately separated so this change stays a focused, reviewable slice with no new domain state.
+
+**Alternatives considered:** fall back to any edition regardless of status — rejected, risks silently downloading a bootleg the caller did not ask for.
+
+### D4 — Chronological partial-date ordering (fixes a live defect)
+
+`dateKey` currently returns the raw MusicBrainz date string, so lexical comparison ranks a year-only `2012` before a same-year `2012-10-22`. Replace it with a comparison over normalized `(year, month, day)` components where missing components sort **after** specified ones within the same year — i.e. a fully-specified date is treated as earlier/more canonical than a vague year-only date for the same year. This removes the "imprecision wins" bias and is applied to `compareReleases` for **both** the descriptor path and the new release-group path. This also hardens D2: even before the modal filter, date ordering no longer favors the odd year-only vinyl/deluxe pressings that caused two of the simulation misses.
+
+### D5 — A tolerant browse schema for release-group editions
+
+The by-release-group fetch (`GET /release?release-group={mbid}&inc=media`) returns a `releases` array with each edition's `id`, `title`, `status`, `date`, and `media[].track-count`. This is a new consumer-contract schema (distinct from the scored search schema — a browse has no `score`). All fields are optional so provider drift or a sparse edition never throws; an edition missing a track count is treated as track count 0 for modal computation and simply won't win. Contract-schema violations still surface as `InfraError` at the boundary, never as malformed data reaching the pure selection logic. (The `country` and `media[].format` fields needed only to *present* candidates are added by the `manual-edition-selection` follow-up, not here.)
+
+## Risks / Trade-offs
+
+- **Modal-across-MB-editions ≠ modal-across-what-people-share.** For an album whose deluxe is the culturally definitive version, the mode still picks the standard edition. → Acceptable: a bare group id expresses no edition preference, and the standard edition is the safe default (its track list is the common subset). A future explicit-edition request and the `manual-edition-selection` follow-up remain the escape hatches.
+- **Modal-count tie** (two track counts equally common). → Deterministic break specified in the spec (prefer the lower track count — the more conservative, standard-like edition — then earliest date, then stable order). No sample album hit this, so it is defined, not observed.
+- **No-official-edition groups fail silently to the caller** (this change resolves them to `unresolved`). → Accepted as an interim behavior; the `manual-edition-selection` follow-up turns it into a surfaced human choice. Never auto-commits to a bootleg in the meantime.
+- **Partial-date semantics are a judgment call** (is year-only "earliest" or "latest" in its year?). → We choose "more-precisely-dated wins within a year," which fixes the observed misses and is defensible as preferring the better-catalogued release; documented in the spec so it is intentional, not incidental.
+
+## Migration Plan
+
+Additive and backward-compatible — no data migration. The new request kind appends to the `AcquisitionRequest` union; historical events replay unchanged (tolerant reader), and the resolution outcome stays `resolved | unresolved`. Ship behind the normal release flow. Rollback is a plain revert: no persisted event depends on the new kind unless a caller uses it.
+
+## Open Questions
+
+- Does the release-group request kind warrant exposure on the **MCP tool** surface immediately, or HTTP/UI first? (Contract is additive either way.)
+- Confirm the exact MusicBrainz browse parameters (`inc=media`, `limit=100`, paging) return `media[].track-count` for all editions without `inc=recordings`, so the picker needs only one lightweight browse per request before the full by-id fetch.

--- a/openspec/changes/archive/2026-07-22-request-by-release-group-id/proposal.md
+++ b/openspec/changes/archive/2026-07-22-request-by-release-group-id/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Callers can name an album two ways today — a specific MusicBrainz **release** (edition) MBID, or a free-text descriptor that the system searches and disambiguates. But the most natural identifier for "this album, whichever edition" is the MusicBrainz **release-group** MBID, and it is currently unsupported: a release group has no track list, so it cannot become a target directly, and there is no path that turns a bare group id into a canonical edition. This forces callers to pre-resolve an edition themselves or fall back to fuzzy descriptor search for an album whose identity they already know exactly.
+
+## What Changes
+
+- Add a third `AcquisitionRequest` kind — a MusicBrainz **release-group** id — alongside the existing release-MBID and descriptor kinds. Additive to the public request contract; existing kinds are unchanged.
+- Resolve a release-group request by fetching the group's editions and selecting a representative **official** one, then producing the canonical target from that edition (reusing the existing by-release-id fetch). Identity is given, so the search / release-group grouping / ambiguity guard of the descriptor path are skipped.
+- Define the edition-selection heuristic for this path:
+  - **Drop the exact-title tier** — a bare group id carries no edition-title intent to honor.
+  - **Constrain to the modal track count first**: among the group's official editions, restrict to those whose total track count equals the most-common (modal) track count, then pick the earliest-dated one (stable order as the final tiebreak). A data-backed simulation over 9 divergent-edition albums showed plain "official → earliest date" picks the standard edition in only 7/9 (missing e.g. Taylor Swift *1989* and Kendrick *good kid, m.A.A.d city*), while the modal-track-count constraint scored 9/9. Modal track count is a proxy for the canonical edition and for what files are commonly findable, minimizing `WrongTrackCount` validation failures.
+  - Define a deterministic break when two track counts tie for the mode (prefer the lower count).
+- When the release group has **no official edition**, resolve to a clean metadata-resolution failure (`unresolved`), consistent with how other no-confident-match cases fail today — rather than silently selecting a bootleg/promo. (A follow-up change, `manual-edition-selection`, upgrades this dead-end to a human-in-the-loop edition choice.)
+- Fix a pre-existing edition-ordering defect that also affects the **live descriptor path**: partial MusicBrainz dates are compared lexically, so a year-only `2012` sorts before a same-year, fully-specified `2012-10-22`, rewarding imprecise dates. Order by true chronology with a defined precision policy instead.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this extends an existing capability)_
+
+### Modified Capabilities
+
+- `metadata-resolution`: add the release-group-id request kind and its edition-selection heuristic (modal-track-count constraint over official editions, no title tier); correct partial-date edition ordering; specify that a release group with no official edition fails cleanly as unresolved.
+
+## Impact
+
+- **Public contract** (`external-api-contracts`, additive): a new request kind on the acquisition-request API. No existing shape changes; contract tests extended, not broken.
+- **Downloader domain**: `AcquisitionRequest` union gains the release-group kind. Domain stays pure; no new events/commands/state (resolution outcome remains `resolved | unresolved`).
+- **MusicBrainz adapter**: new by-release-group resolution branch in `doResolve`; a new edition picker in the mapping layer (modal-track-count over official editions, chronological date ordering); a consumer schema for the release-group browse (media/track-count, status, date). Boundary faults still surface as `InfraError`.
+- **Tests**: test-first across domain, adapter, contract, and the metadata-resolution spec scenarios; 100% coverage preserved.

--- a/openspec/changes/archive/2026-07-22-request-by-release-group-id/specs/metadata-resolution/spec.md
+++ b/openspec/changes/archive/2026-07-22-request-by-release-group-id/specs/metadata-resolution/spec.md
@@ -1,10 +1,4 @@
-# metadata-resolution Specification
-
-## Purpose
-
-Define how a musical request is resolved into a canonical, source-agnostic target via a metadata source, and how unresolvable or ambiguous requests fail cleanly before any search begins.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: A request resolves to a canonical target
 
@@ -65,6 +59,8 @@ The system SHALL resolve a musical request into a canonical target — carrying 
 - **WHEN** edition selection orders them by earliest release date
 - **THEN** the fully-specified edition sorts before the year-only edition
 
+## ADDED Requirements
+
 ### Requirement: A release-group request resolves to a representative edition
 
 The system SHALL accept a request that names a MusicBrainz release group by identifier and resolve it into a canonical target by selecting one representative **official** edition (release) within that group, without searching or judging cross-group ambiguity (the identity is given). Because a bare release-group identifier expresses no edition-title intent, edition selection SHALL NOT apply the request-title precedence used by the descriptor path. The system SHALL select the edition from among the group's official editions as follows: restrict to those whose total track count equals the modal (most common) track count of the official editions; among those, earliest release date (compared chronologically as in the canonical-target requirement); and break any remaining tie deterministically by stable order. When two track counts are equally common (a modal tie), the system SHALL restrict to the lower track count before applying the remaining criteria. A selected edition that cannot yield a valid target SHALL be skipped in favor of the next edition in selection order.
@@ -104,33 +100,3 @@ The system SHALL, when a release-group request resolves to a group that contains
 - **WHEN** the request is resolved
 - **THEN** the acquisition terminates with a metadata-resolution failure
 - **AND** the system does not produce a target from any of the non-official editions
-
-### Requirement: Unresolvable requests fail cleanly
-
-The system SHALL, when a request cannot be resolved to a confident match, terminate the acquisition with a metadata-resolution failure that is visible to the caller, rather than proceeding to search. For album requests without an identifier, ambiguity SHALL be judged at the identity (release group) level: multiple high-scoring editions of one release group are not ambiguity, and comparably-scored sibling groups are not ambiguity when exactly one group's title equals the request title after normalization; comparably-scored groups from different release groups SHALL be ambiguous when none — or more than one — of them bears the requested title.
-
-#### Scenario: No match found
-
-- **GIVEN** a request for which the metadata source returns no candidates
-- **WHEN** the request is resolved
-- **THEN** the acquisition terminates with a metadata-resolution failure
-
-#### Scenario: Distinct albums genuinely sharing a title fail safe
-
-- **GIVEN** a request whose title equals, after normalization, the titles of two or more comparably high-scoring release groups
-- **WHEN** the request is resolved
-- **THEN** the acquisition terminates with a metadata-resolution failure rather than guessing between them
-
-#### Scenario: No titled match and close scores remain ambiguous
-
-- **GIVEN** a request whose title equals no high-confidence release group's title after normalization, and whose top two groups score within the ambiguity margin
-- **WHEN** the request is resolved
-- **THEN** the acquisition terminates with a metadata-resolution failure
-
-### Requirement: The target model is source-agnostic
-The system SHALL express the resolved target in a normalized model that does not depend on metadata-source-specific fields, so that additional metadata sources can be added without changing downstream matching.
-
-#### Scenario: Downstream matching consumes the normalized target
-- **GIVEN** a target produced by the MusicBrainz source
-- **WHEN** matching scores a candidate against it
-- **THEN** matching reads only normalized target fields, not source-specific ones

--- a/openspec/changes/archive/2026-07-22-request-by-release-group-id/tasks.md
+++ b/openspec/changes/archive/2026-07-22-request-by-release-group-id/tasks.md
@@ -1,0 +1,26 @@
+## 1. Edition selection & date ordering (pure, MusicBrainz mapping)
+
+- [x] 1.1 Write failing unit tests for chronological partial-date ordering in `dateKey`/`compareReleases`: a fully-specified date sorts before a year-only date of the same year; year/month/day compared as components, not lexically.
+- [x] 1.2 Replace `dateKey`'s raw-string key with a component-based (year, month, day) comparison where missing components sort after specified ones within the same year; keep it pure. Confirm 1.1 and existing `compareReleases` tests pass.
+- [x] 1.3 Write failing unit tests for the release-group edition picker: select among **official** editions only; filter to the modal (most common) official track count; then earliest date (chronological); stable order as final tiebreak; modal-tie breaks to the lower track count; no title tier. Cover the simulation cases (standard vs deluxe/vinyl divergence).
+- [x] 1.4 Write failing unit tests for the empty/no-official cases: a group with no official edition, and an empty group, both yield no candidate ids.
+- [x] 1.5 Implement the release-group edition picker in `mapping.ts` (a pure function returning ordered release ids for a group's editions, taking `{ id, status?, date?, trackCount }`). Keep title-tier logic out of this path. Confirm 1.3–1.4 pass.
+
+## 2. MusicBrainz adapter — release-group resolution branch
+
+- [x] 2.1 Add a tolerant browse schema (`schemas.ts`) for `GET /release?release-group={mbid}&inc=media`: `releases[]` with optional `id`, `title`, `status`, `date`, `media[].track-count`. Write failing schema tests including sparse/missing fields.
+- [x] 2.2 Write a failing adapter test (HttpClient stub) for `resolveReleaseByReleaseGroup`: fetches the browse URL, computes the pick via the picker, and reuses `resolveReleaseById` to produce the target; 404 / empty group / no-official-edition → unresolved; first pick with unusable data falls through to the next.
+- [x] 2.3 Implement `resolveReleaseByReleaseGroup` and the `kind === 'release-group'` branch in `doResolve`; map browse editions to the picker's input and route the picked edition through `resolveReleaseById`.
+
+## 3. Downloader domain & request plumbing
+
+- [x] 3.1 Write a failing domain test adding `{ kind: 'release-group'; mbid; targetType: 'album' }` to `AcquisitionRequest` and asserting it round-trips on `AcquisitionRequested` and drives a `ResolveMetadata` effect.
+- [x] 3.2 Add the release-group request kind to `AcquisitionRequest` (`events.ts`); resolve any exhaustiveness breaks the new member surfaces.
+- [x] 3.3 Plumb the new kind through the request-entry contract (edge request schema / facade / HTTP / MCP) additively so a caller can submit a release-group id; write failing contract/schema tests first. No existing request shape changes.
+
+## 4. Contract tests, spec scenarios, and the gate
+
+- [x] 4.1 Extend the MusicBrainz contract tier (fixtures + contract test) to cover the release-group browse endpoint.
+- [x] 4.2 Ensure every scenario in the `metadata-resolution` delta is covered by a test (map scenario → test).
+- [x] 4.3 Run `pnpm check` (format, lint, typecheck, build, test w/ 100% coverage) and `openspec validate request-by-release-group-id --strict`; fix any gaps.
+- [x] 4.4 Manually verify against a real release-group MBID (an album with a clear standard/deluxe split resolves to the standard edition; a group with no official edition resolves as unresolved).

--- a/openspec/changes/manual-edition-selection/.openspec.yaml
+++ b/openspec/changes/manual-edition-selection/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/manual-edition-selection/design.md
+++ b/openspec/changes/manual-edition-selection/design.md
@@ -1,0 +1,33 @@
+## Context
+
+Builds on `request-by-release-group-id`, which added the release-group request kind, the modal-track-count edition picker, and the adapter branch, and which resolves a group with no official edition to `unresolved`. This change turns that dead-end into a human-in-the-loop pause, mirroring the importer's review-queue model for uncertain matches. The edition picker and candidate metadata (id, title, date, country, format, track count) already exist from the prerequisite change; what is new is a resolution outcome that carries candidates, an aggregate state that waits, and a UI to choose.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace the "no official edition → unresolved" dead-end with a pause that presents the group's editions for manual choice.
+- Resume cleanly on a user's edition choice, reusing the existing direct-by-release-id resolution.
+
+**Non-Goals:**
+- Manual selection when an official edition exists (the picker auto-resolves) or as an override of a successful auto-pick.
+- Any change to the picker heuristic or the release-group request kind (owned by the prerequisite change).
+
+## Decisions
+
+### D1 — A third resolution outcome carrying candidate editions
+
+`MetadataResolution` gains `{ kind: 'needsSelection'; candidates: readonly EditionCandidate[] }` (additive union). `EditionCandidate` is a lightweight presentation value (release MBID, title, date, country, format, track count) — not a `Target`, since presenting an edition needs no track manifest. The MusicBrainz adapter maps the picker's non-official candidate editions to this shape.
+
+### D2 — An `AwaitingManualSelection` aggregate state; resume reuses the direct path
+
+The interpreter maps `needsSelection` to a command → `ManualSelectionRequested { candidates }` event; the aggregate folds into `AwaitingManualSelection`, retaining candidates and emitting no search/download effects. A user-initiated `SelectEdition { releaseMbid }` command, valid only in that state, resolves the chosen release id via the existing `resolveReleaseById` path → `TargetResolved` → normal flow. This is the key simplification: manual selection adds a pause/candidate-carrying state but no new "release id → target" logic. Cancellation follows the existing cancel path.
+
+### D3 — UI and command surface
+
+A pending-selection read model exposes awaiting-selection acquisitions and their candidates; a `SelectEdition` command endpoint (HTTP/MCP) accepts `{ acquisitionId, releaseMbid }` and returns the modeled rejection for stale/unknown selections; a SvelteKit surface lists candidates and submits the choice.
+
+## Risks / Trade-offs
+
+- **Scope: new aggregate state + UI + endpoint.** → Mitigated by reusing the direct-release path for resume; the new surface is a pause state and a candidate read model.
+- **Unbounded wait** — an acquisition may sit awaiting selection indefinitely. → Match the importer review-queue's human-paced model (no timeout) initially; revisit if operationally needed.
+- **Many bootleg candidates** — a group could present dozens of editions. → Order candidates by the prerequisite change's picker heuristic; present all.

--- a/openspec/changes/manual-edition-selection/proposal.md
+++ b/openspec/changes/manual-edition-selection/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The `request-by-release-group-id` change resolves a release-group request to a representative **official** edition, and when a group has **no official edition** it fails cleanly as unresolved. That is safe but lossy: the group's editions (bootleg/promo/etc.) are real, and the user asked for that album. Rather than guess or give up, we should let a human pick the edition — the same human-in-the-loop model the importer already uses for uncertain matches.
+
+## What Changes
+
+- When a release-group request resolves to a group with editions but **no official edition**, metadata resolution yields a new **needs-selection** outcome carrying the candidate editions instead of failing as unresolved.
+- The acquisition **pauses** in a new `AwaitingManualSelection` state, retaining the candidate editions and performing no search/download/import.
+- A new `SelectEdition` command (valid only while awaiting selection) resumes the acquisition by resolving the chosen release id — reusing the existing direct-by-release-id path — to the target, then continuing the normal flow.
+- The web UI surfaces awaiting-selection acquisitions, presents each candidate edition (title, date, country, format, track count), and lets the user choose one.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `metadata-resolution`: change the release-group "no official edition" outcome from an unresolved failure to a needs-selection outcome carrying the candidate editions.
+- `acquisition-lifecycle`: add the awaiting-manual-selection pause/resume state and the select-edition command.
+- `web-ui`: surface awaiting-selection acquisitions and the edition-choice action.
+
+## Impact
+
+- **Depends on** `request-by-release-group-id` (the release-group request kind, the edition picker, and the release-group adapter branch must exist first).
+- **Downloader domain**: new event/command/state; `MetadataResolution` gains a `needsSelection` variant carrying `EditionCandidate` values; adapter maps the picker's candidate editions.
+- **Interfaces/UI**: a pending-selection read model, a select-edition command endpoint (HTTP/MCP), and a SvelteKit selection surface.
+- Additive to the public contract; contract tests extended, not broken.

--- a/openspec/changes/manual-edition-selection/specs/acquisition-lifecycle/spec.md
+++ b/openspec/changes/manual-edition-selection/specs/acquisition-lifecycle/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: An acquisition awaiting edition selection pauses until a choice is made
+
+The system SHALL, when metadata resolution yields a manual-selection outcome (a release-group request whose group has no official edition), pause the acquisition in an awaiting-selection state that retains the candidate editions, rather than searching or failing. While awaiting selection the acquisition SHALL perform no search, download, or import. The system SHALL resume the acquisition only on an explicit edition selection or a cancellation. On selection of a candidate edition, the system SHALL resolve that edition into the canonical target — identical to resolving the chosen release by its identifier — and continue the normal acquisition flow. Selection SHALL be accepted only while the acquisition is awaiting selection; a selection naming an edition that is not among the retained candidates, or arriving in any other state, SHALL be rejected as a modeled error without altering the acquisition.
+
+#### Scenario: A group with no official edition pauses for selection
+
+- **GIVEN** an acquisition whose release-group request resolves to a group with candidate editions but no official edition
+- **WHEN** metadata resolution completes
+- **THEN** the acquisition enters the awaiting-selection state retaining the candidate editions
+- **AND** no search, download, or import is performed while it waits
+
+#### Scenario: Selecting an edition resumes the acquisition
+
+- **GIVEN** an acquisition awaiting edition selection
+- **WHEN** a caller selects one of the retained candidate editions
+- **THEN** the system resolves that edition into the canonical target and the acquisition proceeds to search as if the target had been resolved directly
+
+#### Scenario: An unknown or out-of-state selection is rejected
+
+- **GIVEN** an acquisition that is awaiting edition selection
+- **WHEN** a selection names an edition that is not among the retained candidates
+- **THEN** the system rejects the selection as a modeled error and the acquisition remains awaiting selection
+- **AND** a selection submitted for an acquisition that is not awaiting selection is likewise rejected without effect
+
+#### Scenario: Cancelling while awaiting selection ends the acquisition
+
+- **GIVEN** an acquisition awaiting edition selection
+- **WHEN** the acquisition is cancelled
+- **THEN** the acquisition terminates through the normal cancellation path without selecting an edition

--- a/openspec/changes/manual-edition-selection/specs/metadata-resolution/spec.md
+++ b/openspec/changes/manual-edition-selection/specs/metadata-resolution/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: A release group with no official edition requests manual selection
+
+The system SHALL, when a release-group request resolves to a group that contains at least one edition but no official edition, neither silently select a non-official edition nor fail the resolution; instead it SHALL yield a manual-selection outcome carrying the group's candidate editions — each presenting the release identifier, title, release date, country, format, and track count — so that a human can choose the edition to acquire. Selecting a candidate edition SHALL resolve to a canonical target for exactly that release, identical to resolving that release by its identifier. This supersedes the prior behavior in which a release group with no official edition failed cleanly as an unresolved metadata-resolution failure.
+
+#### Scenario: No official edition surfaces the editions for manual choice
+
+- **GIVEN** a request naming a release group whose editions are all non-official (e.g. bootleg or promotional)
+- **WHEN** the request is resolved
+- **THEN** the system yields a manual-selection outcome listing the group's candidate editions with their identifying metadata
+- **AND** it does not produce a target and does not terminate with a metadata-resolution failure
+
+#### Scenario: Choosing a candidate edition resolves it
+
+- **GIVEN** a manual-selection outcome listing candidate editions for a release group
+- **WHEN** a caller selects one candidate edition by its release identifier
+- **THEN** the system produces a canonical target for exactly that release

--- a/openspec/changes/manual-edition-selection/specs/web-ui/spec.md
+++ b/openspec/changes/manual-edition-selection/specs/web-ui/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Manual edition selection for release-group requests
+
+The web UI SHALL surface acquisitions that are awaiting manual edition selection, presenting each candidate edition with its identifying metadata — title, release date, country, format, and track count — so a user can distinguish the editions. The UI SHALL let the user select one candidate edition, which resumes the acquisition with that edition as the resolved target. A selection that the system rejects (e.g. the acquisition is no longer awaiting selection) SHALL render as the modeled error, not a crash or a silent no-op. The UI SHALL accept the release-group identifier as a request kind when submitting an acquisition.
+
+#### Scenario: Awaiting-selection acquisition lists its candidate editions
+
+- **GIVEN** an acquisition awaiting manual edition selection
+- **WHEN** the user views it
+- **THEN** the UI lists the candidate editions, each showing title, release date, country, format, and track count
+
+#### Scenario: Selecting an edition resumes the acquisition
+
+- **GIVEN** an acquisition awaiting manual edition selection is shown with its candidate editions
+- **WHEN** the user selects one edition
+- **THEN** the UI submits that selection and the acquisition proceeds with the chosen edition as its target
+
+#### Scenario: A stale selection renders the modeled error
+
+- **GIVEN** an acquisition that has left the awaiting-selection state
+- **WHEN** the user submits a selection for it
+- **THEN** the UI renders the modeled rejection error rather than crashing or silently ignoring it
+
+#### Scenario: Submitting a request by release-group identifier
+
+- **GIVEN** a user submitting a new acquisition
+- **WHEN** they provide a MusicBrainz release-group identifier as the request
+- **THEN** the UI submits a release-group request that the system resolves by selecting a representative edition

--- a/openspec/changes/manual-edition-selection/tasks.md
+++ b/openspec/changes/manual-edition-selection/tasks.md
@@ -1,0 +1,32 @@
+## 1. Resolution outcome & candidate mapping
+
+- [ ] 1.1 Write failing tests for the `EditionCandidate` value and the additive `{ kind: 'needsSelection'; candidates }` variant of `MetadataResolution`; ensure existing `resolved`/`unresolved` consumers still typecheck.
+- [ ] 1.2 Add `EditionCandidate` (domain value carried on events) and the `needsSelection` variant to the ports/domain.
+- [ ] 1.3 Write a failing adapter test: a release group with no official edition returns `needsSelection` with the candidate editions (id, title, date, country, format, track count); implement the mapping from picker output to `EditionCandidate[]` (replacing the prerequisite change's unresolved behavior).
+- [ ] 1.4 Extend the release-search/browse schema additively with `country` and `media[].format` for candidate presentation; failing schema tests first.
+
+## 2. Aggregate state & commands
+
+- [ ] 2.1 Write failing decide/evolve tests: a `needsSelection` resolution produces `ManualSelectionRequested { candidates }`; state folds to `AwaitingManualSelection` retaining candidates; no search/download effects while awaiting.
+- [ ] 2.2 Add the `ManualSelectionRequested` event, the record command, and the `AwaitingManualSelection` phase in decide/evolve.
+- [ ] 2.3 Write failing tests for `SelectEdition { releaseMbid }`: valid only in `AwaitingManualSelection`; a known candidate resolves that release (reusing the direct path) → `TargetResolved` and normal flow; unknown candidate or wrong-state is a modeled error with no state change.
+- [ ] 2.4 Implement `SelectEdition`, its validation, and the resume effect; wire `react` to continue to search.
+- [ ] 2.5 Write failing tests that cancelling while awaiting selection follows the existing cancel path; adjust decide/evolve.
+
+## 3. Application wiring
+
+- [ ] 3.1 Write a failing interpreter test: `needsSelection` maps to `ManualSelectionRequested`; implement the third-outcome branch in `interpreter.ts`.
+- [ ] 3.2 Write a failing test for the select-edition effect path (resolving the chosen release id) and wire it through the interpreter/command handler.
+
+## 4. Interfaces & UI
+
+- [ ] 4.1 Write a failing test for a read model exposing awaiting-selection acquisitions with their candidate editions; implement it.
+- [ ] 4.2 Write a failing test for the select-edition command on the facade / HTTP surface (and MCP if in scope); implement additively, returning the modeled rejection for stale/unknown selections.
+- [ ] 4.3 Write failing UI tests and implement the awaiting-selection surface (candidate list + choose action, modeled error on stale selection).
+
+## 5. Contract tests & the gate
+
+- [ ] 5.1 Extend contract tests for the additive select-edition command and the `needsSelection` outcome (no breaking change).
+- [ ] 5.2 Ensure every scenario in the `metadata-resolution`, `acquisition-lifecycle`, and `web-ui` deltas is covered by a test.
+- [ ] 5.3 Run `pnpm check` and `openspec validate manual-edition-selection --strict`; fix gaps.
+- [ ] 5.4 Manually verify end-to-end: a release-group MBID with no official edition pauses, and a manual choice resumes to import.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "private": true,
   "description": "An extensible, event-sourced music downloader and importer — a modular monolith.",
   "type": "module",

--- a/packages/downloader/src/adapters/musicbrainz/mapping.test.ts
+++ b/packages/downloader/src/adapters/musicbrainz/mapping.test.ts
@@ -4,8 +4,11 @@ import {
   normalizeTitle,
   recordingToTarget,
   releaseCandidateIds,
+  releaseGroupCandidateIds,
+  releaseGroupEditionIds,
   releaseToTarget,
 } from './mapping.js';
+import type { ReleaseGroupEdition } from './mapping.js';
 import type { MbScoredRelease } from './schemas.js';
 
 describe('releaseToTarget', () => {
@@ -203,6 +206,17 @@ describe('releaseCandidateIds', () => {
 
     // one release group → confident; canonical order is earliest official first
     expect(ids).toEqual(['b', 'a', 'c']);
+  });
+
+  it('sorts a fully-specified date before a year-only date of the same year', () => {
+    const ids = releaseCandidateIds(
+      [hit({ id: 'yearonly', date: '2012' }), hit({ id: 'full', date: '2012-10-22' })],
+      'Album',
+    );
+
+    // a precise date is more canonical than a vague year-only date within the same year,
+    // so imprecision never displaces a precisely-dated edition
+    expect(ids).toEqual(['full', 'yearonly']);
   });
 
   it('is ambiguous when two different release groups score within the margin', () => {
@@ -470,5 +484,139 @@ describe('releaseCandidateIds', () => {
 
   it('skips a hit that carries no id', () => {
     expect(releaseCandidateIds([{ score: 100, title: 'Album' }], 'Album')).toEqual([]);
+  });
+});
+
+describe('releaseGroupEditionIds', () => {
+  const edition = (over: Partial<ReleaseGroupEdition> & { id: string }): ReleaseGroupEdition => ({
+    status: 'Official',
+    date: '2020',
+    trackCount: 12,
+    ...over,
+  });
+
+  it('returns no candidates for an empty group', () => {
+    expect(releaseGroupEditionIds([])).toEqual([]);
+  });
+
+  it('returns no candidates when the group has no official edition', () => {
+    const ids = releaseGroupEditionIds([
+      edition({ id: 'boot', status: 'Bootleg', date: '2001' }),
+      edition({ id: 'promo', status: 'Promotion', date: '2002' }),
+    ]);
+    expect(ids).toEqual([]);
+  });
+
+  it('prefers the modal official track count over a divergent (deluxe) edition', () => {
+    // 13-track standard dominates the official editions; the 19-track deluxe must not win
+    const ids = releaseGroupEditionIds([
+      edition({ id: 'deluxe', trackCount: 19, date: '2014-10-27' }),
+      edition({ id: 'std-a', trackCount: 13, date: '2014-10-27' }),
+      edition({ id: 'std-b', trackCount: 13, date: '2015-03-01' }),
+      edition({ id: 'std-c', trackCount: 13, date: '2016-01-01' }),
+    ]);
+    expect(ids).toEqual(['std-a', 'std-b', 'std-c']);
+  });
+
+  it('prefers a modal edition over an earlier official edition of divergent track count', () => {
+    // the earliest official edition has a non-modal (12) count; the modal (10) editions win
+    const ids = releaseGroupEditionIds([
+      edition({ id: 'earlyodd', trackCount: 12, date: '2000-01-01' }),
+      edition({ id: 'modal-a', trackCount: 10, date: '2005-01-01' }),
+      edition({ id: 'modal-b', trackCount: 10, date: '2006-01-01' }),
+    ]);
+    expect(ids).toEqual(['modal-a', 'modal-b']);
+  });
+
+  it('ignores non-official editions when computing the mode and selecting', () => {
+    // non-official 15-track editions outnumber the official 12-track ones, but only officials count
+    const ids = releaseGroupEditionIds([
+      edition({ id: 'v1', status: 'Bootleg', trackCount: 15, date: '2011' }),
+      edition({ id: 'v2', status: 'Bootleg', trackCount: 15, date: '2012' }),
+      edition({ id: 'v3', status: 'Bootleg', trackCount: 15, date: '2013' }),
+      edition({ id: 'official', status: 'Official', trackCount: 12, date: '2012-05-01' }),
+    ]);
+    expect(ids).toEqual(['official']);
+  });
+
+  it('breaks a modal tie toward the lower track count', () => {
+    // two official counts equally common (12 x2, 14 x2) -> pick the 12-track editions
+    const ids = releaseGroupEditionIds([
+      edition({ id: 'a12', trackCount: 12, date: '2001' }),
+      edition({ id: 'b14', trackCount: 14, date: '2002' }),
+      edition({ id: 'c12', trackCount: 12, date: '2003' }),
+      edition({ id: 'd14', trackCount: 14, date: '2004' }),
+    ]);
+    expect(ids).toEqual(['a12', 'c12']);
+  });
+
+  it('orders modal editions by earliest date, precise before year-only within a year', () => {
+    const ids = releaseGroupEditionIds([
+      edition({ id: 'yearonly', date: '2012' }),
+      edition({ id: 'later', date: '2013-01-01' }),
+      edition({ id: 'full', date: '2012-06-15' }),
+    ]);
+    expect(ids).toEqual(['full', 'yearonly', 'later']);
+  });
+
+  it('keeps stable input order among modal editions with equal dates', () => {
+    const ids = releaseGroupEditionIds([
+      edition({ id: 'first', date: '2000' }),
+      edition({ id: 'second', date: '2000' }),
+    ]);
+    expect(ids).toEqual(['first', 'second']);
+  });
+});
+
+describe('releaseGroupCandidateIds', () => {
+  it('returns no candidates for empty or missing input', () => {
+    expect(releaseGroupCandidateIds(undefined)).toEqual([]);
+    expect(releaseGroupCandidateIds([])).toEqual([]);
+  });
+
+  it('sums each edition media track-counts and picks the modal official edition', () => {
+    const ids = releaseGroupCandidateIds([
+      // deluxe: 8 + 11 = 19 tracks
+      {
+        id: 'deluxe',
+        status: 'Official',
+        date: '2014-10-27',
+        media: [{ 'track-count': 8 }, { 'track-count': 11 }],
+      },
+      // standard editions: 13 tracks each (the mode)
+      { id: 'std-a', status: 'Official', date: '2014-10-27', media: [{ 'track-count': 13 }] },
+      {
+        id: 'std-b',
+        status: 'Official',
+        date: '2015-01-01',
+        media: [{ 'track-count': 6 }, { 'track-count': 7 }],
+      },
+    ]);
+
+    expect(ids).toEqual(['std-a', 'std-b']);
+  });
+
+  it('drops editions without an id and treats a medium with no track-count as zero', () => {
+    const ids = releaseGroupCandidateIds([
+      { status: 'Official', date: '2001', media: [{ 'track-count': 12 }] }, // no id → dropped
+      // second medium carries no track-count → contributes 0, total stays 12
+      { id: 'known', status: 'Official', date: '2002', media: [{ 'track-count': 12 }, {}] },
+    ]);
+
+    expect(ids).toEqual(['known']);
+  });
+
+  it('treats an edition with no media as zero tracks', () => {
+    expect(releaseGroupCandidateIds([{ id: 'x', status: 'Official', date: '2000' }])).toEqual([
+      'x',
+    ]);
+  });
+
+  it('returns no candidates when no edition is official', () => {
+    expect(
+      releaseGroupCandidateIds([
+        { id: 'boot', status: 'Bootleg', date: '2001', media: [{ 'track-count': 12 }] },
+      ]),
+    ).toEqual([]);
   });
 });

--- a/packages/downloader/src/adapters/musicbrainz/mapping.ts
+++ b/packages/downloader/src/adapters/musicbrainz/mapping.ts
@@ -1,6 +1,12 @@
 import { createTarget } from '../../domain/target/target.js';
 import type { Target } from '../../domain/target/target.js';
-import type { MbRecording, MbRelease, MbScoredEntry, MbScoredRelease } from './schemas.js';
+import type {
+  MbBrowseRelease,
+  MbRecording,
+  MbRelease,
+  MbScoredEntry,
+  MbScoredRelease,
+} from './schemas.js';
 
 /**
  * Pure mapping from MusicBrainz JSON to the normalized, source-agnostic {@link Target} (D11,
@@ -106,12 +112,19 @@ interface GroupedRelease {
   readonly groupTitle: string;
 }
 
-// Real MusicBrainz dates are year-leading (`2013`, `2016-11-04`), so they order chronologically
-// under a plain lexicographic compare; an undated or non-year-leading value maps to a sentinel that
-// sorts after them all, since ':' (0x3A) follows '9' (0x39).
-const UNDATED = ':';
-function dateKey(date: string | undefined): string {
-  return date !== undefined && /^\d{4}/.test(date) ? date : UNDATED;
+// Order MusicBrainz dates chronologically by (year, month, day) components rather than lexically:
+// a lexical compare ranks a year-only `2012` *before* a same-year `2012-10-22`, letting an imprecise
+// date displace a precisely-dated edition. Missing month/day map to a sentinel (99) that sorts after
+// any real component, so within a year a fully-specified date precedes a year-only one; an undated or
+// non-year-leading value maps to +Infinity and sorts after every dated release.
+const DATE_COMPONENT_SENTINEL = 99;
+function dateKey(date: string | undefined): number {
+  const match = /^(\d{4})(?:-(\d{2}))?(?:-(\d{2}))?/.exec(date ?? '');
+  if (match === null) return Number.POSITIVE_INFINITY;
+  const year = Number(match[1]);
+  const month = match[2] !== undefined ? Number(match[2]) : DATE_COMPONENT_SENTINEL;
+  const day = match[3] !== undefined ? Number(match[3]) : DATE_COMPONENT_SENTINEL;
+  return year * 10000 + month * 100 + day;
 }
 
 /**
@@ -197,4 +210,80 @@ export function releaseCandidateIds(
   }
 
   return [...winner.members].sort(compareReleases(wanted)).map((m) => m.id);
+}
+
+/** One edition (release) of a known release group, reduced to the fields the picker needs. */
+export interface ReleaseGroupEdition {
+  readonly id: string;
+  readonly status: string | undefined;
+  readonly date: string | undefined;
+  readonly trackCount: number;
+}
+
+/**
+ * The most common track count among the editions, breaking a tie toward the *lower* count (the more
+ * conservative, standard-like edition). Map iteration is insertion order, so the tie rule is applied
+ * explicitly rather than relying on it. Assumes a non-empty input.
+ */
+function modalTrackCount(editions: readonly ReleaseGroupEdition[]): number {
+  const frequency = new Map<number, number>();
+  for (const edition of editions) {
+    frequency.set(edition.trackCount, (frequency.get(edition.trackCount) ?? 0) + 1);
+  }
+  let modal = 0;
+  let modalFrequency = 0;
+  for (const [count, freq] of frequency) {
+    if (freq > modalFrequency || (freq === modalFrequency && count < modal)) {
+      modal = count;
+      modalFrequency = freq;
+    }
+  }
+  return modal;
+}
+
+/**
+ * The ordered release ids to try for a release-group request (identity is given, so there is no
+ * search, grouping, or cross-group ambiguity guard — and no request-title tier, since a bare group
+ * id expresses no edition intent). Selection is confined to *official* editions: restrict to those
+ * whose track count equals the modal count of the official editions, then order by earliest date
+ * (chronological, precise before year-only within a year) with stable input order as the final
+ * tiebreak. A group with no official edition (or no editions) yields no candidates — the adapter
+ * reports that as *unresolved*. The caller fetches the ids in order and takes the first that yields a
+ * valid target, so an edition with unusable metadata falls through to the next.
+ */
+export function releaseGroupEditionIds(
+  editions: readonly ReleaseGroupEdition[],
+): readonly string[] {
+  const official = editions.filter((edition) => edition.status === 'Official');
+  if (official.length === 0) return [];
+  const modal = modalTrackCount(official);
+  return official
+    .filter((edition) => edition.trackCount === modal)
+    .sort((a, b) => {
+      const aDate = dateKey(a.date);
+      const bDate = dateKey(b.date);
+      return aDate < bDate ? -1 : aDate > bDate ? 1 : 0;
+    })
+    .map((edition) => edition.id);
+}
+
+/**
+ * Reduce a release-group browse (identity-typed editions) to the ordered release ids to try, via
+ * {@link releaseGroupEditionIds}. An edition's total track count is the sum of its media's
+ * `track-count`s (an unknown count contributes 0); editions without an id are dropped, since there
+ * is nothing to fetch. Empty, all-non-official, or missing input yields no candidates → *unresolved*.
+ */
+export function releaseGroupCandidateIds(
+  releases: readonly MbBrowseRelease[] | undefined,
+): readonly string[] {
+  const editions: ReleaseGroupEdition[] = [];
+  for (const release of releases ?? []) {
+    if (release.id === undefined) continue;
+    const trackCount = (release.media ?? []).reduce(
+      (sum, medium) => sum + (medium['track-count'] ?? 0),
+      0,
+    );
+    editions.push({ id: release.id, status: release.status, date: release.date, trackCount });
+  }
+  return releaseGroupEditionIds(editions);
 }

--- a/packages/downloader/src/adapters/musicbrainz/metadata.test.ts
+++ b/packages/downloader/src/adapters/musicbrainz/metadata.test.ts
@@ -184,6 +184,105 @@ describe('MusicBrainzMetadata', () => {
     expect(result).toEqual({ kind: 'unresolved' });
   });
 
+  const byReleaseGroup = (mbid: string): AcquisitionRequest => ({
+    kind: 'release-group',
+    mbid,
+    targetType: 'album',
+  });
+
+  const browse = (releases: unknown[]): HttpResponse => ok({ releases });
+
+  it('resolves a release-group request to the modal official edition', async () => {
+    const result = (
+      await resolver([
+        [
+          '/release?release-group=rg-1',
+          browse([
+            // 19-track deluxe must not win over the 13-track standard editions
+            {
+              id: 'deluxe',
+              status: 'Official',
+              date: '2014-10-27',
+              media: [{ 'track-count': 19 }],
+            },
+            { id: 'std', status: 'Official', date: '2014-10-27', media: [{ 'track-count': 13 }] },
+            { id: 'std2', status: 'Official', date: '2015-01-01', media: [{ 'track-count': 13 }] },
+          ]),
+        ],
+        ['/release/std', releaseFixture('std')],
+      ]).resolve(byReleaseGroup('rg-1'))
+    )._unsafeUnwrap();
+
+    expect(result).toMatchObject({ kind: 'resolved', target: { mbid: 'std', type: 'album' } });
+  });
+
+  it('requests the recorded browse path with inc=media for a release-group request', async () => {
+    const urls: string[] = [];
+    const capturing: HttpClient = {
+      send: ({ url }) => {
+        urls.push(url);
+        return Promise.resolve(
+          url.includes('/release/std')
+            ? releaseFixture('std')
+            : browse([
+                { id: 'std', status: 'Official', date: '2020', media: [{ 'track-count': 10 }] },
+              ]),
+        );
+      },
+    };
+
+    await new MusicBrainzMetadata(silentLogger(), capturing).resolve(byReleaseGroup('rg-9'));
+
+    const browseUrl = new URL(urls[0]!);
+    expect(browseUrl.searchParams.get('release-group')).toBe('rg-9');
+    expect(browseUrl.searchParams.get('inc')).toBe('media');
+  });
+
+  it('reports unresolved when the release group is not found', async () => {
+    const result = (await resolver([]).resolve(byReleaseGroup('missing')))._unsafeUnwrap();
+    expect(result).toEqual({ kind: 'unresolved' });
+  });
+
+  it('reports unresolved when the release group has no official edition', async () => {
+    const result = (
+      await resolver([
+        [
+          '/release?release-group=rg-2',
+          browse([{ id: 'boot', status: 'Bootleg', date: '2001', media: [{ 'track-count': 12 }] }]),
+        ],
+      ]).resolve(byReleaseGroup('rg-2'))
+    )._unsafeUnwrap();
+
+    expect(result).toEqual({ kind: 'unresolved' });
+  });
+
+  it('reports unresolved when the release group is empty', async () => {
+    const result = (
+      await resolver([['/release?release-group=rg-3', browse([])]]).resolve(byReleaseGroup('rg-3'))
+    )._unsafeUnwrap();
+
+    expect(result).toEqual({ kind: 'unresolved' });
+  });
+
+  it('falls through to the next edition when the modal pick has unusable data', async () => {
+    const sparse = ok({ id: 'edition-a', title: 'Album', 'artist-credit': [{ name: 'Artist' }] });
+    const result = (
+      await resolver([
+        [
+          '/release?release-group=rg-4',
+          browse([
+            { id: 'edition-a', status: 'Official', date: '2010', media: [{ 'track-count': 13 }] },
+            { id: 'edition-b', status: 'Official', date: '2011', media: [{ 'track-count': 13 }] },
+          ]),
+        ],
+        ['/release/edition-a', sparse], // earliest modal edition, but no tracks → no valid target
+        ['/release/edition-b', releaseFixture('edition-b')],
+      ]).resolve(byReleaseGroup('rg-4'))
+    )._unsafeUnwrap();
+
+    expect(result).toMatchObject({ kind: 'resolved', target: { mbid: 'edition-b' } });
+  });
+
   it('resolves a recording by MBID into a single-track target', async () => {
     const result = (
       await resolver([['/recording/rec-1', recordingFixture('rec-1')]]).resolve(trackById)

--- a/packages/downloader/src/adapters/musicbrainz/metadata.ts
+++ b/packages/downloader/src/adapters/musicbrainz/metadata.ts
@@ -7,22 +7,30 @@ import type { Logger } from '../../application/logging/logger.js';
 import type { ZodType } from 'zod';
 import { fetchHttpClient } from '../support/http.js';
 import type { HttpClient } from '../support/http.js';
-import { bestMatchId, recordingToTarget, releaseCandidateIds, releaseToTarget } from './mapping.js';
+import {
+  bestMatchId,
+  recordingToTarget,
+  releaseCandidateIds,
+  releaseGroupCandidateIds,
+  releaseToTarget,
+} from './mapping.js';
 import {
   mbRecordingSchema,
   mbRecordingSearchSchema,
+  mbReleaseGroupBrowseSchema,
   mbReleaseSchema,
   mbReleaseSearchSchema,
 } from './schemas.js';
 
 /**
- * The MusicBrainz `MetadataPort` adapter (D12). Resolves a request — by MBID or by structured
- * descriptor — into a canonical {@link Target}. An album descriptor searches, resolves the album's
- * identity to a confident, unambiguous release group and selects an edition within it
- * ({@link releaseCandidateIds}), then fetches releases in order until one yields a target; a track
- * descriptor uses the flat {@link bestMatchId} guard. Not-found / no-confident-match is the
- * *business* outcome `unresolved`; only transport faults or unexpected HTTP statuses become an
- * `InfraError`.
+ * The MusicBrainz `MetadataPort` adapter (D12). Resolves a request — by release/recording MBID, by
+ * release-*group* MBID, or by structured descriptor — into a canonical {@link Target}. An album
+ * descriptor searches, resolves the album's identity to a confident, unambiguous release group and
+ * selects an edition within it ({@link releaseCandidateIds}), then fetches releases in order until
+ * one yields a target; a release-group request browses the group's editions and selects a
+ * representative official one ({@link releaseGroupCandidateIds}); a track descriptor uses the flat
+ * {@link bestMatchId} guard. Not-found / no-confident-match is the *business* outcome `unresolved`;
+ * only transport faults or unexpected HTTP statuses become an `InfraError`.
  */
 
 const UNRESOLVED: MetadataResolution = { kind: 'unresolved' };
@@ -73,6 +81,9 @@ export class MusicBrainzMetadata implements MetadataPort {
         ? this.resolveReleaseById(request.mbid)
         : this.resolveRecordingById(request.mbid);
     }
+    if (request.kind === 'release-group') {
+      return this.resolveReleaseByReleaseGroup(request.mbid);
+    }
     return request.targetType === 'album'
       ? this.resolveReleaseByDescriptor(request.artist, request.title)
       : this.resolveRecordingByDescriptor(request.artist, request.title);
@@ -96,6 +107,16 @@ export class MusicBrainzMetadata implements MetadataPort {
     if (json === undefined) return UNRESOLVED;
     const target = recordingToTarget(json);
     return target === undefined ? UNRESOLVED : { kind: 'resolved', target };
+  }
+
+  private async resolveReleaseByReleaseGroup(mbid: string): Promise<MetadataResolution> {
+    const url = `${this.baseUrl}/release?release-group=${encodeURIComponent(mbid)}&inc=media&fmt=json&limit=${RELEASE_SEARCH_LIMIT}`;
+    const json = await this.getJson(url, mbReleaseGroupBrowseSchema);
+    for (const id of releaseGroupCandidateIds(json?.releases)) {
+      const resolution = await this.resolveReleaseById(id);
+      if (resolution.kind === 'resolved') return resolution;
+    }
+    return UNRESOLVED;
   }
 
   private async resolveReleaseByDescriptor(

--- a/packages/downloader/src/adapters/musicbrainz/schemas.test.ts
+++ b/packages/downloader/src/adapters/musicbrainz/schemas.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   mbRecordingSchema,
   mbRecordingSearchSchema,
+  mbReleaseGroupBrowseSchema,
   mbReleaseSchema,
   mbReleaseSearchSchema,
 } from './schemas.js';
@@ -120,5 +121,36 @@ describe('MusicBrainz contract schemas', () => {
 
     expect(result.success).toBe(false);
     expect(result.error?.issues[0]?.path).toEqual(['releases', 0, 'release-group', 'id']);
+  });
+
+  it('accepts a release-group browse carrying every consumed edition field', () => {
+    const parsed = mbReleaseGroupBrowseSchema.parse({
+      releases: [
+        {
+          id: 'rel-1',
+          title: 'Album',
+          status: 'Official',
+          date: '2014-10-27',
+          media: [{ 'track-count': 8 }, { 'track-count': 5 }],
+        },
+      ],
+    });
+
+    expect(parsed.releases?.[0]?.media?.map((m) => m['track-count'])).toEqual([8, 5]);
+  });
+
+  it('tolerates a browse edition missing status, date, and media', () => {
+    expect(mbReleaseGroupBrowseSchema.parse({ releases: [{ id: 'rel-1' }] }).releases).toEqual([
+      { id: 'rel-1' },
+    ]);
+  });
+
+  it('rejects a browse edition whose media track-count is not a number', () => {
+    const result = mbReleaseGroupBrowseSchema.safeParse({
+      releases: [{ id: 'x', media: [{ 'track-count': 'ten' }] }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['releases', 0, 'media', 0, 'track-count']);
   });
 });

--- a/packages/downloader/src/adapters/musicbrainz/schemas.ts
+++ b/packages/downloader/src/adapters/musicbrainz/schemas.ts
@@ -67,6 +67,26 @@ export const mbReleaseSearchSchema = z.object({
   releases: z.array(scoredReleaseSchema).optional(),
 });
 
+/**
+ * One edition of a known release group, as returned by the browse `GET /release?release-group={mbid}
+ * &inc=media&fmt=json`. A browse carries no relevance `score` (identity is given); the picker reads
+ * only `status` and `date` (edition selection) and the per-medium `track-count`s, whose sum is the
+ * edition's total track count. All fields are optional — a sparse edition degrades selection (e.g.
+ * an unknown track count of 0 simply won't be modal), never the resolution as a whole.
+ */
+const browseReleaseSchema = z.object({
+  id: z.string().optional(),
+  title: z.string().optional(),
+  status: z.string().optional(),
+  date: z.string().optional(),
+  media: z.array(z.object({ 'track-count': z.number().optional() })).optional(),
+});
+
+/** `GET /release?release-group={mbid}&inc=media&fmt=json` — the editions of one release group. */
+export const mbReleaseGroupBrowseSchema = z.object({
+  releases: z.array(browseReleaseSchema).optional(),
+});
+
 /** `GET /recording?query=…&fmt=json`. */
 export const mbRecordingSearchSchema = z.object({
   recordings: z.array(scoredEntrySchema).optional(),
@@ -78,3 +98,5 @@ export type MbScoredEntry = z.infer<typeof scoredEntrySchema>;
 export type MbScoredRelease = z.infer<typeof scoredReleaseSchema>;
 export type MbReleaseSearch = z.infer<typeof mbReleaseSearchSchema>;
 export type MbRecordingSearch = z.infer<typeof mbRecordingSearchSchema>;
+export type MbReleaseGroupBrowse = z.infer<typeof mbReleaseGroupBrowseSchema>;
+export type MbBrowseRelease = z.infer<typeof browseReleaseSchema>;

--- a/packages/downloader/src/domain/acquisition/acquisition.test.ts
+++ b/packages/downloader/src/domain/acquisition/acquisition.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { Acquisition } from './acquisition.js';
 import type { Effect } from './acquisition.js';
 import type { AcquisitionCommand } from './commands.js';
-import type { AcquisitionEvent } from './events.js';
+import type { AcquisitionEvent, AcquisitionRequest } from './events.js';
 import {
   defaultPolicies,
   fulfilledHistory,
@@ -524,6 +524,18 @@ describe('Acquisition.reactTo — the event → effect table', () => {
       policies,
     });
     expect(effects).toEqual([{ type: 'ResolveMetadata', request: sampleRequest }]);
+  });
+
+  it('resolves metadata for a release-group request, carrying it verbatim to the effect', () => {
+    const request: AcquisitionRequest = {
+      kind: 'release-group',
+      mbid: 'rg-1',
+      targetType: 'album',
+    };
+    const effects = Acquisition.fromHistory([
+      { type: 'AcquisitionRequested', request, policies },
+    ]).reactTo({ type: 'AcquisitionRequested', request, policies });
+    expect(effects).toEqual([{ type: 'ResolveMetadata', request }]);
   });
 
   it('searches after a target resolves', () => {

--- a/packages/downloader/src/domain/acquisition/events.ts
+++ b/packages/downloader/src/domain/acquisition/events.ts
@@ -10,9 +10,14 @@ import type { ValidationVerdict } from '../validation/verdict.js';
  * frequency transfer progress is deliberately kept OFF the stream (D1) as an ephemeral read model.
  */
 
-/** What the caller asked for: a MusicBrainz id, or a structured descriptor to resolve (D12). */
+/**
+ * What the caller asked for: a MusicBrainz release/recording id, a MusicBrainz release-*group* id
+ * (an album identity, resolved to a representative official edition), or a structured descriptor to
+ * resolve (D12).
+ */
 export type AcquisitionRequest =
   | { readonly kind: 'musicbrainz'; readonly mbid: string; readonly targetType: TargetType }
+  | { readonly kind: 'release-group'; readonly mbid: string; readonly targetType: 'album' }
   | {
       readonly kind: 'descriptor';
       readonly targetType: TargetType;

--- a/packages/downloader/src/facade/mapping.test.ts
+++ b/packages/downloader/src/facade/mapping.test.ts
@@ -11,6 +11,14 @@ describe('requestToDomain', () => {
       targetType: 'album',
     });
   });
+
+  it('carries a release-group request through to the domain shape', () => {
+    expect(requestToDomain({ kind: 'release-group', mbid: 'rg-1', targetType: 'album' })).toEqual({
+      kind: 'release-group',
+      mbid: 'rg-1',
+      targetType: 'album',
+    });
+  });
 });
 
 describe('resolvePolicies', () => {

--- a/packages/downloader/src/facade/schemas.test.ts
+++ b/packages/downloader/src/facade/schemas.test.ts
@@ -19,6 +19,22 @@ describe('submitAcquisitionRequestSchema', () => {
     expect(parsed.request).toMatchObject({ kind: 'descriptor', artist: 'A' });
   });
 
+  it('accepts a release-group request (album only)', () => {
+    const parsed = submitAcquisitionRequestSchema.parse({
+      request: { kind: 'release-group', mbid: 'rg-1', targetType: 'album' },
+    });
+
+    expect(parsed.request).toMatchObject({ kind: 'release-group', mbid: 'rg-1' });
+  });
+
+  it('rejects a release-group request targeting a track', () => {
+    expect(() =>
+      submitAcquisitionRequestSchema.parse({
+        request: { kind: 'release-group', mbid: 'rg-1', targetType: 'track' },
+      }),
+    ).toThrow();
+  });
+
   it('rejects an unknown request kind', () => {
     expect(() =>
       submitAcquisitionRequestSchema.parse({ request: { kind: 'torrent', mbid: 'x' } }),

--- a/packages/downloader/src/facade/schemas.ts
+++ b/packages/downloader/src/facade/schemas.ts
@@ -61,6 +61,13 @@ export const acquisitionRequestSchema = z.discriminatedUnion('kind', [
     targetType: targetTypeSchema,
   }),
   z.object({
+    // A MusicBrainz release-*group* id (an album identity); resolved to a representative official
+    // edition. Albums only — a release group has no track (recording) analogue.
+    kind: z.literal('release-group'),
+    mbid: z.string().min(1),
+    targetType: z.literal('album'),
+  }),
+  z.object({
     kind: z.literal('descriptor'),
     targetType: targetTypeSchema,
     artist: z.string().min(1),

--- a/packages/downloader/test/contract/fixtures/musicbrainz/release-group-browse.json
+++ b/packages/downloader/test/contract/fixtures/musicbrainz/release-group-browse.json
@@ -1,0 +1,5499 @@
+{
+  "provenance": {
+    "source": "https://musicbrainz.org/ws/2 (live)",
+    "capturedAt": "2026-07-22",
+    "note": "public data; no sanitization"
+  },
+  "request": {
+    "method": "GET",
+    "path": "/release",
+    "query": {
+      "release-group": "f5093c06-23e3-404f-aeaa-40f72885ee3a",
+      "inc": "media",
+      "fmt": "json",
+      "limit": "100"
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": {
+      "release-offset": 0,
+      "releases": [
+        {
+          "quality": "normal",
+          "status": "Official",
+          "date": "1978-06-05",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "date": "1978-06-05",
+              "area": {
+                "sort-name": "Japan",
+                "name": "Japan",
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "type": null,
+                "type-id": null,
+                "disambiguation": "",
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "asin": null,
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "media": [
+            {
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "title": "",
+              "id": "ded18664-e877-322f-a188-352d43ce5511",
+              "format": "12\" Vinyl",
+              "track-count": 10,
+              "position": 1
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging": "Gatefold Cover",
+          "id": "01aa589c-a7cb-45bd-89a3-c2cb8ddab0a9",
+          "disambiguation": "",
+          "cover-art-archive": {
+            "back": true,
+            "count": 18,
+            "darkened": false,
+            "artwork": true,
+            "front": true
+          },
+          "country": "JP",
+          "barcode": ""
+        },
+        {
+          "quality": "normal",
+          "date": "1979-06",
+          "status": "Official",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "date": "1979-06",
+              "area": {
+                "type-id": null,
+                "disambiguation": "",
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "type": null,
+                "name": "United States",
+                "sort-name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ]
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "asin": null,
+          "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "id": "d89d8533-3da0-363c-8648-2411eb421fbc",
+              "format": "12\" Vinyl",
+              "title": "",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64"
+            }
+          ],
+          "packaging": "Cardboard/Paper Sleeve",
+          "id": "03683c48-eb9e-47a8-bcdf-d5e5bae93de3",
+          "disambiguation": "1979 Mobile Fidelity Sound Lab remaster",
+          "cover-art-archive": {
+            "back": true,
+            "artwork": true,
+            "count": 16,
+            "darkened": false,
+            "front": true
+          },
+          "barcode": "",
+          "country": "US"
+        },
+        {
+          "quality": "normal",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Official",
+          "date": "1994",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "type": null,
+                "name": "Europe",
+                "sort-name": "Europe",
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "disambiguation": "",
+                "type-id": null,
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a"
+              },
+              "date": "1994"
+            }
+          ],
+          "asin": null,
+          "media": [
+            {
+              "position": 1,
+              "track-count": 9,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "format": "CD",
+              "id": "d80333fc-cc58-3008-94f2-b2be367a17b3"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "packaging": "Jewel Case",
+          "id": "0373a8a1-843e-4a4b-8919-fca2de16986a",
+          "disambiguation": "“made in Italy” on CD, “printed in the U.K.” on rear",
+          "country": "XE",
+          "barcode": "724382975229",
+          "cover-art-archive": {
+            "count": 15,
+            "artwork": true,
+            "darkened": false,
+            "front": true,
+            "back": true
+          }
+        },
+        {
+          "release-events": [
+            {
+              "area": {
+                "type-id": null,
+                "disambiguation": "",
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+                "type": null,
+                "sort-name": "Europe",
+                "name": "Europe",
+                "iso-3166-1-codes": [
+                  "XE"
+                ]
+              },
+              "date": "2003-03-31"
+            },
+            {
+              "area": {
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+                "disambiguation": "",
+                "type-id": null,
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "sort-name": "United Kingdom",
+                "name": "United Kingdom",
+                "type": null
+              },
+              "date": "2003-03-31"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "date": "2003-03-31",
+          "status": "Official",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "quality": "normal",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "title": "",
+              "format-id": "1a168dbd-d7ce-381d-a38a-3948de2cb4d6",
+              "format": "Hybrid SACD (CD layer)",
+              "id": "040c4dc1-4bef-31e7-94b9-e325828d4578",
+              "track-count": 10,
+              "position": 1
+            },
+            {
+              "format-id": "6c521ee3-f723-41de-bc6b-ec3621b9ffa9",
+              "title": "",
+              "id": "e64e047e-208f-3abc-b951-dc8efdc69838",
+              "format": "Hybrid SACD (SACD layer, 2 channels)",
+              "position": 2,
+              "track-count": 10
+            },
+            {
+              "position": 3,
+              "track-count": 10,
+              "format-id": "fa46fab8-4c29-495a-b2fa-7bc14257dcca",
+              "title": "",
+              "format": "Hybrid SACD (SACD layer, multichannel)",
+              "id": "37b888e7-8e27-32c0-ac11-1235cad86e31"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "asin": "B00008CLOA",
+          "packaging": "Jewel Case",
+          "cover-art-archive": {
+            "artwork": true,
+            "count": 17,
+            "darkened": false,
+            "front": true,
+            "back": true
+          },
+          "country": "XE",
+          "barcode": "724358213621",
+          "disambiguation": "30th anniversary edition, printed in EU, Made in EU, various boxes/lines in matrix",
+          "id": "0cae1eb4-b159-4d03-8719-1f5bb40bcd2f"
+        },
+        {
+          "packaging": null,
+          "disambiguation": "Ultradisc, pure gold plated",
+          "id": "10600476-3b48-4709-a91d-3fdf6d2455e6",
+          "cover-art-archive": {
+            "count": 9,
+            "darkened": false,
+            "artwork": true,
+            "front": true,
+            "back": true
+          },
+          "barcode": "015775151727",
+          "country": "US",
+          "quality": "normal",
+          "release-events": [
+            {
+              "area": {
+                "disambiguation": "",
+                "type-id": null,
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "sort-name": "United States",
+                "name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "type": null
+              },
+              "date": "1988"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "date": "1988",
+          "status": "Official",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "packaging-id": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "format": "CD",
+              "id": "5569aaf0-7325-3d84-a7a7-60976f84d224",
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "track-count": 10,
+              "position": 1
+            }
+          ],
+          "asin": null
+        },
+        {
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "artwork": true,
+            "count": 11,
+            "darkened": false
+          },
+          "barcode": "",
+          "country": "GB",
+          "id": "106ec6c3-1a30-336f-9572-65cc0e47109d",
+          "disambiguation": "",
+          "packaging": "Jewel Case",
+          "asin": null,
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 9,
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "format": "CD",
+              "id": "911aafa8-b9bf-3dc5-b59f-75a9b3c08b7b"
+            }
+          ],
+          "date": "1984-08",
+          "status": "Official",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "date": "1984-08",
+              "area": {
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+                "disambiguation": "",
+                "type-id": null,
+                "type": null,
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "sort-name": "United Kingdom",
+                "name": "United Kingdom"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "quality": "normal"
+        },
+        {
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "2001-06-16",
+              "area": {
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "disambiguation": "",
+                "type-id": null,
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "sort-name": "Japan",
+                "name": "Japan",
+                "type": null
+              }
+            }
+          ],
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "date": "2001-06-16",
+          "status": "Official",
+          "quality": "normal",
+          "title": "狂気",
+          "media": [
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "id": "7f375fe5-a9c8-3272-a560-f88fa9335fe7",
+              "format": "CD",
+              "track-count": 9,
+              "position": 1
+            }
+          ],
+          "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+          "asin": "B00005HYHA",
+          "packaging": "Cardboard/Paper Sleeve",
+          "barcode": "4988006791800",
+          "country": "JP",
+          "cover-art-archive": {
+            "back": false,
+            "artwork": true,
+            "count": 1,
+            "darkened": false,
+            "front": false
+          },
+          "disambiguation": "",
+          "id": "1295cd4c-bcee-33ac-8b1b-48c98c04718e"
+        },
+        {
+          "packaging": "Other",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "artwork": true,
+            "count": 93,
+            "darkened": false
+          },
+          "country": "GB",
+          "barcode": "5099902943121",
+          "disambiguation": "Immersion box set",
+          "id": "12fb801c-5903-4a99-a10c-7af599fe3986",
+          "release-events": [
+            {
+              "date": "2011-09-26",
+              "area": {
+                "type": null,
+                "name": "United Kingdom",
+                "sort-name": "United Kingdom",
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "type-id": null,
+                "disambiguation": "",
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "date": "2011-09-26",
+          "status": "Official",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "quality": "normal",
+          "packaging-id": "815b7785-8284-3926-8f04-e48bc6c4d102",
+          "media": [
+            {
+              "format": "CD",
+              "id": "3af915fc-2848-32fa-ae72-89eee2b69809",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "2011 Remaster",
+              "position": 1,
+              "track-count": 10
+            },
+            {
+              "id": "2d302b42-52c8-3e5c-83b3-ac6c34d701ee",
+              "format": "CD",
+              "title": "Live at the Empire Pool, Wembley, London 1974",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "position": 2,
+              "track-count": 10
+            },
+            {
+              "position": 3,
+              "track-count": 30,
+              "title": "Audio Only",
+              "format-id": "bb71fd58-ff93-32b4-a201-4ad1b2a80e5f",
+              "id": "bff4f567-d09c-3cbf-90ea-7701237478e0",
+              "format": "DVD-Video"
+            },
+            {
+              "id": "052fc0ea-799b-349f-a7a1-73a3c35f18ae",
+              "format": "DVD-Video",
+              "format-id": "bb71fd58-ff93-32b4-a201-4ad1b2a80e5f",
+              "title": "Audio‐Visual Material",
+              "position": 4,
+              "track-count": 28
+            },
+            {
+              "format": "Blu-ray",
+              "id": "5c05d49e-68f8-3cd8-8f51-c5667cfa9231",
+              "title": "",
+              "format-id": "c693c05b-3316-3d69-afc2-5e2bc455bffc",
+              "position": 5,
+              "track-count": 58
+            },
+            {
+              "track-count": 16,
+              "position": 6,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "Previously Unreleased Tracks",
+              "format": "CD",
+              "id": "0842d4c9-adc8-3a58-919e-af08648e30e6"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "asin": "B004ZNARH4"
+        },
+        {
+          "packaging": "Jewel Case",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "count": 19,
+            "artwork": true,
+            "darkened": false
+          },
+          "barcode": "724382975229",
+          "country": "XE",
+          "disambiguation": "reissue with SID codes",
+          "id": "144883ae-fabb-45e3-acd1-c43107f661d2",
+          "release-events": [
+            {
+              "area": {
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+                "disambiguation": "",
+                "type-id": null,
+                "type": null,
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "name": "Europe",
+                "sort-name": "Europe"
+              },
+              "date": "1994"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "date": "1994",
+          "status": "Official",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "quality": "normal",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 9,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "format": "CD",
+              "id": "2e45b429-925e-4e61-82c4-c7d216f9e59e"
+            }
+          ],
+          "asin": null
+        },
+        {
+          "disambiguation": "30th anniversary edition, Printed in EU, Made in Japan, stars in matrix",
+          "id": "1a2a37a4-2ee5-3aa8-b1bf-4976dbb8007c",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "count": 21,
+            "darkened": false,
+            "artwork": true
+          },
+          "barcode": "724358213621",
+          "country": "XE",
+          "packaging": "Jewel Case",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "format": "Hybrid SACD (CD layer)",
+              "id": "3945c1fa-1b58-3b93-b196-401d6de60022",
+              "title": "",
+              "format-id": "1a168dbd-d7ce-381d-a38a-3948de2cb4d6",
+              "position": 1,
+              "track-count": 10
+            },
+            {
+              "format-id": "6c521ee3-f723-41de-bc6b-ec3621b9ffa9",
+              "title": "",
+              "id": "f99e4bcf-a858-37c8-857d-06fcfae7480e",
+              "format": "Hybrid SACD (SACD layer, 2 channels)",
+              "position": 2,
+              "track-count": 10
+            },
+            {
+              "title": "",
+              "format-id": "fa46fab8-4c29-495a-b2fa-7bc14257dcca",
+              "format": "Hybrid SACD (SACD layer, multichannel)",
+              "id": "e2798916-4553-320e-82e7-b9c783b0e72d",
+              "position": 3,
+              "track-count": 10
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "asin": "B00008CLOA",
+          "quality": "normal",
+          "release-events": [
+            {
+              "date": "2003-03-31",
+              "area": {
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "name": "Europe",
+                "sort-name": "Europe",
+                "type": null,
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+                "type-id": null,
+                "disambiguation": ""
+              }
+            },
+            {
+              "date": "2003-03-31",
+              "area": {
+                "name": "United Kingdom",
+                "sort-name": "United Kingdom",
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "type": null,
+                "type-id": null,
+                "disambiguation": "",
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "2003-03-31",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          }
+        },
+        {
+          "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "id": "edd61af2-9970-3d72-8ce3-79565804c1fa",
+              "format": "CD",
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "asin": "B004ZN9RWK",
+          "quality": "normal",
+          "release-events": [
+            {
+              "date": "2011-09-26",
+              "area": {
+                "type": null,
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "name": "Europe",
+                "sort-name": "Europe",
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+                "type-id": null,
+                "disambiguation": ""
+              }
+            },
+            {
+              "area": {
+                "sort-name": "United Kingdom",
+                "name": "United Kingdom",
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "type": null,
+                "type-id": null,
+                "disambiguation": "",
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed"
+              },
+              "date": "2011-09-27"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "2011-09-26",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "disambiguation": "“Why Pink Floyd…?” Discovery edition",
+          "id": "1c04f98c-6c5e-4e4f-ab40-4ea5a3f09c86",
+          "cover-art-archive": {
+            "count": 6,
+            "darkened": false,
+            "artwork": true,
+            "front": true,
+            "back": true
+          },
+          "country": "XE",
+          "barcode": "5099902895529",
+          "packaging": "Cardboard/Paper Sleeve"
+        },
+        {
+          "packaging": "Cassette Case",
+          "disambiguation": "",
+          "id": "1c3ea255-3cc5-4861-9864-81e3bceb4443",
+          "country": "GB",
+          "barcode": "",
+          "cover-art-archive": {
+            "front": true,
+            "artwork": true,
+            "count": 2,
+            "darkened": false,
+            "back": false
+          },
+          "quality": "normal",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1973",
+              "area": {
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+                "disambiguation": "",
+                "type-id": null,
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "sort-name": "United Kingdom",
+                "name": "United Kingdom",
+                "type": null
+              }
+            }
+          ],
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Official",
+          "date": "1973",
+          "media": [
+            {
+              "title": "",
+              "format-id": "f5e6e254-8f39-331c-936b-9c69d686dc47",
+              "format": "Cassette",
+              "id": "e4820bac-c78d-3553-bc58-969e38310166",
+              "position": 1,
+              "track-count": 10
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "c70b737a-0114-39a9-88f7-82843e54f906",
+          "asin": null
+        },
+        {
+          "id": "1ce759f7-641e-409a-994d-5d3531127435",
+          "disambiguation": "",
+          "barcode": "5099902895529",
+          "country": "XE",
+          "cover-art-archive": {
+            "darkened": false,
+            "count": 2,
+            "artwork": true,
+            "front": true,
+            "back": true
+          },
+          "packaging": "Cardboard/Paper Sleeve",
+          "asin": "B019VQSA64",
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "id": "81017953-81bd-3132-9ed3-c2667962bd7e",
+              "format": "CD"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+          "quality": "normal",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Official",
+          "date": "2016-01-08",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "type-id": null,
+                "disambiguation": "",
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+                "name": "Europe",
+                "sort-name": "Europe",
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "type": null
+              },
+              "date": "2016-01-08"
+            }
+          ]
+        },
+        {
+          "release-events": [
+            {
+              "date": "1994",
+              "area": {
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+                "disambiguation": "",
+                "type-id": null,
+                "type": null,
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "name": "Europe",
+                "sort-name": "Europe"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "1994",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "quality": "normal",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "format": "CD",
+              "id": "d9cf2f36-f9c0-41f7-8210-36a98e0bdfce",
+              "position": 1,
+              "track-count": 9
+            }
+          ],
+          "title": "Dark Side of the Moon",
+          "asin": null,
+          "packaging": "Jewel Case",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "artwork": true,
+            "count": 18,
+            "darkened": false
+          },
+          "barcode": "724382975229",
+          "country": "XE",
+          "disambiguation": "EMI Uden pressing with Mould SID code",
+          "id": "1dd9f622-b1f7-41c4-ae20-74fd46bd1b24"
+        },
+        {
+          "barcode": "",
+          "country": "US",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "count": 12,
+            "darkened": false,
+            "artwork": true
+          },
+          "disambiguation": "",
+          "id": "24824319-9bb8-3d1e-a2c5-b8b864dafd1b",
+          "packaging": "Gatefold Cover",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "id": "bfecd8bf-cf41-3735-b2d2-4aff5135f081",
+              "format": "12\" Vinyl",
+              "title": "",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64"
+            }
+          ],
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "asin": "B00HYIXDUK",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1973",
+              "area": {
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "type-id": null,
+                "disambiguation": "",
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "name": "United States",
+                "sort-name": "United States",
+                "type": null
+              }
+            }
+          ],
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "date": "1973",
+          "status": "Official",
+          "quality": "normal"
+        },
+        {
+          "packaging": "Jewel Case",
+          "barcode": "077774600125",
+          "country": "US",
+          "cover-art-archive": {
+            "darkened": false,
+            "count": 16,
+            "artwork": true,
+            "front": true,
+            "back": true
+          },
+          "disambiguation": "",
+          "id": "25fbfbb4-b1ee-4448-aadf-ae3bc2e2dd27",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "sort-name": "United States",
+                "name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "type": null,
+                "type-id": null,
+                "disambiguation": "",
+                "id": "489ce91b-6658-3307-9877-795b68554c98"
+              },
+              "date": "1994"
+            }
+          ],
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "date": "1994",
+          "status": "Official",
+          "quality": "normal",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "track-count": 9,
+              "position": 1,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "id": "6ffc5750-8510-36e9-a31e-ec8f40e4c0e1",
+              "format": "CD"
+            }
+          ],
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "asin": "B000002U82"
+        },
+        {
+          "packaging": "Digipak",
+          "cover-art-archive": {
+            "back": true,
+            "count": 24,
+            "darkened": false,
+            "artwork": true,
+            "front": true
+          },
+          "country": "GB",
+          "barcode": "077778147923",
+          "disambiguation": "20th anniversary edition, made in UK",
+          "id": "2755bfc1-9438-4ae8-8a49-3f820dbca482",
+          "release-events": [
+            {
+              "area": {
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+                "disambiguation": "",
+                "type-id": null,
+                "type": null,
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "sort-name": "United Kingdom",
+                "name": "United Kingdom"
+              },
+              "date": "1993-03-08"
+            },
+            {
+              "date": "1993",
+              "area": {
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "sort-name": "Europe",
+                "name": "Europe",
+                "type": null,
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+                "type-id": null,
+                "disambiguation": ""
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "1993-03-08",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "quality": "normal",
+          "packaging-id": "8f931351-d2e2-310f-afc6-37b89ddba246",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "format": "CD",
+              "id": "66f179b2-eb03-380a-89bc-490620037126",
+              "position": 1,
+              "track-count": 9
+            }
+          ],
+          "asin": "B000008JGJ"
+        },
+        {
+          "id": "29e1c397-5030-4d89-ae02-95b849d8d596",
+          "disambiguation": "Japan Quadraphonic",
+          "cover-art-archive": {
+            "darkened": false,
+            "count": 1,
+            "artwork": true,
+            "front": true,
+            "back": false
+          },
+          "country": "JP",
+          "barcode": "",
+          "packaging": "Cardboard/Paper Sleeve",
+          "asin": null,
+          "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "title": "",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "id": "562e3516-1508-4c97-964b-3e1060448bde",
+              "format": "12\" Vinyl"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "quality": "normal",
+          "date": "1974-12-20",
+          "status": "Official",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "date": "1974-12-20",
+              "area": {
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "type-id": null,
+                "disambiguation": "",
+                "type": null,
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "name": "Japan",
+                "sort-name": "Japan"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe"
+        },
+        {
+          "packaging": "None",
+          "barcode": "5099908217059",
+          "country": null,
+          "cover-art-archive": {
+            "back": false,
+            "front": true,
+            "count": 1,
+            "artwork": true,
+            "darkened": false
+          },
+          "id": "2b53df77-f0ea-4597-994b-a79861af8796",
+          "disambiguation": "2011 remastered version",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Withdrawn",
+          "date": "2011-09-26",
+          "status-id": "6a3772de-4605-4132-993d-aa315cd19b4b",
+          "release-events": [
+            {
+              "area": null,
+              "date": "2011-09-26"
+            }
+          ],
+          "quality": "normal",
+          "asin": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 20,
+              "title": "",
+              "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
+              "id": "d47ef3a9-3bdb-389d-bf32-1ddad6625ca0",
+              "format": "Digital Media"
+            }
+          ],
+          "packaging-id": "119eba76-b343-3e02-a292-f0f00644bb9b"
+        },
+        {
+          "quality": "normal",
+          "status": "Official",
+          "date": "2003-03-29",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "area": {
+                "sort-name": "Japan",
+                "name": "Japan",
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "type": null,
+                "type-id": null,
+                "disambiguation": "",
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c"
+              },
+              "date": "2003-03-29"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "asin": "B00008CHEX",
+          "packaging-id": null,
+          "media": [
+            {
+              "format": "Hybrid SACD (CD layer)",
+              "id": "918d851d-26a0-3537-95cd-0be4d8364266",
+              "title": "",
+              "format-id": "1a168dbd-d7ce-381d-a38a-3948de2cb4d6",
+              "track-count": 10,
+              "position": 1
+            },
+            {
+              "format-id": "6c521ee3-f723-41de-bc6b-ec3621b9ffa9",
+              "title": "",
+              "format": "Hybrid SACD (SACD layer, 2 channels)",
+              "id": "3421b48b-8430-366a-a1f6-6fc5c379ee50",
+              "track-count": 10,
+              "position": 2
+            },
+            {
+              "id": "ca5f1a85-8ad6-3f4b-b922-1cbc10d84c6e",
+              "format": "Hybrid SACD (SACD layer, multichannel)",
+              "title": "",
+              "format-id": "fa46fab8-4c29-495a-b2fa-7bc14257dcca",
+              "track-count": 10,
+              "position": 3
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging": null,
+          "id": "3081d6e7-bb1c-3d90-ad1f-4e939582e3c0",
+          "disambiguation": "30th anniversary edition, Japanese with obi and kana text insert",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "artwork": true,
+            "count": 27,
+            "darkened": false
+          },
+          "barcode": "4988006809994",
+          "country": "JP"
+        },
+        {
+          "cover-art-archive": {
+            "count": 14,
+            "artwork": true,
+            "darkened": false,
+            "front": true,
+            "back": true
+          },
+          "country": "US",
+          "barcode": "077774600125",
+          "id": "33078c7e-cc8d-4084-b5b3-09ab5b0e0a74",
+          "disambiguation": "",
+          "packaging": "Jewel Case",
+          "asin": null,
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 9,
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "format": "CD",
+              "id": "e2e5463f-3b16-4269-bba6-60a6b5a0c67f"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "date": "1987",
+          "status": "Official",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "date": "1987",
+              "area": {
+                "disambiguation": "",
+                "type-id": null,
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "name": "United States",
+                "sort-name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "type": null
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "quality": "normal"
+        },
+        {
+          "asin": null,
+          "packaging-id": null,
+          "media": [
+            {
+              "title": "",
+              "format-id": "49b49ca7-d2d8-4d36-a7dd-d61363ee3697",
+              "id": "145f1636-64d9-3c03-acce-131dc15fe8b7",
+              "format": "8-Track Cartridge",
+              "track-count": 10,
+              "position": 1
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "date": "1973",
+          "status": "Official",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "date": "1973",
+              "area": {
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+                "type-id": null,
+                "disambiguation": "",
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "name": "United Kingdom",
+                "sort-name": "United Kingdom",
+                "type": null
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "quality": "normal",
+          "cover-art-archive": {
+            "back": true,
+            "count": 6,
+            "darkened": false,
+            "artwork": true,
+            "front": true
+          },
+          "barcode": "",
+          "country": "GB",
+          "id": "330e4267-eaf9-4d68-8938-146bd427ed0e",
+          "disambiguation": "",
+          "packaging": null
+        },
+        {
+          "id": "35bd2c37-d3d2-34b8-bdf5-5afa0693e4b9",
+          "disambiguation": "",
+          "barcode": "4988006680951",
+          "country": "JP",
+          "cover-art-archive": {
+            "count": 0,
+            "darkened": false,
+            "artwork": false,
+            "front": false,
+            "back": false
+          },
+          "packaging": "Jewel Case",
+          "asin": "B007CDVIXG",
+          "title": "狂気",
+          "media": [
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "id": "e33fbde3-145d-3af8-ba38-32bd3b573a6e",
+              "format": "CD",
+              "track-count": 9,
+              "position": 1
+            }
+          ],
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "quality": "normal",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Official",
+          "date": "1993-04-28",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1993-04-28",
+              "area": {
+                "disambiguation": "",
+                "type-id": null,
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "name": "Japan",
+                "sort-name": "Japan",
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "type": null
+              }
+            }
+          ]
+        },
+        {
+          "packaging": "Cardboard/Paper Sleeve",
+          "cover-art-archive": {
+            "back": false,
+            "front": false,
+            "darkened": false,
+            "count": 1,
+            "artwork": true
+          },
+          "country": "US",
+          "barcode": "07777111631",
+          "id": "3e5ae0f7-f7e2-493b-b1a8-3cf595c06a1d",
+          "disambiguation": "",
+          "status": "Official",
+          "date": "1983",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "area": {
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "sort-name": "United States",
+                "name": "United States",
+                "type": null,
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "type-id": null,
+                "disambiguation": ""
+              },
+              "date": "1983"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "quality": "normal",
+          "asin": null,
+          "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+          "media": [
+            {
+              "format": "12\" Vinyl",
+              "id": "d12bd71b-dfb5-3e70-b30d-9038ebb2591e",
+              "title": "",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "track-count": 10,
+              "position": 1
+            }
+          ],
+          "title": "The Dark Side of the Moon"
+        },
+        {
+          "cover-art-archive": {
+            "front": true,
+            "darkened": false,
+            "count": 1,
+            "artwork": true,
+            "back": false
+          },
+          "barcode": "5099968084158",
+          "country": "XW",
+          "disambiguation": "remastered",
+          "id": "3f15055a-8fcd-435c-b434-19b6caa1e1d6",
+          "packaging": "None",
+          "packaging-id": "119eba76-b343-3e02-a292-f0f00644bb9b",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
+              "title": "",
+              "id": "e30dd6c8-b570-37b2-aa6c-d855a68d3845",
+              "format": "Digital Media"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "asin": null,
+          "release-events": [
+            {
+              "date": "2013",
+              "area": {
+                "sort-name": "[Worldwide]",
+                "name": "[Worldwide]",
+                "iso-3166-1-codes": [
+                  "XW"
+                ],
+                "type": null,
+                "disambiguation": "",
+                "type-id": null,
+                "id": "525d4e18-3d00-31b9-a58b-a146a916de8f"
+              }
+            }
+          ],
+          "status-id": "6a3772de-4605-4132-993d-aa315cd19b4b",
+          "date": "2013",
+          "status": "Withdrawn",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "quality": "normal"
+        },
+        {
+          "packaging": "Gatefold Cover",
+          "country": "YU",
+          "barcode": "",
+          "cover-art-archive": {
+            "count": 6,
+            "darkened": false,
+            "artwork": true,
+            "front": true,
+            "back": true
+          },
+          "id": "3fde611f-de09-46c9-8233-731b3e2ed76f",
+          "disambiguation": "quadraphonic",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "date": "1973",
+          "status": "Official",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1973",
+              "area": {
+                "id": "885dce63-c211-3033-8cf7-46cb82d440c7",
+                "disambiguation": "",
+                "type-id": null,
+                "type": null,
+                "iso-3166-1-codes": [
+                  "YU"
+                ],
+                "iso-3166-3-codes": [
+                  "YUCS"
+                ],
+                "name": "Yugoslavia",
+                "sort-name": "Yugoslavia"
+              }
+            }
+          ],
+          "quality": "normal",
+          "asin": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "id": "7d75e1e5-41de-3b65-ad52-613cfc1a5481",
+              "format": "12\" Vinyl",
+              "title": "",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64"
+            }
+          ],
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202"
+        },
+        {
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Official",
+          "date": "1973",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1973",
+              "area": {
+                "disambiguation": "",
+                "type-id": null,
+                "id": "8524c7d9-f472-3890-a458-f28d5081d9c4",
+                "name": "New Zealand",
+                "sort-name": "New Zealand",
+                "iso-3166-1-codes": [
+                  "NZ"
+                ],
+                "type": null
+              }
+            }
+          ],
+          "quality": "normal",
+          "asin": null,
+          "media": [
+            {
+              "title": "",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "id": "041a5e92-ee58-300a-ae09-ae227645527c",
+              "format": "12\" Vinyl",
+              "position": 1,
+              "track-count": 10
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "packaging": "Gatefold Cover",
+          "country": "NZ",
+          "barcode": "",
+          "cover-art-archive": {
+            "count": 4,
+            "artwork": true,
+            "darkened": false,
+            "front": false,
+            "back": false
+          },
+          "id": "4534f168-c25e-4d84-9da6-4fb26a261640",
+          "disambiguation": ""
+        },
+        {
+          "id": "4f9afe70-3c77-4ad7-a52e-d0e07dc1efcf",
+          "disambiguation": "20th anniversary edition",
+          "barcode": "077778147923",
+          "country": null,
+          "cover-art-archive": {
+            "back": true,
+            "count": 3,
+            "darkened": false,
+            "artwork": true,
+            "front": true
+          },
+          "packaging": "Digipak",
+          "asin": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "format": "CD",
+              "id": "52beab97-9874-4157-9fde-bc466df9ade0",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "track-count": 9,
+              "position": 1
+            }
+          ],
+          "packaging-id": "8f931351-d2e2-310f-afc6-37b89ddba246",
+          "quality": "normal",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "status": "Official",
+          "date": "1993",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1993",
+              "area": null
+            }
+          ]
+        },
+        {
+          "id": "4fef4027-2245-47f9-b102-950f58306d56",
+          "disambiguation": "",
+          "cover-art-archive": {
+            "front": false,
+            "artwork": false,
+            "count": 0,
+            "darkened": false,
+            "back": false
+          },
+          "barcode": "",
+          "country": "GB",
+          "packaging": "Gatefold Cover",
+          "asin": null,
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "title": "",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "format": "12\" Vinyl",
+              "id": "e9f7537f-64a5-345b-a149-0931541f780f"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "quality": "normal",
+          "status": "Official",
+          "date": "1977",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "date": "1977",
+              "area": {
+                "type": null,
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "sort-name": "United Kingdom",
+                "name": "United Kingdom",
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+                "disambiguation": "",
+                "type-id": null
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe"
+        },
+        {
+          "packaging": null,
+          "id": "556e8d5d-6cbc-3292-ba42-3d8408c5977c",
+          "disambiguation": "",
+          "cover-art-archive": {
+            "artwork": true,
+            "count": 4,
+            "darkened": false,
+            "front": true,
+            "back": false
+          },
+          "barcode": "4988006715578",
+          "country": "JP",
+          "quality": "normal",
+          "date": "1996-03-27",
+          "status": "Official",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "area": {
+                "type": null,
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "name": "Japan",
+                "sort-name": "Japan",
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "type-id": null,
+                "disambiguation": ""
+              },
+              "date": "1996-03-27"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "asin": "B000064TUF",
+          "packaging-id": null,
+          "title": "狂気",
+          "media": [
+            {
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "id": "c962dbe7-f838-3280-a5f1-bc1e57cf5edb",
+              "format": "CD",
+              "track-count": 9,
+              "position": 1
+            }
+          ]
+        },
+        {
+          "cover-art-archive": {
+            "artwork": true,
+            "count": 5,
+            "darkened": false,
+            "front": true,
+            "back": false
+          },
+          "barcode": "07777111634",
+          "country": "US",
+          "disambiguation": "",
+          "id": "57a2c82e-d8ea-4733-a5c4-13c114e3a894",
+          "packaging": null,
+          "packaging-id": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "title": "",
+              "format-id": "f5e6e254-8f39-331c-936b-9c69d686dc47",
+              "format": "Cassette",
+              "id": "9ea422e3-7dd7-3fa7-be8d-9112683f4c2e"
+            }
+          ],
+          "asin": null,
+          "release-events": [
+            {
+              "date": "1983",
+              "area": {
+                "type-id": null,
+                "disambiguation": "",
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "type": null,
+                "sort-name": "United States",
+                "name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ]
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "1983",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "quality": "normal"
+        },
+        {
+          "asin": null,
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "format": "CD",
+              "id": "132384eb-b9de-3b3c-ae57-96c7df44474e"
+            }
+          ],
+          "status": "Official",
+          "date": "2013",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "area": {
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+                "type-id": null,
+                "disambiguation": "",
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "name": "Europe",
+                "sort-name": "Europe",
+                "type": null
+              },
+              "date": "2013"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "quality": "normal",
+          "cover-art-archive": {
+            "front": true,
+            "count": 1,
+            "darkened": false,
+            "artwork": true,
+            "back": false
+          },
+          "country": "XE",
+          "barcode": "5099902895529",
+          "id": "586ff28d-c0fc-4a50-ba18-d7152680417d",
+          "disambiguation": "",
+          "packaging": "Gatefold Cover"
+        },
+        {
+          "quality": "normal",
+          "release-events": [
+            {
+              "date": "1993-03-31",
+              "area": {
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "type-id": null,
+                "disambiguation": "",
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "name": "Japan",
+                "sort-name": "Japan",
+                "type": null
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "1993-03-31",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "track-count": 9,
+              "position": 1,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "id": "c28a6419-1f72-3c2e-810e-1fc73ffb8b3f",
+              "format": "CD"
+            }
+          ],
+          "title": "狂気",
+          "asin": "B000UVIP42",
+          "packaging": "Jewel Case",
+          "disambiguation": "20th anniversary edition, made in Japan",
+          "id": "58fd6184-9753-3843-8cee-b79507583298",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "darkened": false,
+            "count": 4,
+            "artwork": true
+          },
+          "barcode": "4988006683129",
+          "country": "JP"
+        },
+        {
+          "disambiguation": "Experience Edition",
+          "id": "5937d458-d92c-4bab-bb4e-17ea1efa8a28",
+          "cover-art-archive": {
+            "darkened": false,
+            "count": 15,
+            "artwork": true,
+            "front": true,
+            "back": true
+          },
+          "barcode": "5099902945323",
+          "country": "US",
+          "packaging": "Cardboard/Paper Sleeve",
+          "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+          "media": [
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "id": "0ffde085-7a60-3752-a38a-16b48036f3b8",
+              "format": "CD",
+              "track-count": 10,
+              "position": 1
+            },
+            {
+              "position": 2,
+              "track-count": 10,
+              "format": "CD",
+              "id": "f1058d71-137b-3f63-88c9-089c92a12cf3",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "Live at The Empire Pool, Wembley, London 1974"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "asin": "B004ZNAGNE",
+          "quality": "normal",
+          "release-events": [
+            {
+              "area": {
+                "disambiguation": "",
+                "type-id": null,
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "type": null,
+                "name": "United States",
+                "sort-name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ]
+              },
+              "date": "2011-09-27"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "2011-09-27",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          }
+        },
+        {
+          "asin": null,
+          "packaging-id": "119eba76-b343-3e02-a292-f0f00644bb9b",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "format": "Digital Media",
+              "id": "6d5c570f-4f39-311b-b299-d12e553aab3e",
+              "title": "",
+              "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794"
+            },
+            {
+              "position": 2,
+              "track-count": 10,
+              "id": "b941eb66-0db6-3a60-ab31-400c1f7ba9c1",
+              "format": "Digital Media",
+              "title": "",
+              "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794"
+            },
+            {
+              "title": "",
+              "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
+              "id": "e01f4903-4acc-3f65-98fb-aca4bad462da",
+              "format": "Digital Media",
+              "position": 3,
+              "track-count": 3
+            },
+            {
+              "track-count": 1,
+              "position": 4,
+              "title": "",
+              "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
+              "format": "Digital Media",
+              "id": "836b26f4-e03d-349e-9947-670364cc94a1"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "quality": "normal",
+          "status": "Withdrawn",
+          "date": "2011-09-26",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "date": "2011-09-26",
+              "area": {
+                "name": "[Worldwide]",
+                "sort-name": "[Worldwide]",
+                "iso-3166-1-codes": [
+                  "XW"
+                ],
+                "type": null,
+                "disambiguation": "",
+                "type-id": null,
+                "id": "525d4e18-3d00-31b9-a58b-a146a916de8f"
+              }
+            }
+          ],
+          "status-id": "6a3772de-4605-4132-993d-aa315cd19b4b",
+          "id": "5eeac1d5-febe-4b81-a98d-ad7577c6562c",
+          "disambiguation": "deluxe experience version",
+          "cover-art-archive": {
+            "darkened": false,
+            "count": 1,
+            "artwork": true,
+            "front": true,
+            "back": false
+          },
+          "barcode": "5099968089252",
+          "country": "XW",
+          "packaging": "None"
+        },
+        {
+          "cover-art-archive": {
+            "back": true,
+            "darkened": false,
+            "count": 15,
+            "artwork": true,
+            "front": true
+          },
+          "country": "DE",
+          "barcode": "",
+          "id": "61288af4-6fdb-42be-b94e-7e7b90258951",
+          "disambiguation": "quadraphonic",
+          "packaging": "Cardboard/Paper Sleeve",
+          "asin": null,
+          "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "title": "",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "format": "12\" Vinyl",
+              "id": "648968d5-3847-3413-a4b7-b8eb55af48bd",
+              "position": 1,
+              "track-count": 10
+            }
+          ],
+          "status": "Official",
+          "date": "1978",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "date": "1978",
+              "area": {
+                "type": null,
+                "name": "Germany",
+                "sort-name": "Germany",
+                "iso-3166-1-codes": [
+                  "DE"
+                ],
+                "type-id": null,
+                "disambiguation": "",
+                "id": "85752fda-13c4-31a3-bee5-0e5cb1f51dad"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "quality": "normal"
+        },
+        {
+          "packaging": "Box",
+          "barcode": "",
+          "country": "US",
+          "cover-art-archive": {
+            "back": true,
+            "count": 20,
+            "artwork": true,
+            "darkened": false,
+            "front": true
+          },
+          "disambiguation": "1979 Mobile Fidelity Sound Lab remaster",
+          "id": "6151d934-4eb2-3b51-8868-c18440b9864d",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "type-id": null,
+                "disambiguation": "",
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "name": "United States",
+                "sort-name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "type": null
+              },
+              "date": "1981"
+            }
+          ],
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "date": "1981",
+          "status": "Official",
+          "quality": "normal",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "title": "",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "id": "e3b44983-1b04-3f47-ba02-014dbfbe212c",
+              "format": "12\" Vinyl",
+              "track-count": 10,
+              "position": 1
+            }
+          ],
+          "packaging-id": "c1668fc7-8944-4a00-bc3e-46e8d861d211",
+          "asin": null
+        },
+        {
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "iso-3166-1-codes": [
+                  "AU"
+                ],
+                "sort-name": "Australia",
+                "name": "Australia",
+                "type": null,
+                "id": "106e0bec-b638-3b37-b731-f53d507dc00e",
+                "disambiguation": "",
+                "type-id": null
+              },
+              "date": "1991-07-22"
+            }
+          ],
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "date": "1991-07-22",
+          "status": "Official",
+          "quality": "normal",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "id": "add790f1-e2f0-3871-a906-9897250f1cc9",
+              "format": "Cassette",
+              "title": "",
+              "format-id": "f5e6e254-8f39-331c-936b-9c69d686dc47",
+              "track-count": 9,
+              "position": 1
+            }
+          ],
+          "packaging-id": "c70b737a-0114-39a9-88f7-82843e54f906",
+          "asin": null,
+          "packaging": "Cassette Case",
+          "barcode": "0077774600149",
+          "country": "AU",
+          "cover-art-archive": {
+            "front": true,
+            "count": 6,
+            "artwork": true,
+            "darkened": false,
+            "back": true
+          },
+          "disambiguation": "",
+          "id": "61f09e6c-b63d-433d-a928-11faeb283081"
+        },
+        {
+          "asin": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "id": "5ee02f38-37a6-4e31-a592-61f3b279c40d",
+              "format": "CD",
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "track-count": 10,
+              "position": 1
+            }
+          ],
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "quality": "normal",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "status": "Official",
+          "date": "2011-09-28",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "type": null,
+                "sort-name": "United States",
+                "name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "disambiguation": "",
+                "type-id": null,
+                "id": "489ce91b-6658-3307-9877-795b68554c98"
+              },
+              "date": "2011-09-28"
+            }
+          ],
+          "id": "63632ed1-964b-47bb-a365-fdef550864d5",
+          "disambiguation": "“Why Pink Floyd...?” Discovery edition",
+          "country": "US",
+          "barcode": "5099902895529",
+          "cover-art-archive": {
+            "count": 0,
+            "darkened": false,
+            "artwork": false,
+            "front": false,
+            "back": false
+          },
+          "packaging": "Gatefold Cover"
+        },
+        {
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1973",
+              "area": {
+                "sort-name": "Italy",
+                "name": "Italy",
+                "iso-3166-1-codes": [
+                  "IT"
+                ],
+                "type": null,
+                "disambiguation": "",
+                "type-id": null,
+                "id": "c6500277-9a3d-349b-bf30-41afdbf42add"
+              }
+            }
+          ],
+          "text-representation": {
+            "language": "eng",
+            "script": null
+          },
+          "status": "Official",
+          "date": "1973",
+          "quality": "normal",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "format": "Cassette",
+              "id": "425a4644-fc9a-3a92-8cca-93118715bdb0",
+              "title": "",
+              "format-id": "f5e6e254-8f39-331c-936b-9c69d686dc47",
+              "track-count": 10,
+              "position": 1
+            }
+          ],
+          "packaging-id": "c70b737a-0114-39a9-88f7-82843e54f906",
+          "asin": null,
+          "packaging": "Cassette Case",
+          "country": "IT",
+          "barcode": "",
+          "cover-art-archive": {
+            "front": true,
+            "darkened": false,
+            "count": 6,
+            "artwork": true,
+            "back": true
+          },
+          "disambiguation": "",
+          "id": "65d67b87-f13a-4f1f-9efa-6d80975921a6"
+        },
+        {
+          "packaging": "Jewel Case",
+          "disambiguation": "",
+          "id": "68e536bc-a621-3d82-b3ba-b6923617a168",
+          "cover-art-archive": {
+            "front": true,
+            "darkened": false,
+            "count": 16,
+            "artwork": true,
+            "back": true
+          },
+          "barcode": "724382975229",
+          "country": "GB",
+          "quality": "normal",
+          "release-events": [
+            {
+              "date": "1994-07-25",
+              "area": {
+                "disambiguation": "",
+                "type-id": null,
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+                "type": null,
+                "name": "United Kingdom",
+                "sort-name": "United Kingdom",
+                "iso-3166-1-codes": [
+                  "GB"
+                ]
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "date": "1994-07-25",
+          "status": "Official",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "track-count": 9,
+              "position": 1,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "format": "CD",
+              "id": "dfe6dcb7-d690-304a-aaed-fc1ab184d29b"
+            }
+          ],
+          "asin": "B000024D4P"
+        },
+        {
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "format": "CD",
+              "id": "37bffb3d-6d04-3cd4-8b8d-c59f66e00ced",
+              "track-count": 9,
+              "position": 1
+            }
+          ],
+          "packaging-id": null,
+          "asin": "B000GUK734",
+          "quality": "normal",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "name": "Japan",
+                "sort-name": "Japan",
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "type": null,
+                "disambiguation": "",
+                "type-id": null,
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c"
+              },
+              "date": "2006-09-06"
+            }
+          ],
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Official",
+          "date": "2006-09-06",
+          "disambiguation": "",
+          "id": "68edcb7b-02d9-3781-9a29-ff59554521f4",
+          "country": "JP",
+          "barcode": "4988006846586",
+          "cover-art-archive": {
+            "back": false,
+            "count": 0,
+            "artwork": false,
+            "darkened": false,
+            "front": false
+          },
+          "packaging": null
+        },
+        {
+          "id": "6ef6e6cd-ad36-4c2f-816d-121bfb2f6774",
+          "disambiguation": "2011 remastered",
+          "cover-art-archive": {
+            "back": false,
+            "darkened": false,
+            "count": 1,
+            "artwork": true,
+            "front": true
+          },
+          "country": "XW",
+          "barcode": "5099968084158",
+          "packaging": "None",
+          "asin": null,
+          "packaging-id": "119eba76-b343-3e02-a292-f0f00644bb9b",
+          "media": [
+            {
+              "id": "0587aea8-4172-3ef6-bc97-7bc7b058493a",
+              "format": "Digital Media",
+              "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
+              "title": "",
+              "track-count": 10,
+              "position": 1
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "quality": "normal",
+          "date": "2011-09-26",
+          "status": "Withdrawn",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "date": "2011-09-26",
+              "area": {
+                "type-id": null,
+                "disambiguation": "",
+                "id": "525d4e18-3d00-31b9-a58b-a146a916de8f",
+                "name": "[Worldwide]",
+                "sort-name": "[Worldwide]",
+                "iso-3166-1-codes": [
+                  "XW"
+                ],
+                "type": null
+              }
+            }
+          ],
+          "status-id": "6a3772de-4605-4132-993d-aa315cd19b4b"
+        },
+        {
+          "packaging": "Gatefold Cover",
+          "id": "6f69054c-cde6-446b-9c0e-fbbefd1197b2",
+          "disambiguation": "",
+          "country": "CA",
+          "barcode": "",
+          "cover-art-archive": {
+            "count": 4,
+            "darkened": false,
+            "artwork": true,
+            "front": true,
+            "back": true
+          },
+          "quality": "normal",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Official",
+          "date": "1973",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "iso-3166-1-codes": [
+                  "CA"
+                ],
+                "name": "Canada",
+                "sort-name": "Canada",
+                "type": null,
+                "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b",
+                "type-id": null,
+                "disambiguation": ""
+              },
+              "date": "1973"
+            }
+          ],
+          "asin": null,
+          "media": [
+            {
+              "id": "b64d63d7-16f8-3583-aac1-9abe098c9eab",
+              "format": "12\" Vinyl",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "title": "",
+              "track-count": 10,
+              "position": 1
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202"
+        },
+        {
+          "packaging": "Cassette Case",
+          "barcode": "077774600149",
+          "country": "US",
+          "cover-art-archive": {
+            "artwork": true,
+            "count": 4,
+            "darkened": false,
+            "front": true,
+            "back": true
+          },
+          "id": "77084e55-c1db-4805-9998-6a03d688e8e2",
+          "disambiguation": "",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Official",
+          "date": "1988",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1988",
+              "area": {
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "disambiguation": "",
+                "type-id": null,
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "sort-name": "United States",
+                "name": "United States",
+                "type": null
+              }
+            }
+          ],
+          "quality": "normal",
+          "asin": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "format": "Cassette",
+              "id": "cd78deda-4b89-3f07-8481-7c4536433954",
+              "title": "",
+              "format-id": "f5e6e254-8f39-331c-936b-9c69d686dc47"
+            }
+          ],
+          "packaging-id": "c70b737a-0114-39a9-88f7-82843e54f906"
+        },
+        {
+          "cover-art-archive": {
+            "front": true,
+            "count": 31,
+            "artwork": true,
+            "darkened": false,
+            "back": true
+          },
+          "country": "CA",
+          "barcode": "077778147923",
+          "disambiguation": "20th anniversary edition, made in Canada",
+          "id": "7cf17389-df89-4605-baee-818bb816ba04",
+          "packaging": "Digipak",
+          "packaging-id": "8f931351-d2e2-310f-afc6-37b89ddba246",
+          "media": [
+            {
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "format": "CD",
+              "id": "4b272e63-8001-355c-843b-fd3f48737048",
+              "position": 1,
+              "track-count": 9
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "asin": null,
+          "release-events": [
+            {
+              "date": "1993",
+              "area": {
+                "type": null,
+                "name": "Canada",
+                "sort-name": "Canada",
+                "iso-3166-1-codes": [
+                  "CA"
+                ],
+                "type-id": null,
+                "disambiguation": "",
+                "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "1993",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "quality": "normal"
+        },
+        {
+          "packaging": "Cardboard/Paper Sleeve",
+          "id": "7d48e73f-b054-4d50-a3fe-e2beaecfdd4f",
+          "disambiguation": "Experience Edition",
+          "country": "GB",
+          "barcode": "5099902945323",
+          "cover-art-archive": {
+            "front": true,
+            "count": 15,
+            "darkened": false,
+            "artwork": true,
+            "back": true
+          },
+          "quality": "normal",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Official",
+          "date": "2011-09-26",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+                "disambiguation": "",
+                "type-id": null,
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "sort-name": "United Kingdom",
+                "name": "United Kingdom",
+                "type": null
+              },
+              "date": "2011-09-26"
+            },
+            {
+              "date": "2011",
+              "area": {
+                "type": null,
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "sort-name": "Europe",
+                "name": "Europe",
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+                "disambiguation": "",
+                "type-id": null
+              }
+            }
+          ],
+          "asin": "B004ZNAGNE",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "format": "CD",
+              "id": "4ddd7e34-a1ac-36f7-a3d9-0fac2c7250d6",
+              "track-count": 10,
+              "position": 1
+            },
+            {
+              "track-count": 10,
+              "position": 2,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "Live at Empire Pool, Wembley, London 1974",
+              "id": "50c82aad-2370-3deb-b194-cc8e389ed6e7",
+              "format": "CD"
+            }
+          ],
+          "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f"
+        },
+        {
+          "packaging": "Jewel Case",
+          "cover-art-archive": {
+            "count": 20,
+            "darkened": false,
+            "artwork": true,
+            "front": true,
+            "back": true
+          },
+          "barcode": "",
+          "country": "JP",
+          "id": "7f6d3088-837d-495e-905f-be5c70ac2d82",
+          "disambiguation": "",
+          "date": "1983-05-21",
+          "status": "Official",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "area": {
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "type-id": null,
+                "disambiguation": "",
+                "type": null,
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "name": "Japan",
+                "sort-name": "Japan"
+              },
+              "date": "1983-05-21"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "quality": "normal",
+          "asin": null,
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "id": "b7e14810-37a3-3d85-82be-ac551c5bd632",
+              "format": "CD",
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "position": 1,
+              "track-count": 9
+            }
+          ]
+        },
+        {
+          "status": "Official",
+          "date": "2011-11-27",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "date": "2011-11-27",
+              "area": {
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "sort-name": "Europe",
+                "name": "Europe",
+                "type": null,
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+                "disambiguation": "",
+                "type-id": null
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "quality": "normal",
+          "asin": null,
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "id": "5f1a853f-bb67-372c-baab-94d86d7e759a",
+              "format": "12\" Vinyl",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "title": ""
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging": "Gatefold Cover",
+          "cover-art-archive": {
+            "back": false,
+            "front": false,
+            "artwork": false,
+            "count": 0,
+            "darkened": false
+          },
+          "country": "XE",
+          "barcode": "5099902987613",
+          "id": "86a0a552-74ec-4a5e-ab8f-bfd9a73af726",
+          "disambiguation": ""
+        },
+        {
+          "packaging": "None",
+          "cover-art-archive": {
+            "front": true,
+            "artwork": true,
+            "count": 1,
+            "darkened": false,
+            "back": false
+          },
+          "barcode": "5099968089252",
+          "country": "XW",
+          "id": "86dedf29-be03-4d8d-98aa-67389f5447c2",
+          "disambiguation": "deluxe experience version, remastered",
+          "status": "Withdrawn",
+          "date": "2013",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "area": {
+                "type": null,
+                "sort-name": "[Worldwide]",
+                "name": "[Worldwide]",
+                "iso-3166-1-codes": [
+                  "XW"
+                ],
+                "disambiguation": "",
+                "type-id": null,
+                "id": "525d4e18-3d00-31b9-a58b-a146a916de8f"
+              },
+              "date": "2013"
+            }
+          ],
+          "status-id": "6a3772de-4605-4132-993d-aa315cd19b4b",
+          "quality": "normal",
+          "asin": null,
+          "packaging-id": "119eba76-b343-3e02-a292-f0f00644bb9b",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "id": "1e473e9d-ea61-3eec-92e8-f1e5fd4c1492",
+              "format": "Digital Media",
+              "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
+              "title": "",
+              "track-count": 10,
+              "position": 1
+            },
+            {
+              "track-count": 10,
+              "position": 2,
+              "format": "Digital Media",
+              "id": "a6485f84-eaa2-380f-a165-08463897b213",
+              "title": "",
+              "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794"
+            },
+            {
+              "position": 3,
+              "track-count": 3,
+              "title": "",
+              "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
+              "format": "Digital Media",
+              "id": "24fdb677-5fda-3b35-b573-f50570a29b42"
+            },
+            {
+              "track-count": 1,
+              "position": 4,
+              "title": "",
+              "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
+              "format": "Digital Media",
+              "id": "5444ff37-10ec-396b-a9d7-54a440cf993b"
+            }
+          ]
+        },
+        {
+          "release-events": [
+            {
+              "area": {
+                "disambiguation": "",
+                "type-id": null,
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "sort-name": "Japan",
+                "name": "Japan",
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "type": null
+              },
+              "date": "1986"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "1986",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "quality": "normal",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 9,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "format": "CD",
+              "id": "e672dd01-faf0-30e5-9580-0aee1073cb8a"
+            }
+          ],
+          "asin": null,
+          "packaging": "Jewel Case",
+          "cover-art-archive": {
+            "artwork": true,
+            "count": 17,
+            "darkened": false,
+            "front": true,
+            "back": true
+          },
+          "barcode": "",
+          "country": "JP",
+          "disambiguation": "TO remastering",
+          "id": "8d17f5db-b9d0-4e35-9a06-9e1bffebc5be"
+        },
+        {
+          "id": "8ede3645-4d20-4ca6-a4e3-4e9179115968",
+          "disambiguation": "quadraphonic",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "count": 5,
+            "darkened": false,
+            "artwork": true
+          },
+          "country": "NZ",
+          "barcode": "",
+          "packaging": "Gatefold Cover",
+          "asin": null,
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "format": "12\" Vinyl",
+              "id": "99910b67-c468-3375-a6e5-b801a5d0a74d",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "title": "",
+              "track-count": 10,
+              "position": 1
+            }
+          ],
+          "quality": "normal",
+          "status": "Official",
+          "date": "1973",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "area": {
+                "id": "8524c7d9-f472-3890-a458-f28d5081d9c4",
+                "type-id": null,
+                "disambiguation": "",
+                "iso-3166-1-codes": [
+                  "NZ"
+                ],
+                "sort-name": "New Zealand",
+                "name": "New Zealand",
+                "type": null
+              },
+              "date": "1973"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe"
+        },
+        {
+          "asin": null,
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 9,
+              "format": "CD",
+              "id": "d6557e96-afaf-3375-83b6-92d13caa0a6d",
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31"
+            }
+          ],
+          "quality": "normal",
+          "status": "Official",
+          "date": "1994",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "area": {
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "type-id": null,
+                "disambiguation": "",
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "name": "United States",
+                "sort-name": "United States",
+                "type": null
+              },
+              "date": "1994"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "id": "93314fd5-5f6e-422b-9ee5-d8daa9945657",
+          "disambiguation": "1992 digital remaster",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "artwork": true,
+            "count": 18,
+            "darkened": false
+          },
+          "barcode": "077774600125",
+          "country": "US",
+          "packaging": "Jewel Case"
+        },
+        {
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "date": "1977",
+          "status": "Official",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "id": "85752fda-13c4-31a3-bee5-0e5cb1f51dad",
+                "disambiguation": "",
+                "type-id": null,
+                "type": null,
+                "iso-3166-1-codes": [
+                  "DE"
+                ],
+                "name": "Germany",
+                "sort-name": "Germany"
+              },
+              "date": "1977"
+            }
+          ],
+          "quality": "normal",
+          "asin": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "title": "",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "format": "12\" Vinyl",
+              "id": "c3fc1d2a-6a7b-3f4b-a5fe-ec50f5040f58",
+              "track-count": 10,
+              "position": 1
+            }
+          ],
+          "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+          "packaging": "Cardboard/Paper Sleeve",
+          "barcode": "",
+          "country": "DE",
+          "cover-art-archive": {
+            "front": true,
+            "darkened": false,
+            "count": 11,
+            "artwork": true,
+            "back": true
+          },
+          "id": "956fbc58-362d-43b8-b880-3779e0508559",
+          "disambiguation": ""
+        },
+        {
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "type": null,
+                "iso-3166-1-codes": [
+                  "CA"
+                ],
+                "name": "Canada",
+                "sort-name": "Canada",
+                "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b",
+                "disambiguation": "",
+                "type-id": null
+              },
+              "date": "2011-09-27"
+            },
+            {
+              "area": {
+                "name": "United States",
+                "sort-name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "type": null,
+                "disambiguation": "",
+                "type-id": null,
+                "id": "489ce91b-6658-3307-9877-795b68554c98"
+              },
+              "date": "2011-09-27"
+            }
+          ],
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Official",
+          "date": "2011-09-27",
+          "quality": "normal",
+          "media": [
+            {
+              "title": "The Original Album, Remastered in 2011",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "id": "354863e7-7f09-39e9-bd3e-e012f3e2a599",
+              "format": "CD",
+              "position": 1,
+              "track-count": 10
+            },
+            {
+              "id": "55660e9f-627c-3b2a-95f7-ec8b736f6f59",
+              "format": "CD",
+              "title": "The Dark Side of the Moon Live at Wembley, 1974",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "track-count": 10,
+              "position": 2
+            },
+            {
+              "position": 3,
+              "track-count": 50,
+              "id": "55e85b74-ca0f-3d31-aaec-3f1289cf0c1c",
+              "format": "DVD",
+              "format-id": "2875c583-4580-3a90-b723-ba1b39921e23",
+              "title": "The Dark Side of the Moon Multi-Channel Audio Mixes"
+            },
+            {
+              "id": "aa7399bf-589c-3873-8ed6-cb0b21c57eb0",
+              "format": "DVD",
+              "title": "Audio-Visual Material",
+              "format-id": "2875c583-4580-3a90-b723-ba1b39921e23",
+              "track-count": 28,
+              "position": 4
+            },
+            {
+              "track-count": 79,
+              "position": 5,
+              "title": "High Resolution Audio and Audio-Visual Material",
+              "format-id": "c693c05b-3316-3d69-afc2-5e2bc455bffc",
+              "format": "Blu-ray",
+              "id": "82fc8811-196e-32fd-8eac-321dcc7db56d"
+            },
+            {
+              "track-count": 16,
+              "position": 6,
+              "format": "CD",
+              "id": "e5f36ae7-7b0d-3793-bf5a-df995b1ee483",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "The Dark Side of the Moon Early Mix (1972)"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": null,
+          "asin": null,
+          "packaging": null,
+          "barcode": "5099902943121",
+          "country": "CA",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "artwork": true,
+            "count": 4,
+            "darkened": false
+          },
+          "disambiguation": "Immersion box set",
+          "id": "96a7097a-1600-405a-a22e-5c02a720fb49"
+        },
+        {
+          "packaging": null,
+          "country": "JP",
+          "barcode": "",
+          "cover-art-archive": {
+            "front": true,
+            "darkened": false,
+            "count": 27,
+            "artwork": true,
+            "back": true
+          },
+          "disambiguation": "",
+          "id": "96f28a60-32ec-4df2-8c71-b9210220783a",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "type-id": null,
+                "disambiguation": "",
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "name": "Japan",
+                "sort-name": "Japan",
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "type": null
+              },
+              "date": "1974"
+            }
+          ],
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "date": "1974",
+          "status": "Official",
+          "quality": "normal",
+          "media": [
+            {
+              "id": "711ac6f7-6b37-3df5-a411-0b3148c270aa",
+              "format": "12\" Vinyl",
+              "title": "",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "position": 1,
+              "track-count": 10
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": null,
+          "asin": null
+        },
+        {
+          "date": "2003",
+          "status": "Official",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "date": "2003",
+              "area": {
+                "name": "United States",
+                "sort-name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "type": null,
+                "disambiguation": "",
+                "type-id": null,
+                "id": "489ce91b-6658-3307-9877-795b68554c98"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "quality": "normal",
+          "asin": null,
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "id": "ff371498-d572-3236-8176-01b8725b5a70",
+              "format": "Hybrid SACD (CD layer)",
+              "format-id": "1a168dbd-d7ce-381d-a38a-3948de2cb4d6",
+              "title": ""
+            },
+            {
+              "position": 2,
+              "track-count": 10,
+              "id": "ff86dc0f-939c-3bfa-ad4d-e686b245d028",
+              "format": "Hybrid SACD (SACD layer, 2 channels)",
+              "title": "",
+              "format-id": "6c521ee3-f723-41de-bc6b-ec3621b9ffa9"
+            },
+            {
+              "position": 3,
+              "track-count": 10,
+              "format": "Hybrid SACD (SACD layer, multichannel)",
+              "id": "518ba074-77f4-36f2-94fc-cb0c26863991",
+              "format-id": "fa46fab8-4c29-495a-b2fa-7bc14257dcca",
+              "title": ""
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging": "Jewel Case",
+          "cover-art-archive": {
+            "back": true,
+            "count": 14,
+            "darkened": false,
+            "artwork": true,
+            "front": true
+          },
+          "country": "US",
+          "barcode": "724358213621",
+          "id": "9a4df5ff-faa2-4e62-8542-dc7684e62bf2",
+          "disambiguation": "30th anniversary edition, printed in the USA, spaced out cat#"
+        },
+        {
+          "asin": null,
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "media": [
+            {
+              "title": "",
+              "format-id": "10e17707-9751-3aaf-95b2-2432acd5374c",
+              "format": "Vinyl",
+              "id": "548c4e4e-2b86-3401-8d58-31bf26c8b1b1",
+              "position": 1,
+              "track-count": 10
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "quality": "normal",
+          "date": "2015",
+          "status": "Bootleg",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "date": "2015",
+              "area": {
+                "type": null,
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "name": "United Kingdom",
+                "sort-name": "United Kingdom",
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+                "disambiguation": "",
+                "type-id": null
+              }
+            }
+          ],
+          "status-id": "1156806e-d06a-38bd-83f0-cf2284a808b9",
+          "id": "9cb98907-c8d6-4c76-8456-63cfa2ef74fd",
+          "disambiguation": "",
+          "cover-art-archive": {
+            "front": true,
+            "count": 1,
+            "darkened": false,
+            "artwork": true,
+            "back": false
+          },
+          "country": "GB",
+          "barcode": null,
+          "packaging": "Gatefold Cover"
+        },
+        {
+          "packaging": null,
+          "id": "9cf0c97d-0cd4-4538-ac8a-4a5fd87ab218",
+          "disambiguation": "",
+          "cover-art-archive": {
+            "back": false,
+            "artwork": true,
+            "count": 1,
+            "darkened": false,
+            "front": true
+          },
+          "country": "RU",
+          "barcode": "077778056621",
+          "quality": "normal",
+          "status": "Bootleg",
+          "date": "2000",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "date": "2000",
+              "area": {
+                "id": "1f1fc3a4-9500-39b8-9f10-f0a465557eef",
+                "disambiguation": "",
+                "type-id": null,
+                "type": null,
+                "iso-3166-1-codes": [
+                  "RU"
+                ],
+                "sort-name": "Russia",
+                "name": "Russia"
+              }
+            }
+          ],
+          "status-id": "1156806e-d06a-38bd-83f0-cf2284a808b9",
+          "asin": null,
+          "packaging-id": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 13,
+              "format": "CD",
+              "id": "1ce4793a-b9c2-3ea0-bdf3-572d6d3c266b",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": ""
+            }
+          ]
+        },
+        {
+          "media": [
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "id": "0d73c968-a15c-3b64-b699-f2c4fca1eb28",
+              "format": "CD",
+              "track-count": 9,
+              "position": 1
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "asin": null,
+          "quality": "normal",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1986",
+              "area": {
+                "type": null,
+                "iso-3166-1-codes": [
+                  "AU"
+                ],
+                "sort-name": "Australia",
+                "name": "Australia",
+                "id": "106e0bec-b638-3b37-b731-f53d507dc00e",
+                "type-id": null,
+                "disambiguation": ""
+              }
+            }
+          ],
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "date": "1986",
+          "status": "Official",
+          "disambiguation": "3rd Australian issue",
+          "id": "9f5b28e3-2e51-4926-abcc-4039e92fe38c",
+          "country": "AU",
+          "barcode": "0077774600125",
+          "cover-art-archive": {
+            "back": false,
+            "artwork": true,
+            "count": 2,
+            "darkened": false,
+            "front": false
+          },
+          "packaging": "Jewel Case"
+        },
+        {
+          "packaging": "Jewel Case",
+          "id": "a0f8ed51-882c-451c-8dbc-31f0daf276f7",
+          "disambiguation": "Ultradisc, 24kt gold plated",
+          "country": "US",
+          "barcode": "015775151727",
+          "cover-art-archive": {
+            "back": true,
+            "darkened": false,
+            "count": 4,
+            "artwork": true,
+            "front": true
+          },
+          "quality": "normal",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Official",
+          "date": "1988",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1988",
+              "area": {
+                "disambiguation": "",
+                "type-id": null,
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "type": null,
+                "name": "United States",
+                "sort-name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ]
+              }
+            }
+          ],
+          "asin": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "format": "CD",
+              "id": "ec30a854-21b3-3c14-a59b-052320d0a846",
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31"
+            }
+          ],
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a"
+        },
+        {
+          "media": [
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "id": "15b6ddc4-d489-3c95-b312-eb201452d86a",
+              "format": "CD",
+              "position": 1,
+              "track-count": 9
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "asin": "B000002U82",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "type": null,
+                "name": "Canada",
+                "sort-name": "Canada",
+                "iso-3166-1-codes": [
+                  "CA"
+                ],
+                "type-id": null,
+                "disambiguation": "",
+                "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b"
+              },
+              "date": "1993"
+            }
+          ],
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "status": "Official",
+          "date": "1993",
+          "quality": "normal",
+          "barcode": "077774600125",
+          "country": "CA",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "artwork": true,
+            "count": 10,
+            "darkened": false
+          },
+          "disambiguation": "",
+          "id": "a1170afd-e95f-3975-ad26-e04c70d6a42b",
+          "packaging": "Jewel Case"
+        },
+        {
+          "packaging": "Other",
+          "country": "BR",
+          "barcode": "5099902945323",
+          "cover-art-archive": {
+            "back": false,
+            "count": 0,
+            "artwork": false,
+            "darkened": false,
+            "front": false
+          },
+          "id": "a2b62291-2981-4409-b024-44d5be206346",
+          "disambiguation": "The Experience Edition",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "status": "Official",
+          "date": "2011",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "type": null,
+                "sort-name": "Brazil",
+                "name": "Brazil",
+                "iso-3166-1-codes": [
+                  "BR"
+                ],
+                "disambiguation": "",
+                "type-id": null,
+                "id": "f45b47f8-5796-386e-b172-6c31b009a5d8"
+              },
+              "date": "2011"
+            }
+          ],
+          "quality": "normal",
+          "asin": null,
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "id": "edde7715-7191-3f22-990b-c266ed54625b",
+              "format": "CD"
+            },
+            {
+              "title": "Live at Empire Pool, Wembley, London 1974",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "format": "CD",
+              "id": "b575edf2-50a4-3a68-9b4a-3cea70ffd6f0",
+              "track-count": 10,
+              "position": 2
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "815b7785-8284-3926-8f04-e48bc6c4d102"
+        },
+        {
+          "id": "a302011c-2b1d-4e55-9ba1-a59646fb1f0b",
+          "disambiguation": "longbox Ultradisc II",
+          "country": "US",
+          "barcode": "015775151727",
+          "cover-art-archive": {
+            "artwork": true,
+            "count": 6,
+            "darkened": false,
+            "front": true,
+            "back": true
+          },
+          "packaging": "Jewel Case",
+          "asin": null,
+          "media": [
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "id": "95d241ac-d531-3fe7-a799-de6bd08370b5",
+              "format": "CD",
+              "position": 1,
+              "track-count": 10
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "quality": "normal",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Official",
+          "date": "1993",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1993",
+              "area": {
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "name": "United States",
+                "sort-name": "United States",
+                "type": null,
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "type-id": null,
+                "disambiguation": ""
+              }
+            }
+          ]
+        },
+        {
+          "asin": null,
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "id": "93463a26-5230-31c8-a9cc-53fefad34661",
+              "format": "CD",
+              "position": 1,
+              "track-count": 9
+            }
+          ],
+          "title": "Dark Side of the Moon",
+          "quality": "normal",
+          "date": "2010",
+          "status": "Official",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "date": "2010",
+              "area": {
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "type-id": null,
+                "disambiguation": "",
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "name": "United States",
+                "sort-name": "United States",
+                "type": null
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "id": "a773d9ee-9930-4bf8-8e79-51a755396e25",
+          "disambiguation": "1992 digital remaster, Pitman pressing",
+          "cover-art-archive": {
+            "back": false,
+            "artwork": false,
+            "count": 0,
+            "darkened": false,
+            "front": false
+          },
+          "barcode": "077774600125",
+          "country": "US",
+          "packaging": "Jewel Case"
+        },
+        {
+          "packaging": null,
+          "barcode": "4988006784161",
+          "country": "JP",
+          "cover-art-archive": {
+            "front": false,
+            "artwork": false,
+            "count": 0,
+            "darkened": false,
+            "back": false
+          },
+          "disambiguation": "",
+          "id": "aaf8e5cb-bd5d-33f9-ac7b-f8e4402070ab",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "2000-08-30",
+              "area": {
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "type-id": null,
+                "disambiguation": "",
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "sort-name": "Japan",
+                "name": "Japan",
+                "type": null
+              }
+            }
+          ],
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "status": "Official",
+          "date": "2000-08-30",
+          "quality": "normal",
+          "media": [
+            {
+              "track-count": 9,
+              "position": 1,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "format": "CD",
+              "id": "7d9d93b7-028a-3215-8746-10a0b496b940"
+            }
+          ],
+          "title": "狂気",
+          "packaging-id": null,
+          "asin": "B00005HK29"
+        },
+        {
+          "asin": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "title": "",
+              "id": "2a3e2797-4140-377a-9c57-de42fa52529a",
+              "format": "12\" Vinyl"
+            }
+          ],
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "date": "1973",
+          "status": "Official",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1973",
+              "area": {
+                "type-id": null,
+                "disambiguation": "",
+                "id": "106e0bec-b638-3b37-b731-f53d507dc00e",
+                "sort-name": "Australia",
+                "name": "Australia",
+                "iso-3166-1-codes": [
+                  "AU"
+                ],
+                "type": null
+              }
+            }
+          ],
+          "quality": "normal",
+          "country": "AU",
+          "barcode": "",
+          "cover-art-archive": {
+            "front": true,
+            "count": 6,
+            "artwork": true,
+            "darkened": false,
+            "back": true
+          },
+          "id": "b02a0c0a-3027-4f26-ba2d-3905f228a0d5",
+          "disambiguation": "first Australian quad release",
+          "packaging": "Gatefold Cover"
+        },
+        {
+          "packaging": "Gatefold Cover",
+          "disambiguation": "",
+          "id": "b437bbe8-8d04-43f7-83a0-8325cc77071a",
+          "cover-art-archive": {
+            "back": false,
+            "front": false,
+            "count": 0,
+            "darkened": false,
+            "artwork": false
+          },
+          "country": "GB",
+          "barcode": "724385567315",
+          "quality": "normal",
+          "release-events": [
+            {
+              "date": "1997-02-14",
+              "area": {
+                "type": null,
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "name": "United Kingdom",
+                "sort-name": "United Kingdom",
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+                "disambiguation": "",
+                "type-id": null
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "1997-02-14",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "title": "",
+              "format": "12\" Vinyl",
+              "id": "a71692d6-360c-359d-9362-9d3d81d29207"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "asin": null
+        },
+        {
+          "packaging": "Gatefold Cover",
+          "disambiguation": "",
+          "id": "b84ee12a-09ef-421b-82de-0441a926375b",
+          "barcode": "",
+          "country": "GB",
+          "cover-art-archive": {
+            "darkened": false,
+            "count": 13,
+            "artwork": true,
+            "front": true,
+            "back": true
+          },
+          "quality": "normal",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "type": null,
+                "sort-name": "United Kingdom",
+                "name": "United Kingdom",
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "disambiguation": "",
+                "type-id": null,
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed"
+              },
+              "date": "1973-03-24"
+            }
+          ],
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "date": "1973-03-24",
+          "status": "Official",
+          "media": [
+            {
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "title": "",
+              "format": "12\" Vinyl",
+              "id": "b1d61283-2ff6-3af7-ba80-25b24f3ba6aa",
+              "track-count": 10,
+              "position": 1
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "asin": null
+        },
+        {
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "title": "",
+              "id": "771a6611-0e91-3b5e-b484-a733ea8a1581",
+              "format": "12\" Vinyl"
+            }
+          ],
+          "asin": null,
+          "release-events": [
+            {
+              "area": {
+                "disambiguation": "",
+                "type-id": null,
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+                "type": null,
+                "name": "United Kingdom",
+                "sort-name": "United Kingdom",
+                "iso-3166-1-codes": [
+                  "GB"
+                ]
+              },
+              "date": "1973-12"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "date": "1973-12",
+          "status": "Official",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "quality": "normal",
+          "cover-art-archive": {
+            "front": true,
+            "count": 18,
+            "darkened": false,
+            "artwork": true,
+            "back": true
+          },
+          "country": "GB",
+          "barcode": "",
+          "disambiguation": "quadraphonic",
+          "id": "b8ee4313-2915-40f1-913d-ac0315b4ba3d",
+          "packaging": "Gatefold Cover"
+        },
+        {
+          "packaging": "Jewel Case",
+          "id": "badcfda9-2ca8-32e5-a68b-c9a3cf807502",
+          "disambiguation": "Ultradisc II",
+          "barcode": "015775151727",
+          "country": "US",
+          "cover-art-archive": {
+            "back": true,
+            "count": 12,
+            "artwork": true,
+            "darkened": false,
+            "front": true
+          },
+          "quality": "normal",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "status": "Official",
+          "date": "1993",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "name": "United States",
+                "sort-name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "type": null,
+                "type-id": null,
+                "disambiguation": "",
+                "id": "489ce91b-6658-3307-9877-795b68554c98"
+              },
+              "date": "1993"
+            }
+          ],
+          "asin": "B000000IRB",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "format": "CD",
+              "id": "87080d81-41ec-3a64-a32d-4f2f46749c38"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a"
+        },
+        {
+          "id": "be455c19-7ee4-4c66-b9c0-044ff6ded837",
+          "disambiguation": "30th anniversary edition, printed in EU, \"Sony DADC\" in matrix",
+          "cover-art-archive": {
+            "back": true,
+            "count": 7,
+            "darkened": false,
+            "artwork": true,
+            "front": true
+          },
+          "country": "XE",
+          "barcode": "724358213621",
+          "packaging": "Jewel Case",
+          "asin": "B00008CLOA",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "format-id": "1a168dbd-d7ce-381d-a38a-3948de2cb4d6",
+              "title": "",
+              "format": "Hybrid SACD (CD layer)",
+              "id": "c6d9a15a-a50b-3a73-8257-4da518695e0b"
+            },
+            {
+              "title": "",
+              "format-id": "6c521ee3-f723-41de-bc6b-ec3621b9ffa9",
+              "id": "da0e1b57-ca84-38fd-aaa4-0d011daec673",
+              "format": "Hybrid SACD (SACD layer, 2 channels)",
+              "track-count": 10,
+              "position": 2
+            },
+            {
+              "track-count": 10,
+              "position": 3,
+              "id": "2bdaeedb-92c8-3bee-b19e-74a467e5e618",
+              "format": "Hybrid SACD (SACD layer, multichannel)",
+              "title": "",
+              "format-id": "fa46fab8-4c29-495a-b2fa-7bc14257dcca"
+            }
+          ],
+          "quality": "normal",
+          "status": "Official",
+          "date": "2007",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "date": "2007",
+              "area": {
+                "name": "Europe",
+                "sort-name": "Europe",
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "type": null,
+                "type-id": null,
+                "disambiguation": "",
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe"
+        },
+        {
+          "release-events": [
+            {
+              "date": "2011-08-17",
+              "area": {
+                "type-id": null,
+                "disambiguation": "",
+                "id": "525d4e18-3d00-31b9-a58b-a146a916de8f",
+                "type": null,
+                "sort-name": "[Worldwide]",
+                "name": "[Worldwide]",
+                "iso-3166-1-codes": [
+                  "XW"
+                ]
+              }
+            }
+          ],
+          "status-id": "1156806e-d06a-38bd-83f0-cf2284a808b9",
+          "status": "Bootleg",
+          "date": "2011-08-17",
+          "text-representation": {
+            "language": null,
+            "script": null
+          },
+          "quality": "normal",
+          "packaging-id": "119eba76-b343-3e02-a292-f0f00644bb9b",
+          "media": [
+            {
+              "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
+              "title": "",
+              "id": "2817c693-2650-3162-9b40-859c0e22b0b1",
+              "format": "Digital Media",
+              "position": 1,
+              "track-count": 9
+            }
+          ],
+          "title": "The Dark Side of the Moon (AudioPhil edition)",
+          "asin": null,
+          "packaging": "None",
+          "cover-art-archive": {
+            "front": true,
+            "darkened": false,
+            "count": 1,
+            "artwork": true,
+            "back": false
+          },
+          "country": "XW",
+          "barcode": "",
+          "disambiguation": "",
+          "id": "be839a57-416d-4a7d-ae07-afcae215371f"
+        },
+        {
+          "release-events": [
+            {
+              "date": "2007",
+              "area": {
+                "type": null,
+                "sort-name": "Europe",
+                "name": "Europe",
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "disambiguation": "",
+                "type-id": null,
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "date": "2007",
+          "status": "Official",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "quality": "normal",
+          "packaging-id": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "id": "17ca41dc-396b-4cc6-883a-8c5f6feeb8b2",
+              "format": "CD",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": ""
+            }
+          ],
+          "asin": null,
+          "packaging": null,
+          "cover-art-archive": {
+            "back": true,
+            "darkened": false,
+            "count": 5,
+            "artwork": true,
+            "front": true
+          },
+          "country": "XE",
+          "barcode": null,
+          "disambiguation": "",
+          "id": "bf774f1d-1379-4ed4-81f2-c28d99fac037"
+        },
+        {
+          "quality": "normal",
+          "status": "Bootleg",
+          "date": "1998",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "date": "1998",
+              "area": {
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "type-id": null,
+                "disambiguation": "",
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "name": "Japan",
+                "sort-name": "Japan",
+                "type": null
+              }
+            }
+          ],
+          "status-id": "1156806e-d06a-38bd-83f0-cf2284a808b9",
+          "asin": null,
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "Quadrophonic Tracks \\ Abbey Road Rehearsal",
+              "format": "CD",
+              "id": "fea08194-acd6-3280-89de-1d0964e12cd6",
+              "position": 1,
+              "track-count": 14
+            },
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "Alternate Remix",
+              "format": "CD",
+              "id": "f5de2542-6f97-3a25-8f7b-cb899b89d8ef",
+              "position": 2,
+              "track-count": 14
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging": "Jewel Case",
+          "id": "c0f74d5a-7534-414d-8b90-0ebe6c5da19e",
+          "disambiguation": "",
+          "cover-art-archive": {
+            "back": true,
+            "count": 10,
+            "artwork": true,
+            "darkened": false,
+            "front": true
+          },
+          "barcode": "6981216689750",
+          "country": "JP"
+        },
+        {
+          "asin": null,
+          "title": "Dark Side of the Moon",
+          "media": [
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "format": "CD",
+              "id": "48bb6a2a-8ada-3a53-9fe6-b53f7c1b806c",
+              "track-count": 9,
+              "position": 1
+            }
+          ],
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "date": "1994-07-25",
+          "status": "Official",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1994-07-25",
+              "area": {
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "sort-name": "United Kingdom",
+                "name": "United Kingdom",
+                "type": null,
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+                "disambiguation": "",
+                "type-id": null
+              }
+            },
+            {
+              "area": {
+                "type-id": null,
+                "disambiguation": "",
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+                "name": "Europe",
+                "sort-name": "Europe",
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "type": null
+              },
+              "date": "1994-08"
+            }
+          ],
+          "quality": "normal",
+          "country": "GB",
+          "barcode": "724382975229",
+          "cover-art-archive": {
+            "front": true,
+            "count": 18,
+            "darkened": false,
+            "artwork": true,
+            "back": true
+          },
+          "id": "c712a2bc-1e57-46c1-9432-8b9a33dc4159",
+          "disambiguation": "",
+          "packaging": "Jewel Case"
+        },
+        {
+          "asin": null,
+          "packaging-id": "815b7785-8284-3926-8f04-e48bc6c4d102",
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "id": "3fcdc162-c818-351e-a9b1-db45a1d39b2e",
+              "format": "CD",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": ""
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "date": "2014-01-29",
+          "status": "Official",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "date": "2014-01-29",
+              "area": {
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "sort-name": "Japan",
+                "name": "Japan",
+                "type": null,
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "type-id": null,
+                "disambiguation": ""
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "quality": "normal",
+          "cover-art-archive": {
+            "back": false,
+            "count": 1,
+            "artwork": true,
+            "darkened": false,
+            "front": true
+          },
+          "barcode": "4943674164493",
+          "country": "JP",
+          "id": "c7530927-8de6-40a8-95c4-b36e860abe41",
+          "disambiguation": "Forever Young Campaign 2014",
+          "packaging": "Other"
+        },
+        {
+          "asin": null,
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "format-id": "10e17707-9751-3aaf-95b2-2432acd5374c",
+              "title": "",
+              "id": "962bab3d-81a8-33db-bda4-b345e90cca70",
+              "format": "Vinyl"
+            }
+          ],
+          "quality": "normal",
+          "date": "2003",
+          "status": "Official",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "date": "2003",
+              "area": {
+                "type": null,
+                "name": "United Kingdom",
+                "sort-name": "United Kingdom",
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "type-id": null,
+                "disambiguation": "",
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "id": "c7bb40b0-ec9e-36bd-a35e-8495243e288b",
+          "disambiguation": "30th anniversary edition",
+          "cover-art-archive": {
+            "count": 9,
+            "darkened": false,
+            "artwork": true,
+            "front": true,
+            "back": true
+          },
+          "barcode": "724358213614",
+          "country": "GB",
+          "packaging": "Gatefold Cover"
+        },
+        {
+          "quality": "normal",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "sort-name": "Japan",
+                "name": "Japan",
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "type": null,
+                "disambiguation": "",
+                "type-id": null,
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c"
+              },
+              "date": "1988-12-21"
+            }
+          ],
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "date": "1988-12-21",
+          "status": "Official",
+          "media": [
+            {
+              "format": "CD",
+              "id": "47a89e2e-c601-3533-928a-9dc64a150503",
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "track-count": 9,
+              "position": 1
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": null,
+          "asin": "B005FHO6E4",
+          "packaging": null,
+          "disambiguation": "",
+          "id": "c8050a51-9716-40b0-924e-82843164d81c",
+          "country": "JP",
+          "barcode": "4988006628977",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "count": 7,
+            "artwork": true,
+            "darkened": false
+          }
+        },
+        {
+          "date": "2003",
+          "status": "Bootleg",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "date": "2003",
+              "area": {
+                "disambiguation": "",
+                "type-id": null,
+                "id": "312bc5bb-7e43-3e63-81c6-b4d712b37b2c",
+                "sort-name": "Hungary",
+                "name": "Hungary",
+                "iso-3166-1-codes": [
+                  "HU"
+                ],
+                "type": null
+              }
+            }
+          ],
+          "status-id": "1156806e-d06a-38bd-83f0-cf2284a808b9",
+          "quality": "normal",
+          "asin": null,
+          "packaging-id": null,
+          "media": [
+            {
+              "track-count": 13,
+              "position": 1,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "id": "6d6657aa-42b5-360e-9d13-3b3d2df8ca62",
+              "format": "CD"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging": null,
+          "cover-art-archive": {
+            "back": false,
+            "front": false,
+            "count": 0,
+            "darkened": false,
+            "artwork": false
+          },
+          "country": "HU",
+          "barcode": "5998490700126",
+          "id": "cbaebadf-ba04-4bf8-a9b7-4c90caebd05f",
+          "disambiguation": ""
+        },
+        {
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1993",
+              "area": {
+                "type-id": null,
+                "disambiguation": "",
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "sort-name": "United States",
+                "name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "type": null
+              }
+            }
+          ],
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "date": "1993",
+          "status": "Official",
+          "quality": "normal",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "format": "CD",
+              "id": "429ccf7b-0e2a-35e6-9bbb-be16491df94d",
+              "position": 1,
+              "track-count": 10
+            }
+          ],
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "asin": null,
+          "packaging": "Jewel Case",
+          "barcode": "015775151727",
+          "country": "US",
+          "cover-art-archive": {
+            "count": 4,
+            "artwork": true,
+            "darkened": false,
+            "front": true,
+            "back": true
+          },
+          "disambiguation": "longbox Ultradisc II",
+          "id": "d060c05f-1b72-458d-9147-90047550e31a"
+        },
+        {
+          "quality": "normal",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "disambiguation": "",
+                "type-id": null,
+                "id": "ef1b7cc0-cd26-36f4-8ea0-04d9623786c7",
+                "type": null,
+                "name": "Netherlands",
+                "sort-name": "Netherlands",
+                "iso-3166-1-codes": [
+                  "NL"
+                ]
+              },
+              "date": "1993"
+            }
+          ],
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "status": "Official",
+          "date": "1993",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "track-count": 9,
+              "position": 1,
+              "id": "9363ef71-99fb-3151-aabf-21a563f40c47",
+              "format": "CD",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": ""
+            }
+          ],
+          "packaging-id": "8f931351-d2e2-310f-afc6-37b89ddba246",
+          "asin": null,
+          "packaging": "Digipak",
+          "disambiguation": "20th anniversary edition, made in Holland",
+          "id": "d36ec77b-13b3-4fdf-bdc4-235a07cd7e6f",
+          "country": "NL",
+          "barcode": "077778147923",
+          "cover-art-archive": {
+            "front": true,
+            "count": 22,
+            "darkened": false,
+            "artwork": true,
+            "back": true
+          }
+        },
+        {
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "format": "12\" Vinyl",
+              "id": "e3adc6dc-098f-3dfc-9f57-2c1b30cf63b4",
+              "title": "",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "asin": null,
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1973",
+              "area": {
+                "type": null,
+                "sort-name": "Mozambique",
+                "name": "Mozambique",
+                "iso-3166-1-codes": [
+                  "MZ"
+                ],
+                "disambiguation": "",
+                "type-id": null,
+                "id": "325ce9a0-d58f-3564-b24e-647b33098767"
+              }
+            }
+          ],
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "date": "1973",
+          "status": "Official",
+          "quality": "normal",
+          "barcode": "",
+          "country": "MZ",
+          "cover-art-archive": {
+            "artwork": false,
+            "count": 0,
+            "darkened": false,
+            "front": false,
+            "back": false
+          },
+          "disambiguation": "",
+          "id": "d48328c9-8dd2-49ee-afd3-77b569f66205",
+          "packaging": "Gatefold Cover"
+        },
+        {
+          "disambiguation": "",
+          "id": "d5088e04-945d-3332-b752-26a40c7e7754",
+          "country": "JP",
+          "barcode": "4988006641594",
+          "cover-art-archive": {
+            "back": true,
+            "count": 5,
+            "artwork": true,
+            "darkened": false,
+            "front": true
+          },
+          "packaging": "Jewel Case",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "format": "CD",
+              "id": "6da2c68b-388e-3b04-8545-a12d54f67c66",
+              "track-count": 9,
+              "position": 1
+            }
+          ],
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "asin": "B00C5IPVGS",
+          "quality": "normal",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "name": "Japan",
+                "sort-name": "Japan",
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "type": null,
+                "type-id": null,
+                "disambiguation": "",
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c"
+              },
+              "date": "1986"
+            }
+          ],
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "date": "1986",
+          "status": "Official"
+        },
+        {
+          "packaging": null,
+          "id": "d78ce42f-3a88-39fb-80d2-2d22bea0d358",
+          "disambiguation": "",
+          "barcode": "4988006840751",
+          "country": "JP",
+          "cover-art-archive": {
+            "back": false,
+            "artwork": false,
+            "count": 0,
+            "darkened": false,
+            "front": false
+          },
+          "quality": "normal",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "date": "2006-03-08",
+          "status": "Official",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "2006-03-08",
+              "area": {
+                "sort-name": "Japan",
+                "name": "Japan",
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "type": null,
+                "disambiguation": "",
+                "type-id": null,
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c"
+              }
+            }
+          ],
+          "asin": "B000E6G6KI",
+          "media": [
+            {
+              "track-count": 9,
+              "position": 1,
+              "format": "CD",
+              "id": "9ffacadd-872e-32ec-b856-7595e128e54a",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": ""
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": null
+        },
+        {
+          "id": "d800f372-9673-4edf-8046-8baf79134257",
+          "disambiguation": "Ultradisc",
+          "cover-art-archive": {
+            "front": true,
+            "artwork": true,
+            "count": 8,
+            "darkened": false,
+            "back": true
+          },
+          "country": "JP",
+          "barcode": "015775151727",
+          "packaging": "Jewel Case",
+          "asin": null,
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "id": "fd0f60ad-1df0-3cc5-a9ef-4dc50618ae5a",
+              "format": "CD",
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "position": 1,
+              "track-count": 10
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "quality": "normal",
+          "date": "1988",
+          "status": "Official",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "release-events": [
+            {
+              "area": {
+                "type": null,
+                "name": "Japan",
+                "sort-name": "Japan",
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "type-id": null,
+                "disambiguation": "",
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c"
+              },
+              "date": "1988"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe"
+        },
+        {
+          "packaging": "Snap Case",
+          "id": "d82cb4cf-929d-4b18-af5b-77d9478b606c",
+          "disambiguation": "experience version",
+          "barcode": "4988006887466",
+          "country": "JP",
+          "cover-art-archive": {
+            "back": true,
+            "artwork": true,
+            "count": 8,
+            "darkened": false,
+            "front": true
+          },
+          "quality": "normal",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "date": "2011-09-28",
+          "status": "Official",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "2011-09-28",
+              "area": {
+                "type": null,
+                "iso-3166-1-codes": [
+                  "JP"
+                ],
+                "sort-name": "Japan",
+                "name": "Japan",
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "disambiguation": "",
+                "type-id": null
+              }
+            }
+          ],
+          "asin": null,
+          "media": [
+            {
+              "id": "1b491cf2-84d3-3dc1-86f1-2075ef318007",
+              "format": "CD",
+              "title": "The Original Album",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "position": 1,
+              "track-count": 10
+            },
+            {
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "Live at the Empire Pool, Wembley, London 1974",
+              "id": "e9e7fc79-0360-3077-a521-4a025084250b",
+              "format": "CD",
+              "position": 2,
+              "track-count": 10
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "935f2847-8083-3422-8f0d-d7516fcda682"
+        },
+        {
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "format-id": "1a168dbd-d7ce-381d-a38a-3948de2cb4d6",
+              "title": "",
+              "format": "Hybrid SACD (CD layer)",
+              "id": "b04898c7-06a8-3ff4-ace6-581f8ad842e2",
+              "track-count": 10,
+              "position": 1
+            },
+            {
+              "position": 2,
+              "track-count": 10,
+              "format-id": "6c521ee3-f723-41de-bc6b-ec3621b9ffa9",
+              "title": "",
+              "id": "47f7934d-e5b3-35d0-9fe6-f869f36c325a",
+              "format": "Hybrid SACD (SACD layer, 2 channels)"
+            },
+            {
+              "id": "d8721252-3ccd-3f33-82b0-1189fe990fb8",
+              "format": "Hybrid SACD (SACD layer, multichannel)",
+              "format-id": "fa46fab8-4c29-495a-b2fa-7bc14257dcca",
+              "title": "",
+              "track-count": 10,
+              "position": 3
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "asin": null,
+          "release-events": [
+            {
+              "area": {
+                "type": null,
+                "sort-name": "United States",
+                "name": "United States",
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "disambiguation": "",
+                "type-id": null,
+                "id": "489ce91b-6658-3307-9877-795b68554c98"
+              },
+              "date": "2003-03-25"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "2003-03-25",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "quality": "normal",
+          "cover-art-archive": {
+            "back": true,
+            "artwork": true,
+            "count": 17,
+            "darkened": false,
+            "front": true
+          },
+          "barcode": "724358213621",
+          "country": "US",
+          "disambiguation": "30th anniversary edition, printed in the usa, compact cat# with \"-US\"",
+          "id": "df8fe008-36fa-332d-bca2-8b1c745c09ad",
+          "packaging": "Jewel Case"
+        },
+        {
+          "release-events": [
+            {
+              "date": "1986-05",
+              "area": {
+                "name": "United Kingdom",
+                "sort-name": "United Kingdom",
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "type": null,
+                "disambiguation": "",
+                "type-id": null,
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "1986-05",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "quality": "normal",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "format": "CD",
+              "id": "84497d41-374a-38f6-b69e-f47a24f4821f",
+              "position": 1,
+              "track-count": 9
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "asin": "B000002U82",
+          "packaging": "Jewel Case",
+          "cover-art-archive": {
+            "darkened": false,
+            "count": 11,
+            "artwork": true,
+            "front": true,
+            "back": true
+          },
+          "country": "GB",
+          "barcode": "",
+          "disambiguation": "no barcode; on the CD: Made in U.K.",
+          "id": "dfd839f7-4741-36cf-af82-a1a1e797714e"
+        },
+        {
+          "id": "e1464abb-80ee-402f-9c49-aed3f73003f0",
+          "disambiguation": "made in Japan",
+          "barcode": "077774600125",
+          "country": "US",
+          "cover-art-archive": {
+            "front": true,
+            "artwork": true,
+            "count": 3,
+            "darkened": false,
+            "back": true
+          },
+          "packaging": "Jewel Case",
+          "asin": null,
+          "media": [
+            {
+              "format": "CD",
+              "id": "3a545e4d-58c2-3c39-9bd0-d4a8f5077e85",
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "track-count": 9,
+              "position": 1
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "quality": "normal",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "date": "1984",
+          "status": "Official",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "name": "United States",
+                "sort-name": "United States",
+                "type": null,
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "disambiguation": "",
+                "type-id": null
+              },
+              "date": "1984"
+            }
+          ]
+        },
+        {
+          "quality": "normal",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "status": "Official",
+          "date": "1973",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1973",
+              "area": {
+                "id": "08310658-51eb-3801-80de-5a0739207115",
+                "type-id": null,
+                "disambiguation": "",
+                "iso-3166-1-codes": [
+                  "FR"
+                ],
+                "sort-name": "France",
+                "name": "France",
+                "type": null
+              }
+            }
+          ],
+          "asin": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "id": "7ca0a8f2-3afd-3286-821c-8492bc9baa83",
+              "format": "12\" Vinyl",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "title": ""
+            }
+          ],
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "packaging": "Gatefold Cover",
+          "id": "e2958fed-eb3d-43e4-a824-65ba7995b80f",
+          "disambiguation": "",
+          "country": "FR",
+          "barcode": "",
+          "cover-art-archive": {
+            "darkened": false,
+            "count": 0,
+            "artwork": false,
+            "front": false,
+            "back": false
+          }
+        },
+        {
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "date": "2013",
+          "status": "Official",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+                "disambiguation": "",
+                "type-id": null,
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "sort-name": "Europe",
+                "name": "Europe",
+                "type": null
+              },
+              "date": "2013"
+            }
+          ],
+          "quality": "normal",
+          "asin": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "title": "",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "format": "12\" Vinyl",
+              "id": "2aaea9f3-990f-3b54-ab6c-b3666ffadf52"
+            }
+          ],
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "packaging": "Gatefold Cover",
+          "country": "XE",
+          "barcode": "5099902987613",
+          "cover-art-archive": {
+            "front": true,
+            "artwork": true,
+            "count": 15,
+            "darkened": false,
+            "back": true
+          },
+          "id": "e541eddf-7c4f-4b7c-a7cd-557f7b19f27a",
+          "disambiguation": "40th anniversary edition"
+        },
+        {
+          "quality": "normal",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "date": "2003",
+          "status": "Withdrawn",
+          "status-id": "6a3772de-4605-4132-993d-aa315cd19b4b",
+          "release-events": [
+            {
+              "area": {
+                "type": null,
+                "sort-name": "United Kingdom",
+                "name": "United Kingdom",
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "disambiguation": "",
+                "type-id": null,
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed"
+              },
+              "date": "2003"
+            }
+          ],
+          "asin": null,
+          "media": [
+            {
+              "position": 1,
+              "track-count": 10,
+              "id": "8c46341e-570d-3407-83c9-820ab42be2d0",
+              "format": "Digital Media",
+              "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
+              "title": ""
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "119eba76-b343-3e02-a292-f0f00644bb9b",
+          "packaging": "None",
+          "id": "e54fa99c-e11f-44f7-a834-a497b63a71a5",
+          "disambiguation": "",
+          "country": "GB",
+          "barcode": null,
+          "cover-art-archive": {
+            "back": false,
+            "artwork": true,
+            "count": 1,
+            "darkened": false,
+            "front": true
+          }
+        },
+        {
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "track-count": 9,
+              "position": 1,
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "format": "CD",
+              "id": "a497cc1a-4437-3fca-ab8a-7ba66a3d01fb"
+            }
+          ],
+          "asin": "B000002U82",
+          "release-events": [
+            {
+              "area": {
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "disambiguation": "",
+                "type-id": null,
+                "type": null,
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "name": "United States",
+                "sort-name": "United States"
+              },
+              "date": "1985"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "date": "1985",
+          "status": "Official",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "quality": "normal",
+          "cover-art-archive": {
+            "front": true,
+            "count": 10,
+            "artwork": true,
+            "darkened": false,
+            "back": true
+          },
+          "country": "US",
+          "barcode": "077774600125",
+          "disambiguation": "CAPITOL JAX",
+          "id": "e9216a3b-ee97-3464-88e3-887796c2c29b",
+          "packaging": "Jewel Case"
+        },
+        {
+          "packaging": "Jewel Case",
+          "disambiguation": "",
+          "id": "e92282b9-8963-4362-87b3-bbc990d40360",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "count": 5,
+            "darkened": false,
+            "artwork": true
+          },
+          "country": "US",
+          "barcode": "077774600125",
+          "quality": "normal",
+          "release-events": [
+            {
+              "date": "1993",
+              "area": {
+                "id": "489ce91b-6658-3307-9877-795b68554c98",
+                "disambiguation": "",
+                "type-id": null,
+                "iso-3166-1-codes": [
+                  "US"
+                ],
+                "sort-name": "United States",
+                "name": "United States",
+                "type": null
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "1993",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 9,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "format": "CD",
+              "id": "303fecf8-103b-3b4c-a844-700a2cbfe2e6"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "asin": "B000002U82"
+        },
+        {
+          "cover-art-archive": {
+            "back": false,
+            "front": false,
+            "count": 0,
+            "darkened": false,
+            "artwork": false
+          },
+          "barcode": "724382975229",
+          "country": "AU",
+          "id": "ee8122c5-237c-4b43-bc18-6e71b0fe3266",
+          "disambiguation": "",
+          "packaging": "Jewel Case",
+          "asin": null,
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "title": "",
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "id": "5ca68370-6f3a-48bb-89c9-71e5afccd01d",
+              "format": "CD",
+              "track-count": 9,
+              "position": 1
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "status": "Official",
+          "date": "1994",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "release-events": [
+            {
+              "area": {
+                "name": "Australia",
+                "sort-name": "Australia",
+                "iso-3166-1-codes": [
+                  "AU"
+                ],
+                "type": null,
+                "type-id": null,
+                "disambiguation": "",
+                "id": "106e0bec-b638-3b37-b731-f53d507dc00e"
+              },
+              "date": "1994"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "quality": "normal"
+        },
+        {
+          "barcode": "",
+          "country": "FR",
+          "cover-art-archive": {
+            "back": false,
+            "front": false,
+            "count": 0,
+            "artwork": false,
+            "darkened": false
+          },
+          "disambiguation": "",
+          "id": "ef6aff99-9a42-4dd6-b2db-c0e51bddb52c",
+          "packaging": "Gatefold Cover",
+          "media": [
+            {
+              "format": "12\" Vinyl",
+              "id": "113e48d1-cd7e-3acb-9d7c-5393c9093ff5",
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "title": "",
+              "position": 1,
+              "track-count": 10
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "asin": null,
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "area": {
+                "type": null,
+                "name": "France",
+                "sort-name": "France",
+                "iso-3166-1-codes": [
+                  "FR"
+                ],
+                "type-id": null,
+                "disambiguation": "",
+                "id": "08310658-51eb-3801-80de-5a0739207115"
+              },
+              "date": "1973"
+            }
+          ],
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "date": "1973",
+          "status": "Official",
+          "quality": "normal"
+        },
+        {
+          "packaging": "Jewel Case",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "count": 16,
+            "artwork": true,
+            "darkened": false
+          },
+          "barcode": "724382975229",
+          "country": "GB",
+          "disambiguation": "“made in Italy” on CD, “printed in Italy” on rear",
+          "id": "fc07d51d-8b86-30d4-b70f-452fe7dcb13c",
+          "release-events": [
+            {
+              "date": "1994-07-25",
+              "area": {
+                "type-id": null,
+                "disambiguation": "",
+                "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+                "name": "United Kingdom",
+                "sort-name": "United Kingdom",
+                "iso-3166-1-codes": [
+                  "GB"
+                ],
+                "type": null
+              }
+            },
+            {
+              "area": {
+                "iso-3166-1-codes": [
+                  "XE"
+                ],
+                "name": "Europe",
+                "sort-name": "Europe",
+                "type": null,
+                "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+                "disambiguation": "",
+                "type-id": null
+              },
+              "date": "1994"
+            },
+            {
+              "date": "1994",
+              "area": {
+                "id": "c6500277-9a3d-349b-bf30-41afdbf42add",
+                "disambiguation": "",
+                "type-id": null,
+                "type": null,
+                "iso-3166-1-codes": [
+                  "IT"
+                ],
+                "sort-name": "Italy",
+                "name": "Italy"
+              }
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "date": "1994-07-25",
+          "status": "Official",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "quality": "normal",
+          "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+          "media": [
+            {
+              "position": 1,
+              "track-count": 9,
+              "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+              "title": "",
+              "format": "CD",
+              "id": "d2d5e4f8-85e5-3941-85a0-de1cbf2715d6"
+            }
+          ],
+          "title": "The Dark Side of the Moon",
+          "asin": "B000024D4P"
+        },
+        {
+          "asin": null,
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "track-count": 10,
+              "position": 1,
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "title": "",
+              "id": "e29bf803-06a5-38ab-bf8e-7fd75573b5ec",
+              "format": "12\" Vinyl"
+            }
+          ],
+          "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+          "quality": "normal",
+          "text-representation": {
+            "script": "Latn",
+            "language": "eng"
+          },
+          "status": "Official",
+          "date": "1973",
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "release-events": [
+            {
+              "date": "1973",
+              "area": {
+                "type-id": null,
+                "disambiguation": "",
+                "id": "85752fda-13c4-31a3-bee5-0e5cb1f51dad",
+                "name": "Germany",
+                "sort-name": "Germany",
+                "iso-3166-1-codes": [
+                  "DE"
+                ],
+                "type": null
+              }
+            }
+          ],
+          "id": "fc941a7d-eb66-4f5d-aa14-01857f997168",
+          "disambiguation": "",
+          "barcode": "",
+          "country": "DE",
+          "cover-art-archive": {
+            "back": true,
+            "front": true,
+            "count": 6,
+            "darkened": false,
+            "artwork": true
+          },
+          "packaging": "Gatefold Cover"
+        },
+        {
+          "packaging": "Cardboard/Paper Sleeve",
+          "cover-art-archive": {
+            "front": true,
+            "count": 35,
+            "darkened": false,
+            "artwork": true,
+            "back": true
+          },
+          "barcode": "",
+          "country": "JP",
+          "disambiguation": "",
+          "id": "fd7d8f8e-c894-4088-a7b4-4a66057f41ee",
+          "release-events": [
+            {
+              "area": {
+                "disambiguation": "",
+                "type-id": null,
+                "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+                "type": null,
+                "sort-name": "Japan",
+                "name": "Japan",
+                "iso-3166-1-codes": [
+                  "JP"
+                ]
+              },
+              "date": "1973"
+            }
+          ],
+          "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+          "status": "Official",
+          "date": "1973",
+          "text-representation": {
+            "language": "eng",
+            "script": "Latn"
+          },
+          "quality": "normal",
+          "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+          "title": "The Dark Side of the Moon",
+          "media": [
+            {
+              "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+              "title": "",
+              "format": "12\" Vinyl",
+              "id": "ccc0a746-99ba-33c4-a2c0-159e1cd2d462",
+              "position": 1,
+              "track-count": 10
+            }
+          ],
+          "asin": null
+        }
+      ],
+      "release-count": 147
+    }
+  }
+}

--- a/packages/downloader/test/contract/fixtures/musicbrainz/release-group-lookup.json
+++ b/packages/downloader/test/contract/fixtures/musicbrainz/release-group-lookup.json
@@ -1,0 +1,537 @@
+{
+  "provenance": {
+    "source": "https://musicbrainz.org/ws/2 (live)",
+    "capturedAt": "2026-07-22",
+    "note": "public data; no sanitization"
+  },
+  "request": {
+    "method": "GET",
+    "path": "/release/b84ee12a-09ef-421b-82de-0441a926375b",
+    "query": {
+      "inc": "recordings artist-credits",
+      "fmt": "json"
+    }
+  },
+  "response": {
+    "status": 200,
+    "body": {
+      "id": "b84ee12a-09ef-421b-82de-0441a926375b",
+      "disambiguation": "",
+      "barcode": "",
+      "country": "GB",
+      "cover-art-archive": {
+        "darkened": false,
+        "count": 13,
+        "artwork": true,
+        "front": true,
+        "back": true
+      },
+      "packaging": "Gatefold Cover",
+      "asin": null,
+      "media": [
+        {
+          "position": 1,
+          "tracks": [
+            {
+              "length": 68346,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "country": "GB",
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "disambiguation": "",
+                    "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                    "name": "Pink Floyd",
+                    "sort-name": "Pink Floyd",
+                    "type": "Group"
+                  },
+                  "joinphrase": "",
+                  "name": "Pink Floyd"
+                }
+              ],
+              "recording": {
+                "length": 68346,
+                "artist-credit": [
+                  {
+                    "name": "Pink Floyd",
+                    "joinphrase": "",
+                    "artist": {
+                      "sort-name": "Pink Floyd",
+                      "name": "Pink Floyd",
+                      "type": "Group",
+                      "country": "GB",
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                      "disambiguation": "",
+                      "id": "83d91898-7763-47d7-b03b-b92132375c47"
+                    }
+                  }
+                ],
+                "id": "bef3fddb-5aca-49f5-b2fd-d56a23268d63",
+                "disambiguation": "original stereo mix",
+                "title": "Speak to Me",
+                "video": false,
+                "first-release-date": "1973-03-24"
+              },
+              "number": "A1",
+              "position": 1,
+              "title": "Speak to Me",
+              "id": "d4156411-b884-368f-a4cb-7c0101a557a2"
+            },
+            {
+              "number": "A2",
+              "position": 2,
+              "length": 168720,
+              "artist-credit": [
+                {
+                  "name": "Pink Floyd",
+                  "artist": {
+                    "type": "Group",
+                    "name": "Pink Floyd",
+                    "sort-name": "Pink Floyd",
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "disambiguation": "",
+                    "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                    "country": "GB"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "recording": {
+                "id": "ecbc7c9b-e79d-4ec8-ac77-44e4a7f7f1b8",
+                "disambiguation": "original studio stereo mix",
+                "title": "Breathe",
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type": "Group",
+                      "name": "Pink Floyd",
+                      "sort-name": "Pink Floyd",
+                      "disambiguation": "",
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                      "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                      "country": "GB"
+                    },
+                    "name": "Pink Floyd"
+                  }
+                ],
+                "length": 168720,
+                "video": false,
+                "first-release-date": "1973-03-24"
+              },
+              "id": "7d5f0207-489b-3c93-9837-d8b754d5a821",
+              "title": "Breathe"
+            },
+            {
+              "id": "ffb7f6b2-b20d-3cb4-bc1b-5b6f4c3c4054",
+              "title": "On the Run",
+              "position": 3,
+              "number": "A3",
+              "recording": {
+                "length": 225386,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type": "Group",
+                      "name": "Pink Floyd",
+                      "sort-name": "Pink Floyd",
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                      "disambiguation": "",
+                      "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                      "country": "GB"
+                    },
+                    "name": "Pink Floyd"
+                  }
+                ],
+                "disambiguation": "original studio stereo mix",
+                "title": "On the Run",
+                "id": "747a79a7-644e-42d4-be86-9adaf44393d8",
+                "first-release-date": "1973-03-24",
+                "video": false
+              },
+              "artist-credit": [
+                {
+                  "joinphrase": "",
+                  "artist": {
+                    "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "disambiguation": "",
+                    "country": "GB",
+                    "type": "Group",
+                    "name": "Pink Floyd",
+                    "sort-name": "Pink Floyd"
+                  },
+                  "name": "Pink Floyd"
+                }
+              ],
+              "length": 230600
+            },
+            {
+              "title": "Time",
+              "id": "39478197-6ea3-33ec-af39-dc7ae75c9799",
+              "artist-credit": [
+                {
+                  "name": "Pink Floyd",
+                  "artist": {
+                    "sort-name": "Pink Floyd",
+                    "name": "Pink Floyd",
+                    "type": "Group",
+                    "country": "GB",
+                    "disambiguation": "",
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "id": "83d91898-7763-47d7-b03b-b92132375c47"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "length": 409600,
+              "recording": {
+                "video": false,
+                "first-release-date": "1973-03-24",
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                      "disambiguation": "",
+                      "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                      "country": "GB",
+                      "type": "Group",
+                      "name": "Pink Floyd",
+                      "sort-name": "Pink Floyd"
+                    },
+                    "name": "Pink Floyd"
+                  }
+                ],
+                "length": 413000,
+                "id": "41959321-f2bb-4580-aa19-16248fe665d3",
+                "disambiguation": "original studio stereo mix",
+                "title": "Time"
+              },
+              "position": 4,
+              "number": "A4"
+            },
+            {
+              "id": "47d38542-2382-3a4b-af05-a8f7e5dcaa5c",
+              "title": "The Great Gig in the Sky",
+              "position": 5,
+              "number": "A5",
+              "recording": {
+                "artist-credit": [
+                  {
+                    "name": "Pink Floyd",
+                    "artist": {
+                      "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                      "disambiguation": "",
+                      "country": "GB",
+                      "type": "Group",
+                      "name": "Pink Floyd",
+                      "sort-name": "Pink Floyd"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "length": 284066,
+                "title": "The Great Gig in the Sky",
+                "disambiguation": "original studio stereo mix",
+                "id": "73b01cea-2dad-4fc2-9e61-02a31477c1b1",
+                "first-release-date": "1973-03-24",
+                "video": false
+              },
+              "artist-credit": [
+                {
+                  "artist": {
+                    "sort-name": "Pink Floyd",
+                    "name": "Pink Floyd",
+                    "type": "Group",
+                    "country": "GB",
+                    "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "disambiguation": ""
+                  },
+                  "joinphrase": "",
+                  "name": "Pink Floyd"
+                }
+              ],
+              "length": 284133
+            },
+            {
+              "id": "e04126c2-457c-36b1-a6b3-9191002607bf",
+              "title": "Money",
+              "number": "B1",
+              "position": 6,
+              "recording": {
+                "title": "Money",
+                "disambiguation": "original studio stereo mix",
+                "id": "7fef22bd-76aa-4803-b56b-93a5d6e70662",
+                "length": 382746,
+                "artist-credit": [
+                  {
+                    "name": "Pink Floyd",
+                    "artist": {
+                      "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                      "disambiguation": "",
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                      "country": "GB",
+                      "type": "Group",
+                      "name": "Pink Floyd",
+                      "sort-name": "Pink Floyd"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "first-release-date": "1973-03-24",
+                "video": false
+              },
+              "artist-credit": [
+                {
+                  "name": "Pink Floyd",
+                  "joinphrase": "",
+                  "artist": {
+                    "country": "GB",
+                    "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                    "disambiguation": "",
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "name": "Pink Floyd",
+                    "sort-name": "Pink Floyd",
+                    "type": "Group"
+                  }
+                }
+              ],
+              "length": 382746
+            },
+            {
+              "title": "Us and Them",
+              "id": "25ede3e7-6233-36fb-971b-9465454f247b",
+              "recording": {
+                "video": false,
+                "first-release-date": "1973-03-24",
+                "id": "2d1201cf-59bb-4ffa-9f52-f5b3afa13346",
+                "title": "Us and Them",
+                "disambiguation": "original studio stereo mix",
+                "length": 469853,
+                "artist-credit": [
+                  {
+                    "name": "Pink Floyd",
+                    "artist": {
+                      "sort-name": "Pink Floyd",
+                      "name": "Pink Floyd",
+                      "type": "Group",
+                      "country": "GB",
+                      "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                      "disambiguation": ""
+                    },
+                    "joinphrase": ""
+                  }
+                ]
+              },
+              "artist-credit": [
+                {
+                  "name": "Pink Floyd",
+                  "joinphrase": "",
+                  "artist": {
+                    "name": "Pink Floyd",
+                    "sort-name": "Pink Floyd",
+                    "type": "Group",
+                    "country": "GB",
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "disambiguation": "",
+                    "id": "83d91898-7763-47d7-b03b-b92132375c47"
+                  }
+                }
+              ],
+              "length": 469853,
+              "position": 7,
+              "number": "B2"
+            },
+            {
+              "title": "Any Colour You Like",
+              "id": "98f679d1-87ff-33df-b815-e585349719ea",
+              "length": 206213,
+              "artist-credit": [
+                {
+                  "artist": {
+                    "type": "Group",
+                    "name": "Pink Floyd",
+                    "sort-name": "Pink Floyd",
+                    "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                    "disambiguation": "",
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "country": "GB"
+                  },
+                  "joinphrase": "",
+                  "name": "Pink Floyd"
+                }
+              ],
+              "recording": {
+                "id": "7c278a16-ae04-460c-88ea-39155cadcd09",
+                "title": "Any Colour You Like",
+                "disambiguation": "original studio stereo mix",
+                "length": 205773,
+                "artist-credit": [
+                  {
+                    "joinphrase": "",
+                    "artist": {
+                      "type": "Group",
+                      "name": "Pink Floyd",
+                      "sort-name": "Pink Floyd",
+                      "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                      "disambiguation": "",
+                      "country": "GB"
+                    },
+                    "name": "Pink Floyd"
+                  }
+                ],
+                "video": false,
+                "first-release-date": "1973-03-24"
+              },
+              "position": 8,
+              "number": "B3"
+            },
+            {
+              "position": 9,
+              "number": "B4",
+              "recording": {
+                "id": "71c0e054-b700-4fd2-a35b-95c7afc566cb",
+                "disambiguation": "original studio stereo mix",
+                "title": "Brain Damage",
+                "length": 229000,
+                "artist-credit": [
+                  {
+                    "name": "Pink Floyd",
+                    "artist": {
+                      "sort-name": "Pink Floyd",
+                      "name": "Pink Floyd",
+                      "type": "Group",
+                      "country": "GB",
+                      "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                      "disambiguation": "",
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                    },
+                    "joinphrase": ""
+                  }
+                ],
+                "video": false,
+                "first-release-date": "1973-03-24"
+              },
+              "length": 226933,
+              "artist-credit": [
+                {
+                  "name": "Pink Floyd",
+                  "artist": {
+                    "type": "Group",
+                    "name": "Pink Floyd",
+                    "sort-name": "Pink Floyd",
+                    "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                    "disambiguation": "",
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "country": "GB"
+                  },
+                  "joinphrase": ""
+                }
+              ],
+              "id": "c8a75ec4-0f9a-35e7-b5b5-92ea929526db",
+              "title": "Brain Damage"
+            },
+            {
+              "recording": {
+                "title": "Eclipse",
+                "disambiguation": "",
+                "id": "c46641c1-fdbc-4401-8b1d-23a4062a207a",
+                "length": 126400,
+                "artist-credit": [
+                  {
+                    "artist": {
+                      "sort-name": "Pink Floyd",
+                      "name": "Pink Floyd",
+                      "type": "Group",
+                      "country": "GB",
+                      "id": "83d91898-7763-47d7-b03b-b92132375c47",
+                      "disambiguation": "",
+                      "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                    },
+                    "joinphrase": "",
+                    "name": "Pink Floyd"
+                  }
+                ],
+                "first-release-date": "1973-03-24",
+                "video": false
+              },
+              "length": 131546,
+              "artist-credit": [
+                {
+                  "name": "Pink Floyd",
+                  "joinphrase": "",
+                  "artist": {
+                    "name": "Pink Floyd",
+                    "sort-name": "Pink Floyd",
+                    "type": "Group",
+                    "country": "GB",
+                    "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                    "disambiguation": "",
+                    "id": "83d91898-7763-47d7-b03b-b92132375c47"
+                  }
+                }
+              ],
+              "position": 10,
+              "number": "B5",
+              "title": "Eclipse",
+              "id": "0c7961e2-1156-34ed-beff-58d400421635"
+            }
+          ],
+          "track-count": 10,
+          "format": "12\" Vinyl",
+          "id": "b1d61283-2ff6-3af7-ba80-25b24f3ba6aa",
+          "title": "",
+          "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+          "track-offset": 0
+        }
+      ],
+      "title": "The Dark Side of the Moon",
+      "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+      "artist-credit": [
+        {
+          "artist": {
+            "name": "Pink Floyd",
+            "sort-name": "Pink Floyd",
+            "type": "Group",
+            "country": "GB",
+            "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+            "disambiguation": "",
+            "id": "83d91898-7763-47d7-b03b-b92132375c47"
+          },
+          "joinphrase": "",
+          "name": "Pink Floyd"
+        }
+      ],
+      "quality": "normal",
+      "text-representation": {
+        "language": "eng",
+        "script": "Latn"
+      },
+      "status": "Official",
+      "date": "1973-03-24",
+      "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+      "release-events": [
+        {
+          "area": {
+            "iso-3166-1-codes": [
+              "GB"
+            ],
+            "sort-name": "United Kingdom",
+            "name": "United Kingdom",
+            "type": null,
+            "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+            "disambiguation": "",
+            "type-id": null
+          },
+          "date": "1973-03-24"
+        }
+      ]
+    }
+  }
+}

--- a/packages/downloader/test/contract/musicbrainz.contract.test.ts
+++ b/packages/downloader/test/contract/musicbrainz.contract.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { MusicBrainzMetadata } from '../../src/adapters/musicbrainz/metadata.js';
-import { bestMatchId, releaseCandidateIds } from '../../src/adapters/musicbrainz/mapping.js';
+import {
+  bestMatchId,
+  releaseCandidateIds,
+  releaseGroupCandidateIds,
+} from '../../src/adapters/musicbrainz/mapping.js';
 import {
   mbRecordingSearchSchema,
+  mbReleaseGroupBrowseSchema,
   mbReleaseSearchSchema,
 } from '../../src/adapters/musicbrainz/schemas.js';
 import type { AcquisitionRequest } from '../../src/domain/acquisition/events.js';
@@ -129,5 +134,49 @@ describe('MusicBrainz contract (tier 1)', () => {
         target: { type: 'track', mbid: expectedId },
       });
     }
+  });
+});
+
+// The release-group browse shares the `/release` path with the release search, and the fixture
+// server routes by path alone, so this tier seeds a server with only the release-group fixtures.
+describe('MusicBrainz release-group contract (tier 1)', () => {
+  const browseEntry = fixtures.find((f) => f.name === 'release-group-browse.json')!;
+  const lookupEntry = fixtures.find((f) => f.name === 'release-group-lookup.json')!;
+  const releaseGroupMbid = browseEntry.fixture.request.query!['release-group']!;
+
+  let rgServer: FixtureServer;
+  beforeEach(async () => {
+    rgServer = await startFixtureServer([browseEntry, lookupEntry]);
+  });
+  afterEach(async () => {
+    await rgServer.close();
+  });
+
+  function rgAdapter(): MusicBrainzMetadata {
+    return new MusicBrainzMetadata(silentLogger(), undefined, {
+      baseUrl: rgServer.baseUrl,
+      userAgent: USER_AGENT,
+    });
+  }
+
+  it('browses the group and resolves the picker-selected edition from real data', async () => {
+    // over the recorded browse, the picker selects the modal-official-track-count edition
+    const editions = mbReleaseGroupBrowseSchema.parse(browseEntry.fixture.response.body).releases;
+    const candidates = releaseGroupCandidateIds(editions);
+    const pickedId = lookupEntry.fixture.request.path.split('/').at(-1)!;
+    expect(candidates[0]).toBe(pickedId);
+
+    const request: AcquisitionRequest = {
+      kind: 'release-group',
+      mbid: releaseGroupMbid,
+      targetType: 'album',
+    };
+    const result = (await rgAdapter().resolve(request))._unsafeUnwrap();
+
+    const browse = rgServer.requests.find((r) => r.path === '/release')!;
+    expect(browse.query).toMatchObject(browseEntry.fixture.request.query!);
+    expect(browse.headers['user-agent']).toBe(USER_AGENT);
+    expect(rgServer.requests.some((r) => r.path === `/release/${pickedId}`)).toBe(true);
+    expect(result).toMatchObject({ kind: 'resolved', target: { type: 'album', mbid: pickedId } });
   });
 });

--- a/packages/downloader/test/contract/record/musicbrainz-release-group.ts
+++ b/packages/downloader/test/contract/record/musicbrainz-release-group.ts
@@ -1,0 +1,78 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { releaseGroupCandidateIds } from '../../../src/adapters/musicbrainz/mapping.js';
+import { mbReleaseGroupBrowseSchema } from '../../../src/adapters/musicbrainz/schemas.js';
+import { CONTRACT_FIXTURE_ROOT, type ContractFixture } from '../support/fixture.js';
+
+/**
+ * Records the MusicBrainz contract fixtures for the release-group request path (change:
+ * request-by-release-group-id). Kept separate from `musicbrainz.ts` so refreshing these does not
+ * re-capture the four stable base fixtures. Anonymous, ≥1 req/s, descriptive User-Agent per
+ * MusicBrainz etiquette; public data, so no sanitization.
+ *
+ *   pnpm tsx test/contract/record/musicbrainz-release-group.ts
+ *
+ * It browses one stable release group's editions (with `inc=media` for track counts), then looks up
+ * the representative edition the adapter's picker selects — so tier 1 can replay a full resolution.
+ */
+
+const BASE_URL = 'https://musicbrainz.org/ws/2';
+const USER_AGENT = 'music-downloader-contract/0.0 (https://github.com/anthropics/music-downloader)';
+const OUT_DIR = join(CONTRACT_FIXTURE_ROOT, 'musicbrainz');
+
+// The Dark Side of the Moon — the album whose descriptor/lookup the base recorder also uses.
+const RELEASE_GROUP_MBID = 'f5093c06-23e3-404f-aeaa-40f72885ee3a';
+const RELEASE_SEARCH_LIMIT = 100;
+
+const capturedAt = new Date().toISOString().slice(0, 10);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Fetch with the exact raw query the adapter builds, storing the decoded query a server sees. */
+async function get(path: string, rawQuery: string): Promise<ContractFixture> {
+  const response = await fetch(`${BASE_URL}${path}?${rawQuery}`, {
+    headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+  });
+  const body = (await response.json()) as unknown;
+  await sleep(1100); // ≥1 req/s
+  return {
+    provenance: { source: `${BASE_URL} (live)`, capturedAt, note: 'public data; no sanitization' },
+    request: { method: 'GET', path, query: Object.fromEntries(new URLSearchParams(rawQuery)) },
+    response: { status: response.status, body },
+  };
+}
+
+function write(name: string, fixture: ContractFixture): void {
+  writeFileSync(join(OUT_DIR, name), `${JSON.stringify(fixture, null, 2)}\n`);
+  console.log(`wrote musicbrainz/${name} (${fixture.response.status})`);
+}
+
+// The edition the release-group picker actually selects, so the recorded lookup stays consistent
+// with the adapter's selection.
+function selectedEditionId(body: unknown): string {
+  const releases = mbReleaseGroupBrowseSchema.parse(body).releases;
+  const id = releaseGroupCandidateIds(releases)[0];
+  if (id === undefined) throw new Error('no official edition in release-group browse');
+  return id;
+}
+
+async function main(): Promise<void> {
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  // Mirror the adapter's browse URL construction verbatim (contract must be byte-faithful).
+  const browse = await get(
+    '/release',
+    `release-group=${encodeURIComponent(RELEASE_GROUP_MBID)}&inc=media&fmt=json&limit=${RELEASE_SEARCH_LIMIT}`,
+  );
+  write('release-group-browse.json', browse);
+
+  const editionId = selectedEditionId(browse.response.body);
+  write(
+    'release-group-lookup.json',
+    await get(`/release/${editionId}`, 'inc=recordings+artist-credits&fmt=json'),
+  );
+}
+
+void main();


### PR DESCRIPTION
## What

Adds a third \`AcquisitionRequest\` kind — a MusicBrainz **release-group** MBID — the natural "this album, any edition" identifier. It browses the group's editions and resolves to a representative **official** edition, reusing the existing by-release-id fetch.

### Edition-selection heuristic
- Restrict to the group's **official** editions.
- Keep only those whose total track count equals the **modal (most common) official track count** (tie → lower count).
- Among those, **earliest release date**; stable order as final tiebreak. No title tier (a bare group id carries no edition-title intent).
- A group with **no official edition** resolves as \`unresolved\` (never a silent bootleg).

The modal-track-count constraint is data-backed: over 9 divergent-edition albums, plain "official → earliest date" picked the standard edition only 7/9 (missing e.g. *1989*, GKMC), while the modal constraint scored 9/9. Live end-to-end verification confirmed GKMC resolves to the 12-track standard (not the 15-track vinyl) and Dark Side of the Moon to the 1973 original.

### Bonus fix (also helps the live descriptor path)
Chronological partial-date ordering in edition selection: a year-only \`2012\` no longer outranks a same-year \`2012-10-22\` (previously a lexical compare rewarded imprecise dates).

## Scope notes
- Additive to the public request contract; resolution outcome stays \`resolved | unresolved\` (no new domain state).
- Human-in-the-loop **manual edition selection** for no-official-edition groups is intentionally split into a follow-up OpenSpec change (\`manual-edition-selection\`, included here as a proposal only).

## Testing
- \`pnpm check\` green: format, lint, typecheck, build, **1246 unit tests @ 100% coverage**, contract tests (65 + 51), release tests (23).
- New MusicBrainz **release-group browse** contract fixture recorded from live + replay test (contract-test-reviewer: no gaps).
- OpenSpec change archived; \`metadata-resolution\` deltas synced to main specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)