### PR TITLE
fix: tolerate null MusicBrainz metadata + bound HTTP requests (v3.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.3.1](https://github.com/jgchk/music-downloader/compare/v3.3.0...v3.3.1) (2026-07-22)
+
+
+### Bug Fixes
+
+* **downloader:** tolerate null MusicBrainz metadata fields and bound HTTP requests ([c61287a](https://github.com/jgchk/music-downloader/commit/c61287ab7bfc4c4e3ee12ca76420ff512c2b48e5))
+
 ## [3.3.0](https://github.com/jgchk/music-downloader/compare/v3.2.1...v3.3.0) (2026-07-22)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "private": true,
   "description": "An extensible, event-sourced music downloader and importer — a modular monolith.",
   "type": "module",

--- a/packages/downloader/src/adapters/musicbrainz/mapping.test.ts
+++ b/packages/downloader/src/adapters/musicbrainz/mapping.test.ts
@@ -620,6 +620,35 @@ describe('releaseGroupCandidateIds', () => {
       ]),
     ).toEqual([]);
   });
+
+  it('treats a null-status edition as non-official and a null date as undated', () => {
+    const ids = releaseGroupCandidateIds([
+      { id: 'unknown', title: null, status: null, date: null, media: [{ 'track-count': 10 }] },
+      { id: 'official', status: 'Official', date: '2000', media: [{ 'track-count': 10 }] },
+    ]);
+
+    expect(ids).toEqual(['official']);
+  });
+});
+
+describe('releaseCandidateIds — null tolerance', () => {
+  it('tolerates search hits whose title, status, or date are null', () => {
+    const ids = releaseCandidateIds(
+      [
+        {
+          id: 'hit',
+          score: 100,
+          title: null,
+          status: null,
+          date: null,
+          'release-group': { id: 'rg', title: null },
+        },
+      ],
+      'Album',
+    );
+
+    expect(ids).toEqual(['hit']);
+  });
 });
 
 describe('releaseGroupEditionCandidates', () => {
@@ -680,6 +709,14 @@ describe('releaseGroupEditionCandidates', () => {
     ]);
 
     expect(candidates).toEqual([{ releaseMbid: 'nulled', trackCount: 3 }]);
+  });
+
+  it('treats a null title, status, and date as absent', () => {
+    const candidates = releaseGroupEditionCandidates([
+      { id: 'nulled', title: null, status: null, date: null },
+    ]);
+
+    expect(candidates).toEqual([{ releaseMbid: 'nulled', trackCount: 0 }]);
   });
 
   it('orders candidates by the picker heuristic: modal track count first, then earliest date', () => {

--- a/packages/downloader/src/adapters/musicbrainz/mapping.ts
+++ b/packages/downloader/src/adapters/musicbrainz/mapping.ts
@@ -30,7 +30,7 @@ function artistCreditName(credits: readonly MbArtistCredit[] | undefined): strin
     .trim();
 }
 
-function parseYear(date: string | undefined): number | undefined {
+function parseYear(date: string | null | undefined): number | undefined {
   const year = Number(date?.slice(0, 4));
   return Number.isInteger(year) && year > 0 ? year : undefined;
 }
@@ -119,7 +119,7 @@ interface GroupedRelease {
 // any real component, so within a year a fully-specified date precedes a year-only one; an undated or
 // non-year-leading value maps to +Infinity and sorts after every dated release.
 const DATE_COMPONENT_SENTINEL = 99;
-function dateKey(date: string | undefined): number {
+function dateKey(date: string | null | undefined): number {
   const match = /^(\d{4})(?:-(\d{2}))?(?:-(\d{2}))?/.exec(date ?? '');
   if (match === null) return Number.POSITIVE_INFINITY;
   const year = Number(match[1]);
@@ -129,7 +129,7 @@ function dateKey(date: string | undefined): number {
 }
 
 /** Chronological comparison of two MusicBrainz dates via {@link dateKey}; equal keys rank equal. */
-function compareDates(a: string | undefined, b: string | undefined): number {
+function compareDates(a: string | null | undefined, b: string | null | undefined): number {
   const aKey = dateKey(a);
   const bKey = dateKey(b);
   return aKey < bKey ? -1 : aKey > bKey ? 1 : 0;
@@ -186,8 +186,8 @@ export function releaseCandidateIds(
       id: release.id,
       score: release.score ?? 0,
       title,
-      status: release.status,
-      date: release.date,
+      status: release.status ?? undefined,
+      date: release.date ?? undefined,
       groupTitle: group?.id === undefined ? title : (group.title ?? ''),
     };
     const existing = groups.get(key);
@@ -286,8 +286,8 @@ export function releaseGroupCandidateIds(
     if (release.id === undefined) continue;
     editions.push({
       id: release.id,
-      status: release.status,
-      date: release.date,
+      status: release.status ?? undefined,
+      date: release.date ?? undefined,
       trackCount: totalTrackCount(release),
     });
   }
@@ -323,8 +323,8 @@ export function releaseGroupEditionCandidates(
     ];
     candidates.push({
       releaseMbid: release.id,
-      title: release.title,
-      date: release.date,
+      title: release.title ?? undefined,
+      date: release.date ?? undefined,
       country: release.country ?? undefined,
       format: formats.length > 0 ? formats.join(' + ') : undefined,
       trackCount: totalTrackCount(release),

--- a/packages/downloader/src/adapters/musicbrainz/metadata.test.ts
+++ b/packages/downloader/src/adapters/musicbrainz/metadata.test.ts
@@ -295,6 +295,29 @@ describe('MusicBrainzMetadata', () => {
     expect(result).toEqual({ kind: 'unresolved' });
   });
 
+  it('tolerates a null-status edition among the browsed releases (prod: Red Headed Stranger)', async () => {
+    const result = (
+      await resolver([
+        [
+          '/release?release-group=rg-null',
+          browse([
+            { id: 'official', status: 'Official', date: '2000', media: [{ 'track-count': 10 }] },
+            {
+              id: 'mystery',
+              title: null,
+              status: null,
+              date: null,
+              media: [{ 'track-count': 10 }],
+            },
+          ]),
+        ],
+        ['/release/official', releaseFixture('official')],
+      ]).resolve(byReleaseGroup('rg-null'))
+    )._unsafeUnwrap();
+
+    expect(result).toMatchObject({ kind: 'resolved', target: { mbid: 'official' } });
+  });
+
   it('reports unresolved when the release group is empty', async () => {
     const result = (
       await resolver([['/release?release-group=rg-3', browse([])]]).resolve(byReleaseGroup('rg-3'))

--- a/packages/downloader/src/adapters/musicbrainz/schemas.test.ts
+++ b/packages/downloader/src/adapters/musicbrainz/schemas.test.ts
@@ -181,6 +181,45 @@ describe('MusicBrainz contract schemas', () => {
     expect(parsed.releases?.[0]?.media?.[0]?.format).toBeNull();
   });
 
+  it('accepts a null browse title, status, and date (the Red Headed Stranger wedge: null is a value, not drift)', () => {
+    const parsed = mbReleaseGroupBrowseSchema.parse({
+      releases: [{ id: 'rel-1', title: null, status: null, date: null }],
+    });
+
+    expect(parsed.releases?.[0]?.status).toBeNull();
+  });
+
+  it('accepts null title, status, and date on a scored search hit', () => {
+    const parsed = mbReleaseSearchSchema.parse({
+      releases: [
+        {
+          id: 'rel-1',
+          score: 100,
+          title: null,
+          status: null,
+          date: null,
+          'release-group': { id: 'rg-1', title: null },
+        },
+      ],
+    });
+
+    expect(parsed.releases?.[0]?.status).toBeNull();
+  });
+
+  it('accepts null titles and artist-credit names on lookups', () => {
+    const release = mbReleaseSchema.parse({
+      id: 'rel-1',
+      title: null,
+      date: null,
+      'artist-credit': [{ name: null, joinphrase: null }],
+      media: [{ tracks: [{ position: 1, title: null, length: 1000 }] }],
+    });
+    const recording = mbRecordingSchema.parse({ id: 'rec-1', title: null, length: null });
+
+    expect(release.title).toBeNull();
+    expect(recording.title).toBeNull();
+  });
+
   it('rejects a browse edition whose media format is not a string', () => {
     const result = mbReleaseGroupBrowseSchema.safeParse({
       releases: [{ id: 'x', media: [{ format: 7 }] }],

--- a/packages/downloader/src/adapters/musicbrainz/schemas.ts
+++ b/packages/downloader/src/adapters/musicbrainz/schemas.ts
@@ -9,9 +9,13 @@ import { z } from 'zod';
  * the payloads; the hand-written interfaces they replace are gone so the two cannot diverge.
  */
 
+// Every optional metadata string below is also nullable: MusicBrainz reports "unknown" as null
+// (status, dates, titles, credits alike), and null is a value, not drift — a strict field here
+// turns one sparse release into a permanently-retried resolution fault (the Red Headed Stranger
+// wedge, prod 2026-07-22). Only entity ids stay non-nullable; a null id would be genuine drift.
 const artistCreditSchema = z.object({
-  name: z.string().optional(),
-  joinphrase: z.string().optional(),
+  name: z.string().nullable().optional(),
+  joinphrase: z.string().nullable().optional(),
 });
 
 // MusicBrainz returns `length: null` for a track/recording whose duration it does not know — a
@@ -19,18 +23,18 @@ const artistCreditSchema = z.object({
 // duration (the release then yields no valid target and the caller falls through to the next).
 const trackSchema = z.object({
   position: z.number().optional(),
-  title: z.string().optional(),
+  title: z.string().nullable().optional(),
   length: z.number().nullable().optional(),
   recording: z
-    .object({ title: z.string().optional(), length: z.number().nullable().optional() })
+    .object({ title: z.string().nullable().optional(), length: z.number().nullable().optional() })
     .optional(),
 });
 
 /** `GET /release/{mbid}?inc=recordings+artist-credits&fmt=json`. */
 export const mbReleaseSchema = z.object({
   id: z.string().optional(),
-  title: z.string().optional(),
-  date: z.string().optional(),
+  title: z.string().nullable().optional(),
+  date: z.string().nullable().optional(),
   'artist-credit': z.array(artistCreditSchema).optional(),
   media: z.array(z.object({ tracks: z.array(trackSchema).optional() })).optional(),
 });
@@ -38,7 +42,7 @@ export const mbReleaseSchema = z.object({
 /** `GET /recording/{mbid}?inc=artist-credits&fmt=json`. */
 export const mbRecordingSchema = z.object({
   id: z.string().optional(),
-  title: z.string().optional(),
+  title: z.string().nullable().optional(),
   length: z.number().nullable().optional(),
   'artist-credit': z.array(artistCreditSchema).optional(),
 });
@@ -56,10 +60,12 @@ const scoredEntrySchema = z.object({ id: z.string().optional(), score: z.number(
 const scoredReleaseSchema = z.object({
   id: z.string().optional(),
   score: z.number().optional(),
-  title: z.string().optional(),
-  status: z.string().optional(),
-  date: z.string().optional(),
-  'release-group': z.object({ id: z.string().optional(), title: z.string().optional() }).optional(),
+  title: z.string().nullable().optional(),
+  status: z.string().nullable().optional(),
+  date: z.string().nullable().optional(),
+  'release-group': z
+    .object({ id: z.string().optional(), title: z.string().nullable().optional() })
+    .optional(),
 });
 
 /** `GET /release?query=…&fmt=json` — the scored hit list with each hit's identity/edition fields. */
@@ -79,9 +85,9 @@ export const mbReleaseSearchSchema = z.object({
  */
 const browseReleaseSchema = z.object({
   id: z.string().optional(),
-  title: z.string().optional(),
-  status: z.string().optional(),
-  date: z.string().optional(),
+  title: z.string().nullable().optional(),
+  status: z.string().nullable().optional(),
+  date: z.string().nullable().optional(),
   country: z.string().nullable().optional(), // null = MusicBrainz doesn't know — a value, not drift
   media: z
     .array(

--- a/packages/downloader/src/adapters/support/http.test.ts
+++ b/packages/downloader/src/adapters/support/http.test.ts
@@ -2,7 +2,7 @@ import { createServer } from 'node:http';
 import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { fetchHttpClient } from './http.js';
+import { createFetchHttpClient, fetchHttpClient } from './http.js';
 
 // Drive the real fetch wrapper against a throwaway localhost server — deterministic, no network.
 let server: Server;
@@ -10,6 +10,7 @@ let base: string;
 
 beforeAll(async () => {
   server = createServer((req, res) => {
+    if (req.url === '/hang') return; // never respond — the timeout must fire
     let body = '';
     req.on('data', (chunk: Buffer) => (body += chunk.toString()));
     req.on('end', () => {
@@ -40,5 +41,13 @@ describe('fetchHttpClient', () => {
     });
 
     expect(response.body).toBe('POST /post payload');
+  });
+});
+
+describe('createFetchHttpClient — timeout', () => {
+  it('fails a hung request instead of waiting forever (a frozen fetch must not wedge the caller)', async () => {
+    const client = createFetchHttpClient(100);
+
+    await expect(client.send({ url: `${base}/hang` })).rejects.toThrowError(/timeout|abort/i);
   });
 });

--- a/packages/downloader/src/adapters/support/http.ts
+++ b/packages/downloader/src/adapters/support/http.ts
@@ -19,9 +19,18 @@ export interface HttpClient {
   send(request: HttpRequest): Promise<HttpResponse>;
 }
 
-export const fetchHttpClient: HttpClient = {
-  async send({ method = 'GET', url, headers, body }) {
-    const response = await fetch(url, { method, headers, body });
-    return { status: response.status, body: await response.text() };
-  },
-};
+// Generous for slow providers, but finite: the reactor dispatches effects serially, so an
+// unbounded fetch that never settles freezes the whole drain — every acquisition behind it.
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export function createFetchHttpClient(timeoutMs = DEFAULT_TIMEOUT_MS): HttpClient {
+  return {
+    async send({ method = 'GET', url, headers, body }) {
+      const signal = AbortSignal.timeout(timeoutMs);
+      const response = await fetch(url, { method, headers, body, signal });
+      return { status: response.status, body: await response.text() };
+    },
+  };
+}
+
+export const fetchHttpClient: HttpClient = createFetchHttpClient();


### PR DESCRIPTION
Production hotfix for two wedged acquisitions on flight.

**Root cause 1:** MusicBrainz reports unknown metadata as `null` (observed live: a null-`status` release in the Red Headed Stranger release group). Our schemas accepted absent-but-not-null, so the browse parse threw → retryable `InfraError` → the reactor retried the same effect forever, holding the checkpoint and wedging the drain (same family as the v3.2.1 invalid-mbid wedge). Fix: every optional metadata string in the MusicBrainz schemas is now `.nullable()` (entity ids deliberately stay strict — a null id *is* drift), with nulls coalesced to the existing `undefined` handling at the mapping boundary.

**Root cause 2:** the retry logging stopped without a restart, indicating a fetch that never settled froze the serial drain outright. Fix: the shared fetch client now bounds every request with `AbortSignal.timeout(30s)` (`createFetchHttpClient`), so a hung upstream becomes a normal transport fault. slskd verified unaffected — its polling is discrete fast requests with client-side sleeps, never a held connection.

Tests: schema null-acceptance, picker null-coalescing, an adapter-level regression mirroring the exact prod browse shape, and a hung-request timeout test. Review: one focused pass, no blocking findings. Noted follow-up (out of scope): the importer's separate `fetchHttpClient` has the same timeout-less hazard.

Known limitation this does NOT fix (proposal to follow): a permanently-failing effect still blocks the global reactor queue behind it, and mid-download restarts orphan in-flight transfers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)