### PR TITLE
chore(openspec): propose unified-attention-queue

### DIFF
--- a/openspec/changes/unified-attention-queue/.openspec.yaml
+++ b/openspec/changes/unified-attention-queue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/unified-attention-queue/design.md
+++ b/openspec/changes/unified-attention-queue/design.md
@@ -1,0 +1,40 @@
+## Context
+
+Two bounded contexts now pause for humans: the importer's match-review queue (surfaced at `/reviews`) and the downloader's `AwaitingManualSelection` acquisitions (surfaced only on each acquisition's detail page, per `manual-edition-selection`). The web package is a BFF that calls both module facades in-process (web-ui spec, "BFF calls facades in-process only"), so it already holds everything needed to compose one queue. The original intent — modules expose their own intervention surfaces, the web unifies them — predates both features but was never specified.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One inbox: everything waiting on a human, in one ordered list, discoverable from the navigation.
+- Keep the bounded-context seam intact: neither module learns the other exists; no shared kernel.
+- Make "interventions surface in the queue" a written requirement future pauses inherit.
+
+**Non-Goals:**
+- Inline resolution in the queue (candidate tables, resolve verbs). Items link to their existing resolution surfaces; inlining is a possible later enhancement.
+- A facade-level standard `Intervention` contract (see D2's promotion trigger).
+- New pause states (e.g. needsSelection for ambiguous descriptors) — separate changes; they inherit this queue.
+
+## Decisions
+
+### D1 — Web-owned `AttentionItem` view model, composed in the BFF
+
+The `/reviews` load queries both facades — importer pending reviews and downloader acquisitions filtered to `AwaitingManualSelection` — and maps each into a web-owned `AttentionItem`: `{ module: 'importer' | 'downloader'; kind: 'match-review' | 'edition-selection'; id; title; waitingSince?; href }`. Ordering is oldest-first (longest-waiting leads); mapping is pure and lives beside the other presentation vocabulary (`src/lib/`), unit-tested in the node project. This is the altitude-correct shape: the unification is a parsed UI view model at the edge, not a wire type — per the read-model-shape research recorded in the `manual-edition-selection` review discussion (Wlaschin's DTO encoding on the wire; Feldman/King "parse into precision" at the consumer).
+
+### D2 — No shared kernel; an explicit promotion trigger instead
+
+Each facade keeps its own vocabulary; the standard format exists only where its only consumer lives. A facade-level `listPendingInterventions()` shared shape is deliberately rejected *for now*: it would be a shared kernel coupling both contexts to a UI concern, and its generic shape would merely duplicate `AttentionItem` below the layer that uses it. **Promotion trigger, recorded here on purpose:** the moment a second, out-of-process consumer needs the unified shape (MCP resurrection, notifications, mobile), promote the shape into each facade additively and reduce the web mapping to pass-through. Until then, adding a module's new pause kind costs one arm in the web mapping.
+
+### D3 — Badge count from the same composition
+
+The root layout exposes a pending-attention count (sum of both lists) rendered as a badge on the `/reviews` nav entry. It is computed by the same load-time composition — no polling endpoint, no client-side fetch loop; freshness is page-navigation freshness, consistent with how the rest of the UI reads projections.
+
+### D4 — Action-needed presentation for awaiting-selection acquisitions
+
+`statusTone` gains a third tone (`attention`) so awaiting-selection rows badge distinctly from pending/fulfilled/failed; `targetDescription` stops rendering "(resolving…)" for a request whose group identity is known — awaiting rows title from the request (release-group id or, later, a resolved group title) with an explicit "waiting for your choice" line. The acquisitions list remains the full history; the queue is the filtered inbox.
+
+## Risks / Trade-offs
+
+- **Queue staleness between navigations** (D3, no polling) → acceptable: identical to every other projection-backed page; revisit only with a real-time requirement.
+- **`/reviews` naming now undersells its content** → keep the URL (bookmarks, muscle memory), retitle the page "Needs attention"; a redirect-worthy rename is not worth the churn.
+- **Two-facade load on one page doubles failure surface** → each half degrades independently: a failing module renders its section's error note while the other lists normally (mirrors the health endpoint's per-module reporting).
+- **UI-level composition means each new pause kind edits the web mapping** → intended cost; one mapping arm per kind, and the modified web-ui requirement makes forgetting it a spec violation caught in review.

--- a/openspec/changes/unified-attention-queue/proposal.md
+++ b/openspec/changes/unified-attention-queue/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The product now has two kinds of work that wait indefinitely for a human — importer match reviews and downloader acquisitions awaiting manual edition selection (added by `manual-edition-selection`) — but only the first has a dedicated "needs you" surface. Awaiting-selection acquisitions sit in the general acquisitions list looking like in-progress work ("(resolving…)", a generic pending badge), so the pause the feature exists for can go unnoticed forever. The original product intent — one queue that unifies anything needing manual intervention, composed by the web UI from per-module surfaces — was never written into the specs, which is exactly why the newest pause defaulted to its own corner.
+
+## What Changes
+
+- The `/reviews` page becomes the **attention queue**: a single ordered inbox listing importer reviews *and* downloader awaiting-selection acquisitions, each item linking to its resolution surface (review detail or acquisition detail).
+- The web BFF composes the two in-process facades into a web-owned `AttentionItem` view model (module, kind, title, waiting-since, resolution link). **No shared kernel, no new cross-module contract** — each facade keeps its own vocabulary; the standard format lives at the UI edge where today's only consumer is. The design records the promotion trigger for a facade-level standard shape (a third, out-of-process consumer).
+- The site navigation shows a pending-attention count (badge) sourced from the same composition, so waiting work is discoverable from anywhere.
+- The acquisitions list presents awaiting-selection rows as **action-needed** (distinct label/tone and no "(resolving…)" heading) rather than in-progress.
+- The `web-ui` requirement wording changes from importer-only review listing to the module-agnostic attention queue, so any future pause-adding change lands in the queue **by requirement**, not by luck.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this is a presentation/composition change; both underlying pause capabilities already exist)_
+
+### Modified Capabilities
+
+- `web-ui`: the review-listing requirement generalizes into the cross-module attention queue (list composition, per-item resolution links, badge count, action-needed presentation for awaiting-selection acquisitions).
+
+## Impact
+
+- **packages/web only.** Both facades already expose everything needed: `listReviews()` (importer) and `listAcquisitions()` filtered to `AwaitingManualSelection` with `candidates` (downloader, since v3.3.0). No downloader/importer package changes, no event or DTO changes, no migration.
+- Additive to the public contract; the only removed surface is the importer-only framing of `/reviews`, whose URL and existing content remain.
+- Follow-ups that become cheaper: `needsSelection`-for-ambiguous-descriptors and any future pause state inherit the queue automatically.

--- a/openspec/changes/unified-attention-queue/specs/web-ui/spec.md
+++ b/openspec/changes/unified-attention-queue/specs/web-ui/spec.md
@@ -1,0 +1,65 @@
+## MODIFIED Requirements
+
+### Requirement: Import review resolution
+
+The web UI SHALL let the user resolve a pending import review (matching the importer facade's resolve contract), at parity with the retired `resolve_review` MCP tool. Pending reviews SHALL be listed by the attention queue (see "The attention queue unifies work awaiting a human") rather than by an importer-only listing.
+
+#### Scenario: Resolving a review
+
+- **WHEN** a user resolves a pending review with a valid choice
+- **THEN** the importer facade's resolve command is dispatched and the review leaves the attention queue
+
+#### Scenario: Stale resolution is a modeled error
+
+- **WHEN** a user resolves a review that is no longer pending
+- **THEN** the UI shows the facade's modeled conflict error and the import's state is unchanged
+
+## ADDED Requirements
+
+### Requirement: The attention queue unifies work awaiting a human
+
+The web UI SHALL present a single attention queue that lists every item across modules currently waiting on a human decision — at minimum the importer's pending match reviews and the downloader's acquisitions awaiting manual edition selection — as one list ordered longest-waiting first. Each item SHALL identify its module and kind, describe what is being decided, and link to the surface where the decision is made. The queue SHALL be composed by the web layer from the module facades' own read models; the composition SHALL NOT introduce a cross-module contract between the bounded contexts. When one module's read fails, the queue SHALL render the other module's items alongside a modeled error for the failed section, not fail as a whole. Any capability that adds a new human-decision pause SHALL surface its pending items in this queue.
+
+#### Scenario: Items from both modules appear as one queue
+
+- **GIVEN** a pending import review and an acquisition awaiting manual edition selection
+- **WHEN** the user opens the attention queue
+- **THEN** both items appear in one list, longest-waiting first, each naming its module and kind and linking to its resolution surface
+
+#### Scenario: Resolving an item removes it from the queue
+
+- **GIVEN** an attention queue showing an awaiting-selection acquisition
+- **WHEN** the user follows its link and selects an edition
+- **THEN** the acquisition proceeds and no longer appears in the attention queue
+
+#### Scenario: One module failing does not empty the queue
+
+- **GIVEN** one module's facade read fails
+- **WHEN** the user opens the attention queue
+- **THEN** the other module's items are listed and the failed section renders a modeled error message
+
+### Requirement: Pending attention is discoverable from the navigation
+
+The web UI SHALL show, in the site navigation, the count of items currently in the attention queue, so waiting work is discoverable from any page. A zero count SHALL render without a badge rather than a zero.
+
+#### Scenario: The badge reflects the queue
+
+- **GIVEN** two items awaiting a human across modules
+- **WHEN** the user views any page
+- **THEN** the navigation shows the attention entry with a count of 2
+
+#### Scenario: No badge when nothing waits
+
+- **GIVEN** no pending reviews and no awaiting-selection acquisitions
+- **WHEN** the user views any page
+- **THEN** the attention entry renders without a count badge
+
+### Requirement: Awaiting-selection acquisitions present as action-needed
+
+The web UI SHALL present an acquisition awaiting manual edition selection as requiring the user's action — with a distinct badge tone and an explicit waiting-for-your-choice description — never as generic in-progress work or a bare "(resolving…)" placeholder.
+
+#### Scenario: The list distinguishes an awaiting-selection acquisition
+
+- **GIVEN** the acquisitions list contains an awaiting-selection acquisition and a searching acquisition
+- **WHEN** the user views the list
+- **THEN** the awaiting-selection row carries a visually distinct action-needed tone and states that an edition choice is awaited, while the searching row remains generic in-progress

--- a/openspec/changes/unified-attention-queue/tasks.md
+++ b/openspec/changes/unified-attention-queue/tasks.md
@@ -1,0 +1,25 @@
+## 1. The AttentionItem view model
+
+- [ ] 1.1 Write failing unit tests for a pure `attentionItems(reviews, acquisitions)` mapping in `packages/web/src/lib/`: maps pending importer reviews and `AwaitingManualSelection` acquisitions to `AttentionItem { module, kind, id, title, waitingSince?, href }`, orders longest-waiting first, excludes every other status; implement it.
+- [ ] 1.2 Write failing tests that the mapping is total over sparse inputs (missing dates/titles degrade the item's presentation, never drop the item); implement.
+
+## 2. The queue page
+
+- [ ] 2.1 Write failing `page.server.test.ts` tests for the `/reviews` load: composes both facades into the item list; one facade failing yields the other's items plus a modeled section error (no page-level failure); implement the load.
+- [ ] 2.2 Write failing SSR/component tests for the queue rendering: one ordered list, module/kind labels, resolution links, per-section error note, retitled "Needs attention" heading (URL unchanged); implement (extend/replace `ReviewQueue.svelte` composition).
+- [ ] 2.3 Keep existing review-resolution behavior intact: existing review detail routes/tests unchanged; update any test pinned to the importer-only listing wording.
+
+## 3. Navigation badge
+
+- [ ] 3.1 Write failing tests for the layout load exposing the attention count and for the nav rendering: count badge when > 0, no badge at zero; implement in the root layout.
+
+## 4. Action-needed presentation
+
+- [ ] 4.1 Write failing tests for the third badge tone: `statusTone('AwaitingManualSelection')` → `attention` (distinct from pending/fulfilled/failed), `isCancellable` unchanged; implement in `acquisitions.ts` / `phase-label.ts` / badge component.
+- [ ] 4.2 Write failing tests that an awaiting-selection acquisition never presents as "(resolving…)": list row and detail heading describe the awaited choice; implement in `targetDescription` (or a sibling) and the row/detail components.
+
+## 5. Spec coverage & the gate
+
+- [ ] 5.1 Ensure every scenario in the `web-ui` delta is covered by a test (queue composition, resolution removes item, per-section failure, badge count, zero-badge, action-needed row).
+- [ ] 5.2 Run `pnpm check` and `openspec validate unified-attention-queue --strict`; fix gaps.
+- [ ] 5.3 Manually verify end-to-end: with one pending review and one awaiting-selection acquisition, the queue lists both, the badge shows 2, resolving each empties the queue.


### PR DESCRIPTION
Drafts the OpenSpec change making `/reviews` the single cross-module attention queue (planning artifacts only — no implementation):

- **Queue**: importer pending reviews + downloader awaiting-selection acquisitions composed into one longest-waiting-first inbox by the web BFF, each item linking to its resolution surface.
- **Shape decision**: web-owned `AttentionItem` view model at the UI edge; no shared kernel — the design records the explicit promotion trigger (a second, out-of-process consumer) for a facade-level standard shape.
- **Discoverability**: nav badge count; awaiting-selection acquisitions present as action-needed instead of "(resolving…)".
- **The load-bearing spec line**: any future capability adding a human-decision pause must surface in this queue by requirement.

Follow-up to `manual-edition-selection` (v3.3.0); `openspec validate --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)