### PR TITLE
fix(downloader): treat MusicBrainz 400 (invalid mbid) as unresolved, not a retryable fault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.2.1](https://github.com/jgchk/music-downloader/compare/v3.2.0...v3.2.1) (2026-07-22)
+
+
+### Bug Fixes
+
+* **downloader:** treat MusicBrainz 400 (invalid mbid) as unresolved, not a retryable fault ([4ae0133](https://github.com/jgchk/music-downloader/commit/4ae01333127383f4221b0f7b7e625c161fce9095))
+
 ## [3.2.0](https://github.com/jgchk/music-downloader/compare/v3.1.0...v3.2.0) (2026-07-22)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": true,
   "description": "An extensible, event-sourced music downloader and importer — a modular monolith.",
   "type": "module",

--- a/packages/downloader/src/adapters/musicbrainz/metadata.test.ts
+++ b/packages/downloader/src/adapters/musicbrainz/metadata.test.ts
@@ -370,4 +370,28 @@ describe('MusicBrainzMetadata', () => {
       operation: 'musicbrainz.resolve',
     });
   });
+
+  // MusicBrainz answers an invalid identifier with `400 {"error":"Invalid mbid."}` — a *permanent*
+  // condition that never succeeds on retry. It must be the business outcome `unresolved`, not an
+  // InfraError, or the reactor retries it forever and wedges (regression: an invalid mbid stalled
+  // resolution in production).
+  it('treats a 400 (invalid mbid) on a lookup as unresolved, not a retryable fault', async () => {
+    const result = (
+      await resolver([
+        ['/release/rel-1', { status: 400, body: '{"error":"Invalid mbid."}' }],
+      ]).resolve(albumById)
+    )._unsafeUnwrap();
+
+    expect(result).toEqual({ kind: 'unresolved' });
+  });
+
+  it('treats a 400 (invalid mbid) on the release-group browse as unresolved', async () => {
+    const result = (
+      await resolver([
+        ['/release?release-group=bad', { status: 400, body: '{"error":"Invalid mbid."}' }],
+      ]).resolve(byReleaseGroup('bad'))
+    )._unsafeUnwrap();
+
+    expect(result).toEqual({ kind: 'unresolved' });
+  });
 });

--- a/packages/downloader/src/adapters/musicbrainz/metadata.ts
+++ b/packages/downloader/src/adapters/musicbrainz/metadata.ts
@@ -150,9 +150,13 @@ export class MusicBrainzMetadata implements MetadataPort {
 
   /**
    * GET and validate the body against the endpoint's contract schema; `undefined` for 404 (not
-   * found → unresolved), throw for other non-2xx. A body that violates the contract makes
-   * `schema.parse` throw, which the `resolve` wrapper maps to an `InfraError` — provider drift
-   * surfaces as an attributable boundary fault, never as malformed data reaching the mapping (D2).
+   * found) and 400 (invalid identifier), both of which map to the business outcome *unresolved*;
+   * throw for other non-2xx. MusicBrainz answers a malformed/invalid mbid with `400 {"error":
+   * "Invalid mbid."}` — a *permanent* condition that never succeeds on retry, so it must NOT become
+   * an `InfraError` (which the reactor retries forever, wedging resolution); it is logged and
+   * treated as unresolved. A body that violates the contract makes `schema.parse` throw, which the
+   * `resolve` wrapper maps to an `InfraError` — provider drift surfaces as an attributable boundary
+   * fault, never as malformed data reaching the mapping (D2).
    */
   private async getJson<T>(url: string, schema: ZodType<T>): Promise<T | undefined> {
     const response = await this.http.send({
@@ -160,6 +164,10 @@ export class MusicBrainzMetadata implements MetadataPort {
       headers: { 'User-Agent': this.userAgent, Accept: 'application/json' },
     });
     if (response.status === 404) return undefined;
+    if (response.status === 400) {
+      this.logger.warn({ url }, 'musicbrainz rejected the request (400); treating as unresolved');
+      return undefined;
+    }
     if (response.status < 200 || response.status >= 300) {
       throw new Error(`MusicBrainz responded ${response.status}`);
     }


### PR DESCRIPTION
## What & why

A **production incident**: after v3.1.0, all metadata resolution on the deployed instance wedged in \`Pending\`.

**Root cause** (confirmed from container logs): MusicBrainz answers an *invalid* mbid with \`400 {"error":"Invalid mbid."}\` — **not** \`404\` (a well-formed but *nonexistent* id returns 404). \`getJson\` only mapped \`404\`→unresolved; a \`400\` was thrown as an \`InfraError\`, which the reactor **retries forever**. Being a hot loop, it starved the single serial reactor so even *valid* requests never resolved.

This affects **every mbid path** (release-group browse + \`musicbrainz\` release/recording by-id), not just release-group — the release-group feature just made it easy to trigger with a bad id.

## Fix

Treat a MusicBrainz \`400\` like a \`404\`: a permanent "can't resolve this" → the business outcome \`unresolved\` (logged at warn so a genuine malformed-request bug stays visible), never a retryable infra fault.

## Testing
- \`pnpm check\` green: format, lint, typecheck, build, **1262 tests @ 100% coverage**, contract (65+51) + release (23) tiers.
- New unit tests: a \`400\` on a lookup and on the release-group browse → \`{ kind: 'unresolved' }\`.
- Reproduced live against flight before/after: an invalid-mbid acquisition hot-looped 400s and starved resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)