### PR TITLE
chore(openspec): propose reactor-durability

### DIFF
--- a/openspec/changes/reactor-durability/.openspec.yaml
+++ b/openspec/changes/reactor-durability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/reactor-durability/design.md
+++ b/openspec/changes/reactor-durability/design.md
@@ -1,0 +1,54 @@
+## Context
+
+The reactor is a single durable consumer over the global event log: it reacts to each event, dispatches effects serially, and advances one checkpoint. Two failure modes observed in production (2026-07-22, acquisitions `1e1bae5d` and `155d1887`):
+
+1. A retryable effect failure leaves the checkpoint unadvanced, so the *same* event re-fires on every wakeup — correct for genuinely transient faults, but a permanent condition misclassified as transient (schema drift, invalid input reaching a 4xx) blocks every acquisition behind it, forever. Fixed 5s retries also hammered the upstream (inviting MusicBrainz throttling) until an unbounded fetch froze the drain outright (the fetch timeout shipped in v3.3.1 bounds that; the wedge class remains).
+2. Long-running effects (a download's poll loop) live only in process memory. After the triggering event is checkpointed, a restart orphans the effect: the spec required "not downloaded a second time" and the implementation honored it by never driving the download again. Stall/queue-wait budgets are enforced by the dead poller, so nothing ever times out either.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One acquisition's failing effect must never stall another acquisition's progress.
+- Every retry loop is bounded and lands somewhere modeled and visible.
+- After a restart, every non-terminal acquisition is driven again: resumed, re-attached, or timed out by policy — never orphaned.
+
+**Non-Goals:**
+- Multi-process/distributed reactors, competing consumers, or parallel effect dispatch within a stream (serial per stream remains the concurrency model).
+- Changing the decider or the at-least-once/idempotent-effect contract — this change is confined to the shell that drives it.
+- Surfacing stalled acquisitions in the UI (the `unified-attention-queue` change consumes what this change exposes).
+
+## Decisions
+
+### D1 — Park the stream, advance the checkpoint
+
+On a retryable effect failure, the reactor durably records a parked entry `{ streamId, globalSeq, attempt, nextRetryAt }` (a sibling table to the checkpoint store) and advances the global checkpoint past the event. The drain never re-processes a parked event in-line; a retry scheduler re-dispatches parked entries when due. Per-stream ordering is preserved by parking the *stream*: while a stream has a parked entry, later events for that stream are appended to its parked queue instead of being dispatched (other streams flow past untouched). **Invariant: a parked stream's event N+1 must never leapfrog N** — pinned by a dedicated test. This replaces the current semantics where the global checkpoint is the retry mechanism.
+
+*Prior art:* "park" is the literal term in EventStoreDB/Kurrent persistent subscriptions (`maxRetryCount` → park → `replayParked`); the sibling retry table is the universal SQL job-queue schema (Oban/River/pg-boss `attempt`/`scheduled_at`/discard columns; Solid Queue's sibling execution tables). The per-stream variant — park the key, queue its later work behind, let other keys flow — is the rarer, ordering-preserving shape shipped by Confluent Parallel Consumer's KEY mode and jet/propulsion's `StreamsSink`; most off-the-shelf DLQs (SQS, Service Bus, Kurrent's own parking) explicitly lose per-key ordering, which is why we do not use them raw. Our bounded budget + terminal policy fixes Parallel Consumer's two documented gaps (retry-forever default, no dead-letter path); durability fixes Propulsion's memory-only buffering.
+
+### D2 — Exponential backoff with a budget; the landing is modeled
+
+Parked entries retry on exponential backoff with jitter (e.g. 5s → 10s → … capped at 15min) up to a retry budget measured in **wall-clock time** (default ~6h, configurable via environment), not attempts alone. Errors classified **non-retryable** (a 4xx-shaped permanent condition the adapter recognizes) short-circuit the budget entirely and land immediately — the Temporal non-retryable-error-types / Restate `TerminalError` split; the v3.2.1 and v3.3.1 incidents were both misclassified permanents burning retries. A budget exhausted resolves by effect kind:
+- Effects whose permanent failure has a modeled business outcome degrade to it through the normal command path — `ResolveMetadata` → `RecordMetadataFailed` (the acquisition terminates visibly as `MetadataFailed`, exactly as if resolution had reported unresolved).
+- Effects with no modeled failure (e.g. `Cleanup`) dead-letter: the parked entry moves to the existing dead-letter store with full context, is logged at error, and the acquisition is exposed as stalled in the status read model (`stalled: true` on the view — additive), which the attention queue can surface.
+The budget is deliberately generous: a genuine outage should ride it out; only a permanent condition exhausts it. Dead-lettered/stalled entries get a retention policy (pruned after resolution or a bounded age, like River's discarded-job pruning) — a dead-letter table nobody drains is, per Dudycz, "a car alarm in a parking lot."
+
+*Prior art:* bounded-retry-then-modeled-fallback is textbook under several names — AWS Step Functions `Retry`→`Catch`→fallback state, Temporal activity retry policies (`maximumAttempts`, Schedule-To-Close as the wall-clock budget) with `ActivityFailure` caught by workflow logic, Hohpe's write-off, Helland's "apologies." Restate 1.5's pause-on-exhaustion is the industry converging on exactly our two-tier landing (modeled outcome vs. stalled-awaiting-operator).
+
+### D3 — Startup re-drive derives effects from state, not from replayed events
+
+This is level-triggered reconciliation (the Kubernetes controller model) applied to the reactor: derive pending work from *current state* rather than from possibly-missed edges, so a crash is self-healing by construction. The standard industrial alternatives (Temporal server-side activity timeouts, DBOS's boot-time PENDING-workflow scan, outbox re-scans) re-drive from a durable work record; deriving from the fold is equivalent here because every effect is preceded by the event that implies it — a property the decider architecture already guarantees and this design depends on.
+
+After the catch-up drain, a re-drive pass folds every non-terminal stream and asks `react(lastEvent, state)` for the effect its current state is waiting on, then dispatches it through the normal idempotent path. The pass is **rate-limited/jittered** (reconciling every non-terminal stream at boot must not stampede MusicBrainz or slskd) and **serialized per stream with normal dispatch** (the boot pass and the live drain must not race a check-then-act re-attach on the same acquisition). Consequences per phase: `Pending` re-fires resolution; `Searching`/`Selecting` re-fire search/selection continuation; `Downloading` re-fires the download effect, whose adapter must **reconcile before enqueueing** — via the source-resource ledger and slskd's transfer listing, it re-attaches to an existing live transfer (resuming polling and restarting stall/queue budgets from re-attach time) or re-enqueues if the source lost it; `AwaitingManualSelection` derives no effect (the pause is the state, not a lost effect); terminal phases are skipped. Idempotency and decide's stale-outcome rejection make double-drive safe by the existing contract.
+
+### D4 — Observability is part of the contract
+
+Parked/dead-lettered state is queryable (count + per-acquisition) through the status read model, and every park, retry, degrade, and dead-letter transition logs structured entries with the acquisition id, effect type, attempt, and next retry. The two incidents were prolonged by silence; the fix treats visibility as a requirement, not a nicety.
+
+## Risks / Trade-offs
+
+- **Parking machinery adds state beside the log** (parked table) → kept rebuildable-adjacent: entries carry only scheduling data; losing the table safely degrades to the startup re-drive (D3), which re-derives work from the log.
+- **Degrading to `MetadataFailed` after budget could terminate an acquisition during an extended provider outage** → the budget is hours-long and configurable; the alternative (infinite retry) is the bug this change removes. The landing is visible and the request can be resubmitted.
+- **Download re-attach depends on slskd cooperation** (finding the prior transfer) → the ledger already records source resources per acquisition; where reconciliation is ambiguous, re-enqueue and let slskd/decide dedupe — worst case matches today's at-least-once contract.
+- **Per-stream parking adds ordering bookkeeping** → scoped: only streams with a parked entry queue their later events; the common path (no failures) is unchanged; the no-leapfrog invariant is pinned by test.
+- **Park-table rot** → retention policy for resolved/aged entries plus the stalled read-model exposure; the table is scheduling data only and safely degrades to the boot reconciliation if lost.
+- **Boot-time thundering herd** → the re-drive pass is jittered and rate-limited (general retry-storm guidance; MusicBrainz rate limits are real and bit us on 2026-07-22).

--- a/openspec/changes/reactor-durability/proposal.md
+++ b/openspec/changes/reactor-durability/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Two production stalls (2026-07-22) exposed durability gaps the current spec not only permits but partly mandates. First, a permanently-failing effect classified as an infrastructure fault holds the reactor's single global checkpoint forever — the spec's own words ("the checkpoint is not advanced and the event is processed again") turn one poisoned acquisition into a queue-wide wedge, for the second time (invalid-mbid 400s in v3.1.0, null-status schema drift in v3.3.0). Second, the restart requirement guards against *duplicating* a mid-flight download but never requires *resuming* it: an acquisition whose transfer poller died with the process satisfies "not downloaded a second time" by never being driven again — stuck `Downloading` forever, with the stall/queue timeouts that would abort it running in the process that no longer exists.
+
+## What Changes
+
+- **Per-stream fault isolation.** A retryable effect failure parks *its acquisition's* stream (durable retry state with exponential backoff) while the global checkpoint advances past it — one poisoned effect never blocks other acquisitions' processing.
+- **A retry budget with a modeled landing.** Parked effects retry with backoff up to a bounded budget; a budget exhausted degrades to the effect's modeled business failure where one exists (resolution → metadata failure) or to a dead-letter with the acquisition visibly marked stalled — never a silent infinite loop, never a silent drop.
+- **Restart re-drive.** On startup, after the catch-up drain, the reactor re-derives the pending effect for every non-terminal acquisition from its folded state and re-dispatches it idempotently — a mid-flight download re-attaches to (or re-requests) its transfer and its stall/queue budgets restart; a pending resolution re-fires. `AwaitingManualSelection` correctly re-derives *no* effect (the pause is the state's meaning).
+- **The `acquisition-lifecycle` restart/fault requirements are rewritten** to demand isolation, bounded retry, and resumption — replacing the wording that mandated infinite same-event retry and only forbade duplication.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this hardens the existing lifecycle capability's guarantees)_
+
+### Modified Capabilities
+
+- `acquisition-lifecycle`: the "Processing survives restarts without duplicating effects" requirement is modified to also require resumption and per-stream fault isolation; a new requirement covers bounded retry with a modeled landing for permanently-failing effects.
+
+## Impact
+
+- **packages/downloader only**: reactor (drain/checkpoint/retry state), a durable parked-effects store beside the checkpoint store, the download adapter's re-attach path (reconciling via the ownership ledger), composition wiring. Domain untouched except possibly a modeled "stalled" surfacing decision (see design).
+- The v3.3.1 hotfix (nullable MusicBrainz fields, bounded HTTP requests) removed today's *instances*; this change removes the *class*.
+- Integrates with the pending `unified-attention-queue` change: a dead-lettered/stalled acquisition is a human-attention item; this change exposes the read model, that change surfaces it.

--- a/openspec/changes/reactor-durability/specs/acquisition-lifecycle/spec.md
+++ b/openspec/changes/reactor-durability/specs/acquisition-lifecycle/spec.md
@@ -1,0 +1,66 @@
+## MODIFIED Requirements
+
+### Requirement: Processing survives restarts without duplicating effects
+
+The system SHALL resume in-progress acquisitions after a process restart: for every non-terminal acquisition, the effect its current state is waiting on SHALL be re-derived and re-dispatched idempotently — a mid-flight download re-attaches to its existing transfer where the source still holds it (re-enqueueing otherwise) with its stall and queue-wait budgets restarted, a pending resolution re-fires, and an acquisition awaiting manual selection correctly re-derives no effect. Resumption SHALL NOT start a second download for a candidate whose transfer is already in flight at the source. Within the at-least-once crash window — an effect was dispatched and its follow-on outcome recorded, but the consumer's checkpoint was not yet saved — redelivery SHALL converge: a re-dispatched effect is idempotent or its stale outcome is ignored by the decision logic, the acquisition's recorded history gains no duplicate outcome, and redelivery SHALL NOT wedge processing. A follow-on command rejected by the decision logic as stale or illegal SHALL be recorded and skipped.
+
+#### Scenario: Restart mid-download resumes the transfer
+
+- **GIVEN** an acquisition whose candidate download was dispatched before the process restarted
+- **WHEN** the process restarts
+- **THEN** the download is driven again — re-attached to the source's existing transfer or re-enqueued — and its stall and queue-wait budgets apply from resumption
+- **AND** the candidate is not downloaded a second time when its transfer is already in flight
+
+#### Scenario: Restart mid-resolution re-fires resolution
+
+- **GIVEN** an acquisition that was resolving metadata when the process restarted
+- **WHEN** the process restarts
+- **THEN** the resolution effect is re-dispatched and the acquisition proceeds on its outcome
+
+#### Scenario: Restart while awaiting manual selection stays paused
+
+- **GIVEN** an acquisition awaiting manual edition selection when the process restarted
+- **WHEN** the process restarts
+- **THEN** the acquisition remains awaiting selection with its candidates intact and no effect is dispatched for it
+
+#### Scenario: Restart inside the crash window re-dispatches without duplicating outcomes
+
+- **GIVEN** an acquisition whose effect was dispatched and whose follow-on outcome was recorded, but whose consumer checkpoint was not saved before a crash
+- **WHEN** the process restarts and redelivers the already-reacted event
+- **THEN** the re-dispatched effect converges — the stale follow-on outcome is ignored and the acquisition's recorded history is unchanged
+
+#### Scenario: A stale re-dispatched outcome does not wedge the consumer
+
+- **GIVEN** a redelivered event whose re-dispatched effect produces a follow-on command that the decision logic rejects
+- **WHEN** the consumer handles the rejection
+- **THEN** it records the rejection and continues with subsequent events
+
+## ADDED Requirements
+
+### Requirement: A failing effect stalls only its own acquisition, within a bounded retry budget
+
+The system SHALL isolate effect-dispatch failures per acquisition: an infrastructure fault retrying one acquisition's effect SHALL NOT delay the processing of any other acquisition's events. Retries SHALL back off exponentially and SHALL be bounded by a configurable budget. When the budget is exhausted, the system SHALL land the failure somewhere modeled and visible: an effect whose permanent failure has a modeled business outcome SHALL degrade to that outcome through the normal decision path; an effect without one SHALL be dead-lettered with its full context, and the owning acquisition SHALL be exposed as stalled by the status read model. Every park, retry, degradation, and dead-letter transition SHALL be observably logged with the acquisition, effect, and attempt. Ordering within an acquisition SHALL be preserved while it is parked: its later events wait behind the parked effect; other acquisitions' events do not.
+
+#### Scenario: Other acquisitions flow past a poisoned effect
+
+- **GIVEN** one acquisition whose resolution effect fails on every attempt
+- **WHEN** another acquisition is submitted and processed
+- **THEN** the second acquisition proceeds to its own outcome while the first retries independently
+
+#### Scenario: An exhausted retry budget degrades to the modeled failure
+
+- **GIVEN** an acquisition whose resolution effect has failed for the entire retry budget
+- **WHEN** the final retry fails
+- **THEN** the acquisition terminates through the modeled metadata-failure path, visibly, and retries stop
+
+#### Scenario: An effect with no modeled failure dead-letters visibly
+
+- **GIVEN** an acquisition whose staging-cleanup effect has failed for the entire retry budget
+- **WHEN** the final retry fails
+- **THEN** the effect is dead-lettered with its context and the acquisition is exposed as stalled by the status read model
+
+#### Scenario: A transient outage rides out the backoff
+
+- **GIVEN** an effect failing because its upstream is briefly unavailable
+- **WHEN** the upstream recovers within the retry budget
+- **THEN** a backed-off retry succeeds and the acquisition proceeds normally

--- a/openspec/changes/reactor-durability/tasks.md
+++ b/openspec/changes/reactor-durability/tasks.md
@@ -1,0 +1,31 @@
+## 1. Parked-effect store & backoff
+
+- [ ] 1.1 Write failing tests for a durable parked-effects store (sibling to the checkpoint store): record `{ streamId, globalSeq, attempt, nextRetryAt }`, list due entries, clear on success; implement (SQLite, same file/discipline as checkpoints).
+- [ ] 1.2 Write failing tests for the backoff policy (exponential with jitter, capped interval, wall-clock budget exhaustion signal; env-configurable); implement as a pure function.
+- [ ] 1.3 Write failing tests for non-retryable classification: an error the adapter marks permanent short-circuits the budget and lands immediately (modeled failure or dead-letter); implement the classification seam.
+
+## 2. Reactor: park, advance, retry
+
+- [ ] 2.1 Write failing reactor tests: a retryable effect failure parks the stream and ADVANCES the global checkpoint; a subsequent unrelated stream's event is processed immediately (the isolation scenario); implement.
+- [ ] 2.2 Write failing tests for per-stream ordering under park: later events of a parked stream queue behind it and dispatch in order after the parked effect succeeds; pin the no-leapfrog invariant (event N+1 of a parked stream can never dispatch while N is parked); implement.
+- [ ] 2.3 Write failing tests for the retry scheduler: due parked entries re-dispatch with incremented attempt; success clears the entry; implement (reuse the existing fallback-poll timer seam).
+- [ ] 2.4 Write failing tests for budget exhaustion: `ResolveMetadata` degrades to `RecordMetadataFailed` through the command path; an effect with no modeled failure moves to the dead-letter store; both log structured transitions; implement.
+
+## 3. Stalled visibility
+
+- [ ] 3.1 Write failing tests for the status read model exposing `stalled` (from dead-lettered park entries) additively on the view/DTO; implement (facade schema additive field + mapping).
+- [ ] 3.2 Write failing tests for parked/dead-letter retention: resolved entries clear; aged stalled entries prune per policy; implement.
+
+## 4. Startup re-drive
+
+- [ ] 4.1 Write failing tests for the re-drive pass: after the catch-up drain, every non-terminal stream's current effect is re-derived from folded state and dispatched; terminal and awaiting-selection streams derive none; implement.
+- [ ] 4.2 Write failing tests for the download adapter's reconcile-before-enqueue: an acquisition with a live ledgered transfer re-attaches (polling resumes, budgets restart); a lost transfer re-enqueues; implement against the slskd fakes.
+- [ ] 4.3 Write failing tests that the re-drive pass is jittered/rate-limited and serialized per stream against live dispatch (no check-then-act race on the same acquisition); implement.
+- [ ] 4.4 Extend the out-of-process restart e2e: kill mid-download, restart, assert the transfer is driven to an outcome (completed or timed out) rather than orphaned.
+
+## 5. Contract, spec coverage & the gate
+
+- [ ] 5.1 Contract additivity: the `stalled` view field and any facade changes covered by existing additivity guards; no wire breaks.
+- [ ] 5.2 Ensure every scenario in the `acquisition-lifecycle` delta maps to a test (isolation, degrade, dead-letter, outage ride-out, resume-mid-download, resume-mid-resolution, paused-stays-paused, crash-window convergence).
+- [ ] 5.3 Run `pnpm check` and `openspec validate reactor-durability --strict`; fix gaps.
+- [ ] 5.4 Manually verify: submit a poisoned resolution (unroutable base URL in a dev config) alongside a healthy acquisition — the healthy one completes; restart mid-download in the e2e harness — the download resumes.


### PR DESCRIPTION
Planning artifacts only (no implementation) for the durability follow-up to today's incidents (v3.3.1/v3.3.2 hotfixes removed the instances; this change removes the classes):

- **Per-stream parking**: a failing effect parks its own acquisition (durable `{streamId, globalSeq, attempt, nextRetryAt}` sibling table, exponential backoff + jitter, wall-clock budget, non-retryable short-circuit) while the global checkpoint advances — one poisoned effect never blocks the queue. Budget exhaustion lands in the modeled business failure (`ResolveMetadata` → `MetadataFailed`) or a visible dead-letter with a `stalled` read-model flag (consumed by the pending `unified-attention-queue` change).
- **Startup re-drive**: level-triggered reconciliation — each non-terminal acquisition's pending effect is re-derived from folded state and idempotently re-dispatched on boot (downloads reconcile-before-enqueue via the ledger; awaiting-selection correctly derives nothing), so restarts can no longer orphan in-flight work.
- The `acquisition-lifecycle` restart/fault requirements are rewritten: the old wording mandated infinite same-event retry and only forbade download duplication, not orphaning.

Design includes prior-art citations (EventStoreDB parking, Confluent Parallel Consumer KEY mode, jet/propulsion, Step Functions/Temporal/Restate, Kubernetes controllers) and the researched pitfall checklist (no-leapfrog invariant, park-table retention, boot-time jitter, per-stream serialization). `openspec validate --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)