### PR TITLE
SOLID-review backlog: exhaustive status mapping, dead port removal, SlskdDownload decomposition (v3.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.3.4](https://github.com/jgchk/music-downloader/compare/v3.3.3...v3.3.4) (2026-07-22)
+
+
+### Bug Fixes
+
+* **web:** map facade errors to HTTP status exhaustively ([41265da](https://github.com/jgchk/music-downloader/commit/41265da29a3b9858849544cf2d460724e9912415))
+
 ## [3.3.3](https://github.com/jgchk/music-downloader/compare/v3.3.2...v3.3.3) (2026-07-22)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "private": true,
   "description": "An extensible, event-sourced music downloader and importer — a modular monolith.",
   "type": "module",

--- a/packages/downloader/src/adapters/slskd/client.ts
+++ b/packages/downloader/src/adapters/slskd/client.ts
@@ -10,6 +10,11 @@ import type { HttpClient } from '../support/http.js';
 
 const DEFAULT_BASE_URL = 'http://localhost:5030';
 
+/** The per-user downloads collection path, shared by enqueue, polling, teardown, and the sweep. */
+export function downloadsPath(username: string): string {
+  return `/api/v0/transfers/downloads/${encodeURIComponent(username)}`;
+}
+
 export interface SlskdConfig {
   readonly baseUrl?: string;
   readonly apiKey?: string;

--- a/packages/downloader/src/adapters/slskd/download.ts
+++ b/packages/downloader/src/adapters/slskd/download.ts
@@ -14,21 +14,17 @@ import type {
   SourceResourceKey,
 } from '../../application/ports/resource-ledger-port.js';
 import type { Logger } from '../../application/logging/logger.js';
-import { SlskdClient } from './client.js';
+import { downloadsPath, SlskdClient } from './client.js';
 import type { SlskdConfig } from './client.js';
 import { remoteFilename } from './mapping.js';
-import { slskdEventsSchema, slskdOptionsSchema, slskdTransfersSchema } from './schemas.js';
-import { resolveStagedPaths } from './staged-location.js';
+import { pollOwnedTransfers } from './poll.js';
+import { StagedFileResolver } from './staged-files.js';
+import { TransferLedger, filenameOfKey } from './transfer-ledger.js';
+import { TransferTeardown } from './teardown.js';
 import { realTimer } from './timer.js';
 import type { Timer } from './timer.js';
-import {
-  aggregate,
-  enqueueRejectionReason,
-  flattenDownloads,
-  isTransferComplete,
-  isTransferSucceeded,
-} from './transfers.js';
-import type { SlskdTransfer } from './transfers.js';
+import { aggregate, enqueueRejectionReason } from './transfers.js';
+import type { OwnedTransfer } from './transfers.js';
 
 /**
  * The slskd `DownloadPort` adapter (D10). It enqueues a candidate's files, polls slskd for progress
@@ -37,25 +33,14 @@ import type { SlskdTransfer } from './transfers.js';
  * policy's thresholds (the policy stays source-agnostic), and dooms the whole candidate the moment
  * any file fails rather than downloading the rest of a release it will reject.
  *
- * Completed files are reported at the *actual* on-disk location slskd wrote them — read from slskd's
- * `DownloadFileComplete` events (`localFilename`, correlated by `transfer.id`) and re-rooted onto
- * `STAGING_ROOT` — so the library adapter imports (or `discardStaging`s) real, existing paths rather
- * than a location recomputed from candidate identity (design D1/D2). The staged location is never
- * derived from slskd's OS / destination template / sanitizer; those are slskd's alone. On an abandoned
- * or doomed candidate the *already-completed* subset is resolved the same way and reported on the
- * failed outcome, so the domain's `discardStaging` cleans those partial files rather than orphaning
- * them (design D2). Resolving that subset is best-effort (D3): a lag or fault yields no files, never
- * an infra fault — the adapter itself never touches the filesystem.
- *
- * Every transfer is recorded in the ownership ledger write-ahead (before enqueue) and torn down on
- * every terminal outcome — completed, failed, doomed, or abandoned — so records from one attempt can
- * never contaminate a later attempt's outcome (D: source-resource stewardship). Because slskd's remove
- * is guarded on the terminal flag, teardown is two-step: an in-flight transfer is cancelled, re-polled
- * until terminal, then removed, and a ledger row is marked removed **only** once its record is
- * confirmed gone (design D1). A row not confirmed within the bound stays live so the startup sweep
- * retires it — the backstop for unconfirmed removals. Ledger bookkeeping is best-effort: the adapter's
- * own correctness rests on the in-memory owned set and the live slskd payload, so a ledger fault
- * degrades sweep coverage but never a working download.
+ * The orthogonal concerns are collaborators, composed here from the adapter's own dependencies:
+ * completed files are reported at the actual on-disk location slskd wrote them by the
+ * {@link StagedFileResolver}; ownership rows are recorded write-ahead and retired by the
+ * {@link TransferLedger}; and every terminal outcome — completed, failed, doomed, or abandoned —
+ * tears its transfers down at the source via the two-phase {@link TransferTeardown}, so records
+ * from one attempt can never contaminate a later attempt's outcome (D: source-resource
+ * stewardship). A teardown not confirmed within its bound leaves the ledger row live so the
+ * startup sweep retires it — the backstop for unconfirmed removals.
  *
  * Deployment prerequisites (out of this codebase, tracked in the deploy repo): `STAGING_ROOT` must
  * point at the same volume as slskd's downloads directory, and slskd must run as `PUID/PGID=1000`
@@ -63,48 +48,37 @@ import type { SlskdTransfer } from './transfers.js';
  */
 
 const DEFAULT_POLL_INTERVAL_MS = 1_000;
-const SLSKD_SOURCE = 'slskd';
-/** One page of slskd's newest-first events log; our just-completed events sit at its head. */
-const EVENTS_PAGE_LIMIT = 100;
-/** How many times to re-poll the events log for an id whose completion event still lags. */
-const MAX_EVENT_POLLS = 5;
-/**
- * How many cancel→poll→remove rounds teardown attempts before leaving an unconfirmed transfer to the
- * startup sweep (design D1). Cancellation transitions a transfer to terminal asynchronously, so a
- * small bound absorbs that lag without blocking a settled/abandoned outcome on a flaky transition.
- */
-const MAX_REMOVE_ROUNDS = 3;
 
 export interface SlskdDownloadConfig extends SlskdConfig {
   /** Root under which each candidate's files are staged (shared with the filesystem library). */
   readonly stagingRoot: string;
 }
 
-/** The remote filename half of a transfer ledger key (`${username}|${filename}`). */
-function filenameOfKey(key: SourceResourceKey): string {
-  return key.resourceKey.slice(key.resourceKey.indexOf('|') + 1);
-}
-
-/** A transfer we own: narrowed to a known `filename` (the poll filters foreign/filenameless ones). */
-type OwnedTransfer = SlskdTransfer & { readonly filename: string };
-
 export class SlskdDownload implements DownloadPort {
   private readonly client: SlskdClient;
   private readonly pollIntervalMs: number;
-  private readonly stagingRoot: string;
-  /** slskd's downloads root, read once from `/api/v0/options`; it does not change at runtime. */
-  private cachedDownloadsRoot?: string;
+  private readonly transferLedger: TransferLedger;
+  private readonly teardown: TransferTeardown;
+  private readonly staged: StagedFileResolver;
 
   constructor(
     private readonly logger: Logger,
-    private readonly ledger: ResourceLedgerStore,
+    ledger: ResourceLedgerStore,
     config: SlskdDownloadConfig,
     client: SlskdClient = new SlskdClient(),
     private readonly timer: Timer = realTimer,
   ) {
     this.client = client;
-    this.stagingRoot = config.stagingRoot;
     this.pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.transferLedger = new TransferLedger(logger, ledger);
+    this.teardown = new TransferTeardown(logger, client, timer, this.pollIntervalMs);
+    this.staged = new StagedFileResolver(
+      logger,
+      client,
+      timer,
+      config.stagingRoot,
+      this.pollIntervalMs,
+    );
   }
 
   download(
@@ -132,14 +106,12 @@ export class SlskdDownload implements DownloadPort {
     }));
     const wanted = new Set(requests.map((request) => request.filename));
     const ownedKeys = requests.map((request) =>
-      this.transferKey(acquisitionId, username, request.filename),
+      this.transferLedger.keyFor(acquisitionId, username, request.filename),
     );
 
-    // Write-ahead: record ownership before the enqueue, so a crash still leaves the sweep a trail.
-    for (const key of ownedKeys)
-      await this.record(this.ledger.recordCreated({ ...key }), 'record transfer');
+    await this.transferLedger.recordCreated(ownedKeys);
     this.logger.debug({ username, fileCount: requests.length }, 'enqueueing slskd download');
-    const enqueue = await this.client.postRaw(this.downloadsPath(username), requests);
+    const enqueue = await this.client.postRaw(downloadsPath(username), requests);
     if (enqueue.status < 200 || enqueue.status >= 300) {
       // slskd answered, so the infrastructure is up: it refused THIS candidate's enqueue
       // (typically an unreachable peer). That is a business failure for the retry ladder — reject
@@ -151,9 +123,7 @@ export class SlskdDownload implements DownloadPort {
         { username, status: enqueue.status, reason },
         'slskd rejected the enqueue; failing the candidate',
       );
-      for (const key of ownedKeys) {
-        await this.record(this.ledger.markRemoved(key), 'release rejected transfer');
-      }
+      await this.transferLedger.release(ownedKeys);
       return { kind: 'failed', reason };
     }
 
@@ -162,22 +132,14 @@ export class SlskdDownload implements DownloadPort {
     let lastProgressAt = start;
     const captured = new Set<string>();
     for (;;) {
-      // 404 = the user has no transfers at slskd (a state, not a fault): an empty page lets the
-      // stall/queue budgets settle the outcome instead of wedging retry on a vanished collection.
-      const payload = slskdTransfersSchema.parse(
-        await this.client.getOr(this.downloadsPath(username), {}),
-      );
-      const mine = flattenDownloads(payload).filter(
-        (transfer): transfer is SlskdTransfer & { filename: string } =>
-          transfer.filename !== undefined && wanted.has(transfer.filename),
-      );
-      await this.captureIds(acquisitionId, username, mine, captured);
+      const mine = await pollOwnedTransfers(this.client, username, wanted);
+      await this.transferLedger.captureIds(acquisitionId, username, mine, captured);
       const status = aggregate(mine);
       onProgress(status.progress);
 
       if (status.succeeded) {
         this.logger.debug({ username }, 'slskd download completed');
-        const files = await this.stagedFiles(mine, candidate);
+        const files = await this.staged.stagedFiles(mine, candidate);
         await this.removeOwned(username, mine, ownedKeys);
         return { kind: 'completed', files };
       }
@@ -186,7 +148,7 @@ export class SlskdDownload implements DownloadPort {
         // and report the original failure, not the cancellation it triggers. Files that succeeded
         // before the doom are reported so their staging is cleaned (design D2).
         this.logger.warn({ username, reason: status.failureReason }, 'slskd download failed');
-        const files = await this.completedStagedFiles(mine, candidate);
+        const files = await this.staged.completedStagedFiles(mine, candidate);
         await this.removeOwned(username, mine, ownedKeys);
         return { kind: 'failed', reason: status.failureReason, files };
       }
@@ -230,19 +192,13 @@ export class SlskdDownload implements DownloadPort {
     );
     const wanted = new Set(filenames);
     const ownedKeys = filenames.map((filename) =>
-      this.transferKey(acquisitionId, username, filename),
+      this.transferLedger.keyFor(acquisitionId, username, filename),
     );
-    const payload = slskdTransfersSchema.parse(
-      await this.client.getOr(this.downloadsPath(username), {}),
-    );
-    const mine = flattenDownloads(payload).filter(
-      (transfer): transfer is OwnedTransfer =>
-        transfer.filename !== undefined && wanted.has(transfer.filename),
-    );
+    const mine = await pollOwnedTransfers(this.client, username, wanted);
     this.logger.debug({ username, count: mine.length }, 'aborting slskd download');
     // Resolve the already-completed subset before removal (the events log outlives the record), so
     // the caller can clean its staging even though the domain never saw a completion (design D2).
-    const files = await this.completedStagedFiles(mine, candidate);
+    const files = await this.staged.completedStagedFiles(mine, candidate);
     await this.removeOwned(username, mine, ownedKeys);
     return files;
   }
@@ -260,17 +216,15 @@ export class SlskdDownload implements DownloadPort {
     candidate: Candidate,
   ): Promise<DownloadResult> {
     this.logger.warn({ username, reason }, 'abandoning slskd download');
-    const files = await this.completedStagedFiles(mine, candidate);
+    const files = await this.staged.completedStagedFiles(mine, candidate);
     await this.removeOwned(username, mine, ownedKeys);
     return { kind: 'failed', reason, files };
   }
 
   /**
    * Tear down each owned transfer at the source, then mark a ledger row removed **only** once its
-   * record is confirmed gone (design D1). Best-effort: the outcome is already decided, so a removal
-   * fault (or a record slskd already dropped) never turns a settled download into an error. A record
-   * not confirmed gone within the bound leaves its ledger row live, so the startup sweep converges it
-   * (rather than the old bug of marking it removed while a cancelled record lingered at the source).
+   * record is confirmed gone (slskd-abandon-full-teardown D1) — a row not confirmed within the
+   * bound stays live so the startup sweep retires it.
    */
   private async removeOwned(
     username: string,
@@ -278,192 +232,7 @@ export class SlskdDownload implements DownloadPort {
     ownedKeys: readonly SourceResourceKey[],
   ): Promise<void> {
     const wanted = new Set(ownedKeys.map((key) => filenameOfKey(key)));
-    const stillPresent = await this.teardownTransfers(username, mine, wanted);
-    for (const key of ownedKeys) {
-      if (stillPresent.has(filenameOfKey(key))) continue; // unconfirmed — leave live for the sweep
-      await this.record(this.ledger.markRemoved(key), 'mark transfer removed');
-    }
-  }
-
-  /**
-   * Cancel each present transfer and remove its record once terminal, confirming the record is gone
-   * (design D1). slskd's synchronous remove is guarded on the `Completed` flag, so an in-flight
-   * transfer is cancelled with `?remove=false` (a `?remove=true` would 500), then re-polled until it
-   * carries the flag and removed with `?remove=true`; an already-terminal transfer is removed on the
-   * first pass with no re-poll. Bounded by {@link MAX_REMOVE_ROUNDS}; returns the filenames still
-   * present at the source when the bound is hit, so the caller keeps their ledger rows live.
-   */
-  private async teardownTransfers(
-    username: string,
-    present: readonly OwnedTransfer[],
-    wanted: ReadonlySet<string>,
-  ): Promise<Set<string>> {
-    let current = present;
-    for (let round = 1; ; round++) {
-      const unconfirmed: OwnedTransfer[] = [];
-      for (const transfer of current) {
-        const terminal = isTransferComplete(transfer);
-        try {
-          await this.client.delIfPresent(
-            `${this.downloadsPath(username)}/${encodeURIComponent(transfer.id ?? '')}?remove=${terminal}`,
-          );
-          if (!terminal) unconfirmed.push(transfer); // cancelled — must re-poll to confirm removal
-        } catch (err) {
-          this.logger.warn({ err, username }, 'failed to tear down a slskd transfer');
-          unconfirmed.push(transfer);
-        }
-      }
-      if (unconfirmed.length === 0) return new Set(); // every terminal record removed cleanly
-      if (round >= MAX_REMOVE_ROUNDS)
-        return new Set(unconfirmed.map((transfer) => transfer.filename));
-      await this.timer.sleep(this.pollIntervalMs);
-      current = await this.pollMine(username, wanted);
-      if (current.length === 0) return new Set(); // the cancelled records transitioned and are gone
-    }
-  }
-
-  /** Re-poll the user's downloads, narrowed to the transfers this teardown owns. */
-  private async pollMine(username: string, wanted: ReadonlySet<string>): Promise<OwnedTransfer[]> {
-    const payload = slskdTransfersSchema.parse(
-      await this.client.getOr(this.downloadsPath(username), {}),
-    );
-    return flattenDownloads(payload).filter(
-      (transfer): transfer is OwnedTransfer =>
-        transfer.filename !== undefined && wanted.has(transfer.filename),
-    );
-  }
-
-  /**
-   * Resolve the staged locations of the transfers that succeeded before the candidate was abandoned
-   * or doomed, so the domain can clean them (design D2). Best-effort (D3): a resolution fault (the
-   * events log lagging, a bad options body) yields no files rather than turning the settled failure
-   * into an infra fault — the orphaned files fall to a later reconciliation instead of wedging retry.
-   */
-  private async completedStagedFiles(
-    mine: readonly OwnedTransfer[],
-    candidate: Candidate,
-  ): Promise<readonly DownloadedFile[]> {
-    const completed = mine.filter(
-      (transfer) => isTransferSucceeded(transfer) && transfer.id !== undefined,
-    );
-    if (completed.length === 0) return [];
-    try {
-      return await this.stagedFiles(completed, candidate);
-    } catch (err) {
-      this.logger.warn(
-        { err, username: candidate.identity.username },
-        'could not resolve the abandoned candidate’s completed files',
-      );
-      return [];
-    }
-  }
-
-  /** Attach each newly-seen transfer's slskd GUID to its ledger row, so the sweep can delete it. */
-  private async captureIds(
-    acquisitionId: string,
-    username: string,
-    mine: readonly (SlskdTransfer & { filename: string })[],
-    captured: Set<string>,
-  ): Promise<void> {
-    for (const transfer of mine) {
-      const { id, filename } = transfer;
-      if (id === undefined || captured.has(filename)) continue;
-      captured.add(filename);
-      const key = this.transferKey(acquisitionId, username, filename);
-      await this.record(this.ledger.recordId(key, id), 'record transfer id');
-    }
-  }
-
-  /** Run a ledger write without letting a stewardship fault fail an otherwise-working download. */
-  private async record(op: ResultAsync<void, InfraError>, what: string): Promise<void> {
-    const result = await op;
-    if (result.isErr()) this.logger.warn({ err: result.error }, `ledger: ${what} failed`);
-  }
-
-  private transferKey(
-    acquisitionId: string,
-    username: string,
-    filename: string,
-  ): SourceResourceKey {
-    return {
-      source: SLSKD_SOURCE,
-      kind: 'transfer',
-      resourceKey: `${username}|${filename}`,
-      acquisitionId,
-    };
-  }
-
-  /**
-   * Report each completed file at the real path slskd wrote, correlated to our transfers by id.
-   * The clean candidate file name is kept for the library; only the *path* comes from slskd.
-   */
-  private async stagedFiles(
-    transfers: readonly SlskdTransfer[],
-    candidate: Candidate,
-  ): Promise<DownloadedFile[]> {
-    const downloadsRoot = await this.downloadsRoot();
-    const wantedIds = new Set(transfers.map((transfer) => transfer.id!));
-    const resolved = await this.resolveStaged(wantedIds, downloadsRoot);
-    const nameByRemote = new Map(
-      candidate.files.map((file) => [
-        remoteFilename(candidate.identity.path, file.name),
-        file.name,
-      ]),
-    );
-    return transfers.map((transfer) => ({
-      name: nameByRemote.get(transfer.filename!)!,
-      path: resolved.get(transfer.id!)!,
-    }));
-  }
-
-  /**
-   * Page the newest-first events log for our completed transfers, re-rooting each onto the staging
-   * volume (design D2). Our events sit at the head right after completion; the scan walks older
-   * pages until every id resolves or a page comes back empty (log exhausted). An id can lag its
-   * transfer-state flip by moments, so an exhausted log triggers a bounded re-poll from the top;
-   * persistent absence is an infra fault the acquisition retry then handles.
-   */
-  private async resolveStaged(
-    wantedIds: ReadonlySet<string>,
-    downloadsRoot: string,
-  ): Promise<Map<string, string>> {
-    const resolved = new Map<string, string>();
-    let offset = 0;
-    let polls = 0;
-    for (;;) {
-      const events = slskdEventsSchema.parse(await this.client.events(offset, EVENTS_PAGE_LIMIT));
-      for (const [id, path] of resolveStagedPaths(
-        wantedIds,
-        events,
-        downloadsRoot,
-        this.stagingRoot,
-      )) {
-        resolved.set(id, path);
-      }
-      if (resolved.size === wantedIds.size) return resolved;
-      if (events.length > 0) {
-        offset += EVENTS_PAGE_LIMIT; // older events remain to scan before concluding it hasn't arrived
-        continue;
-      }
-      if (++polls >= MAX_EVENT_POLLS) {
-        throw new Error(
-          `slskd events did not report ${wantedIds.size - resolved.size} completed file(s)`,
-        );
-      }
-      offset = 0; // re-scan from the head after the lag window
-      await this.timer.sleep(this.pollIntervalMs);
-    }
-  }
-
-  private async downloadsRoot(): Promise<string> {
-    if (this.cachedDownloadsRoot === undefined) {
-      const options = slskdOptionsSchema.parse(await this.client.options());
-      this.cachedDownloadsRoot = options.directories.downloads;
-    }
-    return this.cachedDownloadsRoot;
-  }
-
-  private downloadsPath(username: string): string {
-    return `/api/v0/transfers/downloads/${encodeURIComponent(username)}`;
+    const stillPresent = await this.teardown.teardown(username, mine, wanted);
+    await this.transferLedger.markRemoved(ownedKeys, stillPresent);
   }
 }

--- a/packages/downloader/src/adapters/slskd/index.ts
+++ b/packages/downloader/src/adapters/slskd/index.ts
@@ -4,4 +4,8 @@ export * from './mapping.js';
 export * from './transfers.js';
 export * from './search.js';
 export * from './download.js';
+export * from './poll.js';
+export * from './transfer-ledger.js';
+export * from './teardown.js';
+export * from './staged-files.js';
 export * from './resource-remover.js';

--- a/packages/downloader/src/adapters/slskd/poll.ts
+++ b/packages/downloader/src/adapters/slskd/poll.ts
@@ -1,0 +1,23 @@
+import { downloadsPath } from './client.js';
+import type { SlskdClient } from './client.js';
+import { slskdTransfersSchema } from './schemas.js';
+import { flattenDownloads } from './transfers.js';
+import type { OwnedTransfer } from './transfers.js';
+
+/**
+ * The shared ownership-narrowed poll of a user's downloads: one page, filtered to the transfers
+ * the caller owns. A 404 means the user has no transfers at slskd — a state, not a fault — so it
+ * folds to an empty page and the caller's budgets settle the outcome instead of wedging retry on a
+ * vanished collection (prod 2026-07-22).
+ */
+export async function pollOwnedTransfers(
+  client: SlskdClient,
+  username: string,
+  wanted: ReadonlySet<string>,
+): Promise<OwnedTransfer[]> {
+  const payload = slskdTransfersSchema.parse(await client.getOr(downloadsPath(username), {}));
+  return flattenDownloads(payload).filter(
+    (transfer): transfer is OwnedTransfer =>
+      transfer.filename !== undefined && wanted.has(transfer.filename),
+  );
+}

--- a/packages/downloader/src/adapters/slskd/resource-remover.ts
+++ b/packages/downloader/src/adapters/slskd/resource-remover.ts
@@ -6,7 +6,7 @@ import type {
   SourceResourceRemover,
 } from '../../application/ports/resource-ledger-port.js';
 import type { Logger } from '../../application/logging/logger.js';
-import { SlskdClient } from './client.js';
+import { downloadsPath, SlskdClient } from './client.js';
 import { slskdTransfersSchema } from './schemas.js';
 import { realTimer } from './timer.js';
 import type { Timer } from './timer.js';
@@ -76,7 +76,7 @@ export class SlskdResourceRemover implements SourceResourceRemover {
       const id = current.id ?? capturedId ?? '';
       this.logger.debug({ username, id, terminal }, 'sweeping slskd transfer');
       await this.client.delIfPresent(
-        `/api/v0/transfers/downloads/${encodeURIComponent(username)}/${encodeURIComponent(id)}?remove=${terminal}`,
+        `${downloadsPath(username)}/${encodeURIComponent(id)}?remove=${terminal}`,
       );
       if (round >= MAX_REMOVE_ROUNDS) break;
       await this.timer.sleep(this.pollIntervalMs);
@@ -91,9 +91,7 @@ export class SlskdResourceRemover implements SourceResourceRemover {
     filename: string,
     capturedId: string | undefined,
   ): Promise<SlskdTransfer | undefined> {
-    const payload = slskdTransfersSchema.parse(
-      await this.client.get(`/api/v0/transfers/downloads/${encodeURIComponent(username)}`),
-    );
+    const payload = slskdTransfersSchema.parse(await this.client.get(downloadsPath(username)));
     return flattenDownloads(payload).find(
       (transfer) =>
         transfer.filename === filename || (capturedId !== undefined && transfer.id === capturedId),

--- a/packages/downloader/src/adapters/slskd/staged-files.ts
+++ b/packages/downloader/src/adapters/slskd/staged-files.ts
@@ -1,0 +1,135 @@
+import type { DownloadedFile } from '../../domain/acquisition/events.js';
+import type { Candidate } from '../../domain/candidate/candidate.js';
+import type { Logger } from '../../application/logging/logger.js';
+import type { SlskdClient } from './client.js';
+import { remoteFilename } from './mapping.js';
+import { slskdEventsSchema, slskdOptionsSchema } from './schemas.js';
+import { resolveStagedPaths } from './staged-location.js';
+import type { Timer } from './timer.js';
+import { isTransferSucceeded } from './transfers.js';
+import type { OwnedTransfer } from './transfers.js';
+
+/**
+ * Resolves the *actual* on-disk location slskd wrote each completed file — read from slskd's
+ * `DownloadFileComplete` events (`localFilename`, correlated by `transfer.id`) and re-rooted onto
+ * `STAGING_ROOT` — so the library adapter imports (or `discardStaging`s) real, existing paths
+ * rather than a location recomputed from candidate identity (slskd-report-staged-location D1/D2).
+ * The staged location is
+ * never derived from slskd's OS / destination template / sanitizer; those are slskd's alone. The
+ * resolver itself never touches the filesystem.
+ */
+
+/** One page of slskd's newest-first events log; our just-completed events sit at its head. */
+const EVENTS_PAGE_LIMIT = 100;
+/** How many times to re-poll the events log for an id whose completion event still lags. */
+const MAX_EVENT_POLLS = 5;
+
+export class StagedFileResolver {
+  /** slskd's downloads root, read once from `/api/v0/options`; it does not change at runtime. */
+  private cachedDownloadsRoot?: string;
+
+  constructor(
+    private readonly logger: Logger,
+    private readonly client: SlskdClient,
+    private readonly timer: Timer,
+    private readonly stagingRoot: string,
+    private readonly pollIntervalMs: number,
+  ) {}
+
+  /**
+   * Report each completed file at the real path slskd wrote, correlated to our transfers by id.
+   * The clean candidate file name is kept for the library; only the *path* comes from slskd.
+   */
+  async stagedFiles(
+    transfers: readonly OwnedTransfer[],
+    candidate: Candidate,
+  ): Promise<DownloadedFile[]> {
+    const downloadsRoot = await this.downloadsRoot();
+    const wantedIds = new Set(transfers.map((transfer) => transfer.id!));
+    const resolved = await this.resolveStaged(wantedIds, downloadsRoot);
+    const nameByRemote = new Map(
+      candidate.files.map((file) => [
+        remoteFilename(candidate.identity.path, file.name),
+        file.name,
+      ]),
+    );
+    return transfers.map((transfer) => ({
+      name: nameByRemote.get(transfer.filename)!,
+      path: resolved.get(transfer.id!)!,
+    }));
+  }
+
+  /**
+   * Resolve the staged locations of the transfers that succeeded before the candidate was abandoned
+   * or doomed, so the domain can clean them (slskd-abandon-full-teardown D2). Best-effort
+   * (slskd-abandon-full-teardown D3): a resolution fault (the
+   * events log lagging, a bad options body) yields no files rather than turning the settled failure
+   * into an infra fault — the orphaned files fall to a later reconciliation instead of wedging retry.
+   */
+  async completedStagedFiles(
+    mine: readonly OwnedTransfer[],
+    candidate: Candidate,
+  ): Promise<readonly DownloadedFile[]> {
+    const completed = mine.filter(
+      (transfer) => isTransferSucceeded(transfer) && transfer.id !== undefined,
+    );
+    if (completed.length === 0) return [];
+    try {
+      return await this.stagedFiles(completed, candidate);
+    } catch (err) {
+      this.logger.warn(
+        { err, username: candidate.identity.username },
+        'could not resolve the abandoned candidate’s completed files',
+      );
+      return [];
+    }
+  }
+
+  /**
+   * Page the newest-first events log for our completed transfers, re-rooting each onto the staging
+   * volume (slskd-report-staged-location D2). Our events sit at the head right after completion;
+   * the scan walks older
+   * pages until every id resolves or a page comes back empty (log exhausted). An id can lag its
+   * transfer-state flip by moments, so an exhausted log triggers a bounded re-poll from the top;
+   * persistent absence is an infra fault the acquisition retry then handles.
+   */
+  private async resolveStaged(
+    wantedIds: ReadonlySet<string>,
+    downloadsRoot: string,
+  ): Promise<Map<string, string>> {
+    const resolved = new Map<string, string>();
+    let offset = 0;
+    let polls = 0;
+    for (;;) {
+      const events = slskdEventsSchema.parse(await this.client.events(offset, EVENTS_PAGE_LIMIT));
+      for (const [id, path] of resolveStagedPaths(
+        wantedIds,
+        events,
+        downloadsRoot,
+        this.stagingRoot,
+      )) {
+        resolved.set(id, path);
+      }
+      if (resolved.size === wantedIds.size) return resolved;
+      if (events.length > 0) {
+        offset += EVENTS_PAGE_LIMIT; // older events remain to scan before concluding it hasn't arrived
+        continue;
+      }
+      if (++polls >= MAX_EVENT_POLLS) {
+        throw new Error(
+          `slskd events did not report ${wantedIds.size - resolved.size} completed file(s)`,
+        );
+      }
+      offset = 0; // re-scan from the head after the lag window
+      await this.timer.sleep(this.pollIntervalMs);
+    }
+  }
+
+  private async downloadsRoot(): Promise<string> {
+    if (this.cachedDownloadsRoot === undefined) {
+      const options = slskdOptionsSchema.parse(await this.client.options());
+      this.cachedDownloadsRoot = options.directories.downloads;
+    }
+    return this.cachedDownloadsRoot;
+  }
+}

--- a/packages/downloader/src/adapters/slskd/teardown.ts
+++ b/packages/downloader/src/adapters/slskd/teardown.ts
@@ -1,0 +1,68 @@
+import type { Logger } from '../../application/logging/logger.js';
+import { downloadsPath } from './client.js';
+import type { SlskdClient } from './client.js';
+import { pollOwnedTransfers } from './poll.js';
+import type { Timer } from './timer.js';
+import { isTransferComplete } from './transfers.js';
+import type { OwnedTransfer } from './transfers.js';
+
+/**
+ * Two-phase teardown of owned transfers at the source (slskd-abandon-full-teardown D1). slskd's
+ * synchronous remove is guarded on the `Completed` flag, so an in-flight transfer is cancelled with
+ * `?remove=false` (a `?remove=true` would 500), re-polled until it carries the flag, and removed
+ * with `?remove=true`; an already-terminal transfer is removed on the first pass with no re-poll.
+ * Removal faults are absorbed — the outcome is already decided, so a failed DELETE (or a record
+ * slskd already dropped) leaves the transfer unconfirmed rather than erroring; a between-round
+ * re-poll fault still propagates to the caller.
+ */
+
+/**
+ * How many cancel→poll→remove rounds teardown attempts before leaving an unconfirmed transfer to
+ * the startup sweep (slskd-abandon-full-teardown D1). Cancellation transitions a transfer to
+ * terminal asynchronously, so a small bound absorbs that lag without blocking a settled/abandoned
+ * outcome on a flaky transition.
+ */
+const MAX_REMOVE_ROUNDS = 3;
+
+export class TransferTeardown {
+  constructor(
+    private readonly logger: Logger,
+    private readonly client: SlskdClient,
+    private readonly timer: Timer,
+    private readonly pollIntervalMs: number,
+  ) {}
+
+  /**
+   * Cancel each present transfer and remove its record once terminal, confirming the record is
+   * gone. Bounded by {@link MAX_REMOVE_ROUNDS}; returns the filenames still present at the source
+   * when the bound is hit, so the caller keeps their ledger rows live.
+   */
+  async teardown(
+    username: string,
+    present: readonly OwnedTransfer[],
+    wanted: ReadonlySet<string>,
+  ): Promise<Set<string>> {
+    let current = present;
+    for (let round = 1; ; round++) {
+      const unconfirmed: OwnedTransfer[] = [];
+      for (const transfer of current) {
+        const terminal = isTransferComplete(transfer);
+        try {
+          await this.client.delIfPresent(
+            `${downloadsPath(username)}/${encodeURIComponent(transfer.id ?? '')}?remove=${terminal}`,
+          );
+          if (!terminal) unconfirmed.push(transfer); // cancelled — must re-poll to confirm removal
+        } catch (err) {
+          this.logger.warn({ err, username }, 'failed to tear down a slskd transfer');
+          unconfirmed.push(transfer);
+        }
+      }
+      if (unconfirmed.length === 0) return new Set(); // every terminal record removed cleanly
+      if (round >= MAX_REMOVE_ROUNDS)
+        return new Set(unconfirmed.map((transfer) => transfer.filename));
+      await this.timer.sleep(this.pollIntervalMs);
+      current = await pollOwnedTransfers(this.client, username, wanted);
+      if (current.length === 0) return new Set(); // the cancelled records transitioned and are gone
+    }
+  }
+}

--- a/packages/downloader/src/adapters/slskd/transfer-ledger.ts
+++ b/packages/downloader/src/adapters/slskd/transfer-ledger.ts
@@ -1,0 +1,90 @@
+import type { ResultAsync } from 'neverthrow';
+import type { InfraError } from '../../application/ports/errors.js';
+import type { Logger } from '../../application/logging/logger.js';
+import type {
+  ResourceLedgerStore,
+  SourceResourceKey,
+} from '../../application/ports/resource-ledger-port.js';
+import type { OwnedTransfer } from './transfers.js';
+
+/**
+ * Ledger stewardship for the transfers a download attempt owns (D: source-resource stewardship).
+ * Keys are recorded write-ahead (before the enqueue) so a crash still leaves the startup sweep a
+ * trail, slskd GUIDs are attached as they are first reported, and rows are marked removed only for
+ * records confirmed gone at the source. Every write is best-effort: `SlskdDownload`'s own
+ * correctness rests on its in-memory owned set and the live slskd payload, so a ledger fault
+ * degrades sweep coverage but never a working download.
+ */
+
+const SLSKD_SOURCE = 'slskd';
+
+/** The remote filename half of a transfer ledger key (`${username}|${filename}`). */
+export function filenameOfKey(key: SourceResourceKey): string {
+  return key.resourceKey.slice(key.resourceKey.indexOf('|') + 1);
+}
+
+export class TransferLedger {
+  constructor(
+    private readonly logger: Logger,
+    private readonly ledger: ResourceLedgerStore,
+  ) {}
+
+  keyFor(acquisitionId: string, username: string, filename: string): SourceResourceKey {
+    return {
+      source: SLSKD_SOURCE,
+      kind: 'transfer',
+      resourceKey: `${username}|${filename}`,
+      acquisitionId,
+    };
+  }
+
+  /** Must run before the enqueue (write-ahead), so a crash still leaves the sweep a trail. */
+  async recordCreated(keys: readonly SourceResourceKey[]): Promise<void> {
+    for (const key of keys) {
+      await this.record(this.ledger.recordCreated({ ...key }), 'record transfer');
+    }
+  }
+
+  /** Release write-ahead rows for an enqueue slskd refused: nothing was created at the source. */
+  async release(keys: readonly SourceResourceKey[]): Promise<void> {
+    for (const key of keys) {
+      await this.record(this.ledger.markRemoved(key), 'release rejected transfer');
+    }
+  }
+
+  /** Attach each newly-seen transfer's slskd GUID to its ledger row, so the sweep can delete it. */
+  async captureIds(
+    acquisitionId: string,
+    username: string,
+    mine: readonly OwnedTransfer[],
+    captured: Set<string>,
+  ): Promise<void> {
+    for (const transfer of mine) {
+      const { id, filename } = transfer;
+      if (id === undefined || captured.has(filename)) continue;
+      captured.add(filename);
+      const key = this.keyFor(acquisitionId, username, filename);
+      await this.record(this.ledger.recordId(key, id), 'record transfer id');
+    }
+  }
+
+  /**
+   * Mark rows removed for the records teardown confirmed gone; a filename still present at the
+   * source keeps its row live so the startup sweep retires it (slskd-abandon-full-teardown D1).
+   */
+  async markRemoved(
+    keys: readonly SourceResourceKey[],
+    stillPresent: ReadonlySet<string>,
+  ): Promise<void> {
+    for (const key of keys) {
+      if (stillPresent.has(filenameOfKey(key))) continue;
+      await this.record(this.ledger.markRemoved(key), 'mark transfer removed');
+    }
+  }
+
+  /** Run a ledger write without letting a stewardship fault fail an otherwise-working download. */
+  private async record(op: ResultAsync<void, InfraError>, what: string): Promise<void> {
+    const result = await op;
+    if (result.isErr()) this.logger.warn({ err: result.error }, `ledger: ${what} failed`);
+  }
+}

--- a/packages/downloader/src/adapters/slskd/transfers.ts
+++ b/packages/downloader/src/adapters/slskd/transfers.ts
@@ -12,6 +12,9 @@ import type { SlskdTransfer, SlskdTransfersPayload } from './schemas.js';
 
 export type { SlskdTransfer };
 
+/** A transfer we own: narrowed to a known `filename` (the polls filter foreign/filenameless ones). */
+export type OwnedTransfer = SlskdTransfer & { readonly filename: string };
+
 /**
  * slskd's `GET …/downloads/{username}` returns a single user object whose transfers are grouped by
  * directory under `directories`; flatten those groups to a flat file list.

--- a/packages/downloader/src/application/ports/published-events-port.ts
+++ b/packages/downloader/src/application/ports/published-events-port.ts
@@ -1,24 +1,23 @@
-import type { Result, ResultAsync } from 'neverthrow';
+import type { Result } from 'neverthrow';
 import type { AcquisitionEventType } from '../../domain/acquisition/events.js';
-import type { InfraError } from './errors.js';
 import type { StoredEvent } from './event-store-port.js';
 
 /**
  * The outbound published-event seam (change: acquisition-outbound-events). Selected domain events
- * are translated into self-contained published payloads and delivered to configured webhook
- * subscribers. The contract (zod schemas, payload rendering) is owned by the interfaces layer;
- * the publisher only needs these shapes, so the mapping is injected behind this port and the
- * dependency rule holds.
+ * are translated into self-contained published payloads, served through the outbound feed to
+ * cross-module catch-up subscriptions. The contract (zod schemas, payload rendering) is owned by
+ * the interfaces layer; the publisher only needs these shapes, so the mapping is injected behind
+ * this port and the dependency rule holds.
  */
 
-/** A rendered outbound event: the Standard Webhooks `{type, timestamp, data}` body. */
+/** A rendered outbound event; the payload deliberately keeps the Standard Webhooks `{type, timestamp, data}` shape. */
 export interface PublishedEvent {
   readonly type: string; // e.g. 'acquisition.fulfilled'; a breaking change is a NEW type, never a mutation
   readonly timestamp: string; // ISO-8601 — when the domain event occurred (stable across redeliveries)
   readonly data: unknown; // schema-validated payload in the producer's own language
 }
 
-/** A payload-rendering defect: deterministic, so delivery is never attempted (errors are values). */
+/** A payload-rendering defect: deterministic, so the event is never served on the feed (errors are values). */
 export interface RenderError {
   readonly kind: 'RenderError';
   readonly eventType: string;
@@ -33,9 +32,4 @@ export interface RenderError {
 export interface PublishedEventMapping {
   publishes(type: AcquisitionEventType): boolean;
   render(stored: StoredEvent, prefix: readonly StoredEvent[]): Result<PublishedEvent, RenderError>;
-}
-
-/** Delivery of one published event to one subscriber; `Ok` means acknowledged (2xx). */
-export interface WebhookDeliveryPort {
-  deliver(url: string, deliveryId: string, event: PublishedEvent): ResultAsync<void, InfraError>;
 }

--- a/packages/downloader/src/domain/acquisition/react.ts
+++ b/packages/downloader/src/domain/acquisition/react.ts
@@ -47,6 +47,10 @@ export function react(event: AcquisitionEvent, state: AcquisitionState): readonl
     case 'EditionSelected':
       // The resume: resolve exactly the chosen release, reusing the direct-by-release-id path — no
       // new "release id → target" logic exists for manual selection (manual-edition-selection D2).
+      // `kind: 'musicbrainz'` is not a provider choice made here: `EditionSelected` carries a
+      // release MBID, so the direct-by-release-id request is the only kind that can express it. A
+      // second metadata provider would bring its own selection vocabulary (request kind + event),
+      // not reuse this arm.
       // `targetType: 'album'` is domain-guaranteed: `decide` only pauses release-group requests
       // (whose type pins album), so an awaiting acquisition can never hold anything else — and a
       // chosen edition is an album release by definition.

--- a/packages/importer/src/application/ports/published-events-port.ts
+++ b/packages/importer/src/application/ports/published-events-port.ts
@@ -1,24 +1,23 @@
-import type { Result, ResultAsync } from 'neverthrow';
+import type { Result } from 'neverthrow';
 import type { ImportEventType } from '../../domain/import/events.js';
-import type { InfraError } from './errors.js';
 import type { StoredEvent } from './event-store-port.js';
 
 /**
  * The outbound published-event seam (change: outbound-release-verdicts). Selected domain events
- * are translated into self-contained published payloads and delivered to configured webhook
- * subscribers. The contract (zod schemas, payload rendering) is owned by the interfaces layer;
- * the publisher only needs these shapes, so the mapping is injected behind this port and the
- * dependency rule holds.
+ * are translated into self-contained published payloads, served through the outbound feed to
+ * cross-module catch-up subscriptions. The contract (zod schemas, payload rendering) is owned by
+ * the interfaces layer; the publisher only needs these shapes, so the mapping is injected behind
+ * this port and the dependency rule holds.
  */
 
-/** A rendered outbound event: the Standard Webhooks `{type, timestamp, data}` body. */
+/** A rendered outbound event; the payload deliberately keeps the Standard Webhooks `{type, timestamp, data}` shape. */
 export interface PublishedEvent {
   readonly type: string; // e.g. 'release.verdict'; a breaking change is a NEW type, never a mutation
   readonly timestamp: string; // ISO-8601 — when the domain event occurred (stable across redeliveries)
   readonly data: unknown; // schema-validated payload in the producer's own language
 }
 
-/** A payload-rendering defect: deterministic, so delivery is never attempted (errors are values). */
+/** A payload-rendering defect: deterministic, so the event is never served on the feed (errors are values). */
 export interface RenderError {
   readonly kind: 'RenderError';
   readonly eventType: string;
@@ -33,9 +32,4 @@ export interface RenderError {
 export interface PublishedEventMapping {
   publishes(type: ImportEventType): boolean;
   render(stored: StoredEvent, prefix: readonly StoredEvent[]): Result<PublishedEvent, RenderError>;
-}
-
-/** Delivery of one published event to one subscriber; `Ok` means acknowledged (2xx). */
-export interface WebhookDeliveryPort {
-  deliver(url: string, deliveryId: string, event: PublishedEvent): ResultAsync<void, InfraError>;
 }

--- a/packages/web/src/lib/server/facade-errors.ts
+++ b/packages/web/src/lib/server/facade-errors.ts
@@ -21,10 +21,14 @@ export function statusOf(error: FacadeError): 400 | 404 | 409 | 500 {
     case 'NotFound':
     case 'UnknownImport':
       return 404;
+    case 'AlreadyExists':
+    case 'IllegalTransition':
+    case 'NoOpenReview':
+    case 'NoRetainedCandidate':
+    case 'ConcurrencyConflict':
+      return 409;
     case 'InfraError':
       return 500;
-    default:
-      return 409;
   }
 }
 


### PR DESCRIPTION
Works through the code findings from the SOLID review that produced PR #72, one commit per finding.

## fix(web): exhaustive facade-error → HTTP status mapping

`statusOf`'s `default: 409` meant a newly added facade error kind would silently map to 409 instead of failing the build. The conflict-shaped kinds are now enumerated and the `default` is gone, so the switch is compile-checked exhaustive (`noImplicitReturns`) — per the new design-principles rule: never let a `default` arm swallow union variants. Behavior is unchanged; the existing tests already pin every kind→status pair.

## refactor: drop the dangling `WebhookDeliveryPort` (both modules)

Declared in each module's published-events port file but implemented and consumed nowhere — the monolith merge replaced webhook transport with in-process catch-up subscriptions (cross-module-delivery spec) and the port was left behind. `PublishedEvent`/`RenderError`/`PublishedEventMapping` stay (the outbound feed renders through them); header comments now describe the actual delivery path. Not exported from any facade, so nothing public changes.

## docs(downloader): the manual-selection resume's `musicbrainz` kind is entailed, not hardcoded

Investigating the "hardcoded provider" finding showed it was overstated: `EditionSelected` carries a release MBID, so the direct-by-release-id request is the only kind that can express the resume — a second metadata provider would bring its own selection vocabulary rather than reuse this arm. (The interpreter half of the finding was mistaken: `resolutionCommand` switches on resolution *outcome*, not source.) The constraint is now recorded at the site so future reviews don't re-flag it.

## refactor(downloader): decompose `SlskdDownload` (469 → 251 lines)

The one real SRP violation. The adapter fused download orchestration with three orthogonal concerns, now extracted as collaborators composed from the adapter's own injected dependencies:

- **`TransferLedger`** — write-ahead ownership rows, GUID capture, confirmed-removal marking (best-effort by design)
- **`TransferTeardown`** — the bounded cancel→poll→remove rounds against slskd's `Completed`-flag-guarded remove
- **`StagedFileResolver`** — events-log paging that reports completed files at the real slskd-written path, re-rooted onto `STAGING_ROOT`

`SlskdDownload` keeps what is genuinely its own: enqueue, the progress poll loop, stall/queue-timeout policy detection, and outcome aggregation. Pure refactor — constructor signature and behavior unchanged; all 884 downloader tests pass untouched, coverage stays 100%.

Releases as **v3.3.4** (the web fix is the releasable change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)