### PR TITLE
fix: slskd enqueue rejection is a candidate failure (v3.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.3.2](https://github.com/jgchk/music-downloader/compare/v3.3.1...v3.3.2) (2026-07-22)
+
+
+### Bug Fixes
+
+* **downloader:** treat an slskd enqueue rejection as a candidate failure, not an infra fault ([913455f](https://github.com/jgchk/music-downloader/commit/913455f8105996602c9bbef8cbbe254a3bf1312e))
+
 ## [3.3.1](https://github.com/jgchk/music-downloader/compare/v3.3.0...v3.3.1) (2026-07-22)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "private": true,
   "description": "An extensible, event-sourced music downloader and importer — a modular monolith.",
   "type": "module",

--- a/packages/downloader/src/adapters/slskd/client.ts
+++ b/packages/downloader/src/adapters/slskd/client.ts
@@ -49,6 +49,15 @@ export class SlskdClient {
     return this.request('POST', path, body);
   }
 
+  /**
+   * POST returning the raw status and body without throwing on non-2xx — for callers that own the
+   * rejection taxonomy (an enqueue refused by a live slskd is a candidate failure to model, not an
+   * infrastructure fault to retry).
+   */
+  postRaw(path: string, body: unknown): Promise<{ status: number; body: string }> {
+    return this.dispatch('POST', path, body);
+  }
+
   del(path: string): Promise<unknown> {
     return this.request('DELETE', path);
   }

--- a/packages/downloader/src/adapters/slskd/download.test.ts
+++ b/packages/downloader/src/adapters/slskd/download.test.ts
@@ -97,6 +97,7 @@ const bothCompleted = eventsPage([
 
 interface Opts {
   enqueue?: HttpResponse;
+  enqueueThrows?: boolean; // transport-level failure: slskd itself unreachable
   polls: HttpResponse[];
   events?: HttpResponse[];
   options?: HttpResponse;
@@ -124,7 +125,10 @@ function downloader(opts: Opts): Harness {
   const events = [...(opts.events ?? [bothCompleted])];
   const http: HttpClient = {
     send: ({ method, url }) => {
-      if (method === 'POST') return Promise.resolve(opts.enqueue ?? { status: 200, body: '' });
+      if (method === 'POST') {
+        if (opts.enqueueThrows) return Promise.reject(new Error('socket hang up'));
+        return Promise.resolve(opts.enqueue ?? { status: 200, body: '' });
+      }
       if (method === 'DELETE') {
         deletes.push(url);
         return Promise.resolve({ status: opts.deleteStatus ?? 204, body: '' });
@@ -403,8 +407,34 @@ describe('SlskdDownload', () => {
     expect(result._unsafeUnwrap().kind).toBe('completed');
   });
 
-  it('surfaces an enqueue failure as an InfraError', async () => {
+  it('fails the candidate when a live slskd rejects the enqueue for an unreachable peer', async () => {
+    const { adapter, ledger } = downloader({
+      enqueue: {
+        status: 500,
+        body: 'Failed to establish a direct or indirect message connection to user',
+      },
+      polls: [],
+    });
+
+    const result = await adapter.download(ACQ, candidate, policy(1000, 1000), () => undefined);
+
+    // slskd answered, so the infrastructure is up: the candidate failed, and the retry ladder
+    // advances to the next peer instead of retrying this one forever (prod 2026-07-22).
+    expect(result._unsafeUnwrap()).toEqual({ kind: 'failed', reason: 'PeerUnavailable' });
+    // the write-ahead rows are released: nothing was created at the source
+    expect(ledger.removed).toHaveLength(candidate.files.length);
+  });
+
+  it('fails the candidate as a generic transfer error for other enqueue rejections', async () => {
     const { adapter } = downloader({ enqueue: { status: 500, body: 'boom' }, polls: [] });
+
+    const result = await adapter.download(ACQ, candidate, policy(1000, 1000), () => undefined);
+
+    expect(result._unsafeUnwrap()).toEqual({ kind: 'failed', reason: 'TransferError' });
+  });
+
+  it('surfaces a transport fault during enqueue as an InfraError (slskd itself unreachable)', async () => {
+    const { adapter } = downloader({ enqueueThrows: true, polls: [] });
 
     const result = await adapter.download(ACQ, candidate, policy(1000, 1000), () => undefined);
 

--- a/packages/downloader/src/adapters/slskd/download.ts
+++ b/packages/downloader/src/adapters/slskd/download.ts
@@ -23,6 +23,7 @@ import { realTimer } from './timer.js';
 import type { Timer } from './timer.js';
 import {
   aggregate,
+  enqueueRejectionReason,
   flattenDownloads,
   isTransferComplete,
   isTransferSucceeded,
@@ -138,7 +139,23 @@ export class SlskdDownload implements DownloadPort {
     for (const key of ownedKeys)
       await this.record(this.ledger.recordCreated({ ...key }), 'record transfer');
     this.logger.debug({ username, fileCount: requests.length }, 'enqueueing slskd download');
-    await this.client.post(this.downloadsPath(username), requests);
+    const enqueue = await this.client.postRaw(this.downloadsPath(username), requests);
+    if (enqueue.status < 200 || enqueue.status >= 300) {
+      // slskd answered, so the infrastructure is up: it refused THIS candidate's enqueue
+      // (typically an unreachable peer). That is a business failure for the retry ladder — reject
+      // the candidate and advance to the next-best — never an InfraError, which would retry the
+      // same dead peer forever (prod 2026-07-22). The write-ahead rows are released: nothing was
+      // created at the source, so the sweep must not chase them.
+      const reason = enqueueRejectionReason(enqueue.body);
+      this.logger.warn(
+        { username, status: enqueue.status, reason },
+        'slskd rejected the enqueue; failing the candidate',
+      );
+      for (const key of ownedKeys) {
+        await this.record(this.ledger.markRemoved(key), 'release rejected transfer');
+      }
+      return { kind: 'failed', reason };
+    }
 
     const start = this.timer.now();
     let lastBytes = 0;

--- a/packages/downloader/src/adapters/slskd/transfers.test.ts
+++ b/packages/downloader/src/adapters/slskd/transfers.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { aggregate, flattenDownloads, reasonFromTransfer } from './transfers.js';
+import {
+  aggregate,
+  enqueueRejectionReason,
+  flattenDownloads,
+  reasonFromTransfer,
+} from './transfers.js';
 
 describe('flattenDownloads', () => {
   it('returns nothing when the payload omits directories', () => {
@@ -109,5 +114,20 @@ describe('aggregate', () => {
 
     expect(status).toMatchObject({ settled: false, allQueued: false });
     expect(status.progress.percent).toBe(25);
+  });
+});
+
+describe('enqueueRejectionReason', () => {
+  it('names the peer when the rejection body is connection-flavored', () => {
+    expect(
+      enqueueRejectionReason('Failed to establish a direct or indirect message connection to u'),
+    ).toBe('PeerUnavailable');
+    expect(enqueueRejectionReason('User u appears to be offline')).toBe('PeerUnavailable');
+    expect(enqueueRejectionReason('peer unavailable')).toBe('PeerUnavailable');
+  });
+
+  it('falls back to a generic transfer failure for other rejection bodies', () => {
+    expect(enqueueRejectionReason('boom')).toBe('TransferError');
+    expect(enqueueRejectionReason('')).toBe('TransferError');
   });
 });

--- a/packages/downloader/src/adapters/slskd/transfers.ts
+++ b/packages/downloader/src/adapters/slskd/transfers.ts
@@ -55,6 +55,20 @@ export function reasonFromTransfer(transfer: SlskdTransfer): DownloadFailureReas
   return 'TransferError';
 }
 
+/**
+ * Translate an slskd enqueue *rejection* into the candidate-level failure reason (D10). An HTTP
+ * rejection from slskd means slskd itself is up and answered — the candidate, not the
+ * infrastructure, failed; a connection-flavored body names the peer. Transport-level failures
+ * (slskd unreachable) never come here — they stay infrastructure faults and are retried.
+ */
+export function enqueueRejectionReason(body: string): DownloadFailureReason {
+  const text = body.toLowerCase();
+  if (text.includes('connect') || text.includes('offline') || text.includes('unavailable')) {
+    return 'PeerUnavailable';
+  }
+  return 'TransferError';
+}
+
 export interface TransferAggregate {
   readonly progress: DownloadProgress;
   /** Every transfer has reached a terminal state (there is at least one transfer). */


### PR DESCRIPTION
Third instance of the misclassified-permanent-failure family, observed live minutes after v3.3.1 unwedged the reactor: the Red Headed Stranger acquisition's download enqueue gets `slskd 500` for an unreachable peer, classified `InfraError`, retried against the same dead peer every 5s instead of advancing the candidate ladder.

Fix: the enqueue POST no longer throws on non-2xx. slskd answering at all means the infrastructure is up, so the rejection is modeled as the candidate's failure — `PeerUnavailable` for connection-flavored bodies, `TransferError` otherwise — the write-ahead ledger rows are released (nothing was created at the source), and `RecordDownloadFailed` advances the acquisition to the next-best peer. Transport faults (slskd itself unreachable) remain retryable `InfraError`. The adapter already translated peer failures correctly *after* enqueue; this closes the at-enqueue gap.

Tests: reason-classification unit tests, adapter tests for peer-rejection → failed outcome + ledger release, generic rejection → TransferError, and transport fault → InfraError (replacing the test that pinned the old behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)