### PR TITLE
fix: 404 transfer listing is an empty collection, not a fault (v3.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.3.3](https://github.com/jgchk/music-downloader/compare/v3.3.2...v3.3.3) (2026-07-22)
+
+
+### Bug Fixes
+
+* **downloader:** treat a 404 transfer listing as an empty collection, not a retryable fault ([e695f6c](https://github.com/jgchk/music-downloader/commit/e695f6ccf80aa52e7f82d364745e80fdb33f68c3))
+
 ## [3.3.2](https://github.com/jgchk/music-downloader/compare/v3.3.1...v3.3.2) (2026-07-22)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "private": true,
   "description": "An extensible, event-sourced music downloader and importer — a modular monolith.",
   "type": "module",

--- a/packages/downloader/src/adapters/slskd/client.test.ts
+++ b/packages/downloader/src/adapters/slskd/client.test.ts
@@ -87,6 +87,38 @@ describe('SlskdClient', () => {
     await expect(client.get('/api/v0/searches/s1')).rejects.toThrow('slskd responded 500');
   });
 
+  describe('getOr', () => {
+    it('returns the fallback for a 404 (an absent collection is a state, not a fault)', async () => {
+      const { http } = recordingClient({ status: 404, body: '' });
+      const client = new SlskdClient(http);
+
+      await expect(client.getOr('/api/v0/transfers/downloads/u', {})).resolves.toEqual({});
+    });
+
+    it('parses a 2xx body like a plain GET', async () => {
+      const { http } = recordingClient({ status: 200, body: JSON.stringify({ directories: [] }) });
+      const client = new SlskdClient(http);
+
+      await expect(client.getOr('/api/v0/transfers/downloads/u', {})).resolves.toEqual({
+        directories: [],
+      });
+    });
+
+    it('still throws on other non-2xx statuses', async () => {
+      const { http } = recordingClient({ status: 500, body: 'boom' });
+      const client = new SlskdClient(http);
+
+      await expect(client.getOr('/api/v0/transfers/downloads/u', {})).rejects.toThrowError(/500/);
+    });
+
+    it('returns undefined for an empty 2xx body, like a plain GET', async () => {
+      const { http } = recordingClient({ status: 204, body: '' });
+      const client = new SlskdClient(http);
+
+      await expect(client.getOr('/api/v0/transfers/downloads/u', {})).resolves.toBeUndefined();
+    });
+  });
+
   describe('delIfPresent', () => {
     it('resolves on a successful delete', async () => {
       const { http, sent } = recordingClient({ status: 204, body: '' });

--- a/packages/downloader/src/adapters/slskd/client.ts
+++ b/packages/downloader/src/adapters/slskd/client.ts
@@ -63,6 +63,21 @@ export class SlskdClient {
   }
 
   /**
+   * GET a resource, returning `notFound` for a 404 — for collections whose absence is a *state*,
+   * not a fault: slskd 404s the downloads listing of a user with no transfers, and for the abort
+   * and poll paths that means "nothing there" (converge), never "retry until it exists" (which
+   * wedged the reactor on a cancelled acquisition's abort, prod 2026-07-22). Other non-2xx throw.
+   */
+  async getOr(path: string, notFound: unknown): Promise<unknown> {
+    const response = await this.dispatch('GET', path);
+    if (response.status === 404) return notFound;
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`slskd responded ${response.status} for GET ${path}`);
+    }
+    return response.body === '' ? undefined : JSON.parse(response.body);
+  }
+
+  /**
    * DELETE a resource, treating a 404 (already absent) as success — the resource is in the desired
    * end state, so cancel+remove is idempotent. Any other non-2xx still throws. Used for the removals
    * where "already gone" must converge rather than error (settled-transfer cleanup, the sweep).

--- a/packages/downloader/src/adapters/slskd/download.test.ts
+++ b/packages/downloader/src/adapters/slskd/download.test.ts
@@ -444,6 +444,14 @@ describe('SlskdDownload', () => {
     });
   });
 
+  it('treats a 404 mid-download poll as vanished transfers and stalls out, not an infra fault', async () => {
+    const { adapter } = downloader({ polls: [{ status: 404, body: '' }] });
+
+    const result = await adapter.download(ACQ, candidate, policy(200, 1000), () => undefined);
+
+    expect(result._unsafeUnwrap()).toMatchObject({ kind: 'failed', reason: 'Stalled' });
+  });
+
   it('surfaces a contract-violating poll body as an InfraError', async () => {
     const { adapter } = downloader({
       polls: [{ status: 200, body: JSON.stringify({ directories: 'not-an-array' }) }],
@@ -712,6 +720,17 @@ describe('SlskdDownload', () => {
       // The completed file's source-reported staged path is returned for the domain to discard.
       expect(result._unsafeUnwrap()).toEqual([{ name: '01.flac', path: stagedPath('01.flac') }]);
       expect(ledger.removed).toHaveLength(2);
+    });
+
+    it('treats a 404 transfer listing as already-gone: nothing to abort, success (prod 2026-07-22)', async () => {
+      // slskd 404s the downloads collection for a user with no transfers; for an abort that IS
+      // the desired end state — converge instead of wedging the reactor on a retryable fault.
+      const { adapter, deletes } = downloader({ polls: [{ status: 404, body: '' }] });
+
+      const result = await adapter.abort(ACQ, candidate);
+
+      expect(result._unsafeUnwrap()).toEqual([]);
+      expect(deletes).toEqual([]);
     });
 
     it('is a no-op when the candidate has no transfers left', async () => {

--- a/packages/downloader/src/adapters/slskd/download.ts
+++ b/packages/downloader/src/adapters/slskd/download.ts
@@ -162,8 +162,10 @@ export class SlskdDownload implements DownloadPort {
     let lastProgressAt = start;
     const captured = new Set<string>();
     for (;;) {
+      // 404 = the user has no transfers at slskd (a state, not a fault): an empty page lets the
+      // stall/queue budgets settle the outcome instead of wedging retry on a vanished collection.
       const payload = slskdTransfersSchema.parse(
-        await this.client.get(this.downloadsPath(username)),
+        await this.client.getOr(this.downloadsPath(username), {}),
       );
       const mine = flattenDownloads(payload).filter(
         (transfer): transfer is SlskdTransfer & { filename: string } =>
@@ -230,7 +232,9 @@ export class SlskdDownload implements DownloadPort {
     const ownedKeys = filenames.map((filename) =>
       this.transferKey(acquisitionId, username, filename),
     );
-    const payload = slskdTransfersSchema.parse(await this.client.get(this.downloadsPath(username)));
+    const payload = slskdTransfersSchema.parse(
+      await this.client.getOr(this.downloadsPath(username), {}),
+    );
     const mine = flattenDownloads(payload).filter(
       (transfer): transfer is OwnedTransfer =>
         transfer.filename !== undefined && wanted.has(transfer.filename),
@@ -320,7 +324,9 @@ export class SlskdDownload implements DownloadPort {
 
   /** Re-poll the user's downloads, narrowed to the transfers this teardown owns. */
   private async pollMine(username: string, wanted: ReadonlySet<string>): Promise<OwnedTransfer[]> {
-    const payload = slskdTransfersSchema.parse(await this.client.get(this.downloadsPath(username)));
+    const payload = slskdTransfersSchema.parse(
+      await this.client.getOr(this.downloadsPath(username), {}),
+    );
     return flattenDownloads(payload).filter(
       (transfer): transfer is OwnedTransfer =>
         transfer.filename !== undefined && wanted.has(transfer.filename),


### PR DESCRIPTION
Fourth instance of the misclassified-permanent-failure family, found because a user noticed a "Downloading" acquisition with no slskd transfer: the reactor was wedged on a *cancelled* acquisition's `AbortDownload` — slskd 404s the transfers listing of a user with no transfers, the abort's GET threw, and the retryable `InfraError` starved the live acquisition's `Download` dispatch queued behind it.

Fix: `SlskdClient.getOr(path, notFound)` — a 404 on the transfers listing yields an empty page (the same already-gone-is-converged semantics `delIfPresent` has had all along), applied at all three listing sites: abort (nothing to abort → success), the download poll loop (transfers vanished → the stall budget settles it as `Stalled`), and the teardown re-poll. Other non-2xx still throw.

Tests: client `getOr` (404 fallback / 2xx parse / other non-2xx throws / empty body), abort-on-404 convergence, and mid-download 404 → `Stalled` (not `InfraError`).

This unwedges the currently-stuck queue on flight; the class-level fix (per-stream parking so a poisoned effect can never starve the queue) is the merged `reactor-durability` proposal, PR #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)