### PR TITLE
refactor(domain): brand value objects (Target/policies, Mbid, Distance, CandidateIdentity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.5.3](https://github.com/jgchk/music-downloader/compare/v3.5.2...v3.5.3) (2026-07-23)
+
+### Bug Fixes
+
+* **review:** address whole-codebase review findings across downloader/importer/web ([c6671a0](https://github.com/jgchk/music-downloader/commit/c6671a08df46f67caad360eaebf08ae184e5143e))
 ## [3.5.2](https://github.com/jgchk/music-downloader/compare/v3.5.1...v3.5.2) (2026-07-23)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "private": true,
   "description": "An extensible, event-sourced music downloader and importer — a modular monolith.",
   "type": "module",

--- a/packages/downloader/src/adapters/filesystem/library.test.ts
+++ b/packages/downloader/src/adapters/filesystem/library.test.ts
@@ -5,17 +5,18 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { silentLogger } from '../../application/__fixtures__/fakes.js';
 import type { DownloadedFile } from '../../domain/acquisition/events.js';
+import { createTarget } from '../../domain/target/target.js';
 import type { Target } from '../../domain/target/target.js';
 import { FilesystemLibrary, nodeLibraryFileSystem } from './library.js';
 import type { LibraryConfig, LibraryFileSystem } from './library.js';
 
-const TARGET: Target = {
+const TARGET: Target = createTarget({
   type: 'album',
   artist: 'The Band',
   title: 'Great Album',
   tracks: [{ position: 1, title: 'One', durationMs: 1000 }],
   year: 2020,
-};
+})._unsafeUnwrap();
 
 const roots: string[] = [];
 

--- a/packages/downloader/src/adapters/filesystem/paths.test.ts
+++ b/packages/downloader/src/adapters/filesystem/paths.test.ts
@@ -1,15 +1,16 @@
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { createTarget } from '../../domain/target/target.js';
 import type { Target } from '../../domain/target/target.js';
 import { renderReleaseDir, sanitizeSegment } from './paths.js';
 
-const target: Target = {
+const target: Target = createTarget({
   type: 'album',
   artist: 'The Band',
   title: 'Great Album',
   tracks: [{ position: 1, title: 'One', durationMs: 1000 }],
   year: 2020,
-};
+})._unsafeUnwrap();
 
 describe('sanitizeSegment', () => {
   it('replaces filesystem-unsafe characters and spaces', () => {

--- a/packages/downloader/src/adapters/musicbrainz/mapping.ts
+++ b/packages/downloader/src/adapters/musicbrainz/mapping.ts
@@ -1,3 +1,5 @@
+import { branded } from '../../domain/shared/brand.js';
+import type { Mbid } from '../../domain/shared/mbid.js';
 import { createTarget } from '../../domain/target/target.js';
 import type { Target } from '../../domain/target/target.js';
 import type { EditionCandidate } from '../../domain/acquisition/events.js';
@@ -35,6 +37,15 @@ function parseYear(date: string | null | undefined): number | undefined {
   return Number.isInteger(year) && year > 0 ? year : undefined;
 }
 
+/**
+ * Brand a MusicBrainz id as an {@link Mbid} at this ACL edge. MusicBrainz is the *authoritative
+ * issuer* of mbids, so its ids are trusted and branded directly — unlike a user-supplied id, which
+ * the facade validates with `parseMbid` before it ever reaches the domain.
+ */
+function optionalMbid(id: string | undefined): Mbid | undefined {
+  return id === undefined ? undefined : branded<Mbid>(id);
+}
+
 export function releaseToTarget(release: MbRelease): Target | undefined {
   const tracks = (release.media ?? []).flatMap((medium) =>
     (medium.tracks ?? []).map((track, index) => ({
@@ -49,7 +60,7 @@ export function releaseToTarget(release: MbRelease): Target | undefined {
     title: release.title ?? '',
     tracks,
     year: parseYear(release.date),
-    mbid: release.id,
+    mbid: optionalMbid(release.id),
   });
   return result.isOk() ? result.value : undefined;
 }
@@ -60,7 +71,7 @@ export function recordingToTarget(recording: MbRecording): Target | undefined {
     artist: artistCreditName(recording['artist-credit']),
     title: recording.title ?? '',
     tracks: [{ position: 1, title: recording.title ?? '', durationMs: recording.length ?? 0 }],
-    mbid: recording.id,
+    mbid: optionalMbid(recording.id),
   });
   return result.isOk() ? result.value : undefined;
 }
@@ -313,7 +324,8 @@ export function releaseGroupEditionCandidates(
 ): readonly EditionCandidate[] {
   const candidates: EditionCandidate[] = [];
   for (const release of releases ?? []) {
-    if (release.id === undefined) continue;
+    const releaseMbid = optionalMbid(release.id);
+    if (releaseMbid === undefined) continue;
     const formats = [
       ...new Set(
         (release.media ?? [])
@@ -322,7 +334,7 @@ export function releaseGroupEditionCandidates(
       ),
     ];
     candidates.push({
-      releaseMbid: release.id,
+      releaseMbid,
       title: release.title ?? undefined,
       date: release.date ?? undefined,
       country: release.country ?? undefined,

--- a/packages/downloader/src/adapters/musicbrainz/metadata.test.ts
+++ b/packages/downloader/src/adapters/musicbrainz/metadata.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { silentLogger } from '../../application/__fixtures__/fakes.js';
 import type { AcquisitionRequest } from '../../domain/acquisition/events.js';
+import { asMbid } from '../../domain/shared/__fixtures__/mbid.js';
 import type { HttpClient, HttpResponse } from '../support/http.js';
 import { MusicBrainzMetadata } from './metadata.js';
 
@@ -33,8 +34,16 @@ function resolver(routes: Array<[string, HttpResponse]>): MusicBrainzMetadata {
   return new MusicBrainzMetadata(silentLogger(), http(routes));
 }
 
-const albumById: AcquisitionRequest = { kind: 'musicbrainz', mbid: 'rel-1', targetType: 'album' };
-const trackById: AcquisitionRequest = { kind: 'musicbrainz', mbid: 'rec-1', targetType: 'track' };
+const albumById: AcquisitionRequest = {
+  kind: 'musicbrainz',
+  mbid: asMbid('rel-1'),
+  targetType: 'album',
+};
+const trackById: AcquisitionRequest = {
+  kind: 'musicbrainz',
+  mbid: asMbid('rec-1'),
+  targetType: 'track',
+};
 
 describe('MusicBrainzMetadata', () => {
   it('resolves a release by MBID into a canonical target', async () => {
@@ -186,7 +195,7 @@ describe('MusicBrainzMetadata', () => {
 
   const byReleaseGroup = (mbid: string): AcquisitionRequest => ({
     kind: 'release-group',
-    mbid,
+    mbid: asMbid(mbid),
     targetType: 'album',
   });
 

--- a/packages/downloader/src/adapters/slskd/download.test.ts
+++ b/packages/downloader/src/adapters/slskd/download.test.ts
@@ -1,7 +1,9 @@
 import { join } from 'node:path';
+import { asCandidateIdentity } from '../../domain/shared/__fixtures__/candidate-identity.js';
 import { describe, expect, it } from 'vitest';
 import { FakeResourceLedger, silentLogger } from '../../application/__fixtures__/fakes.js';
 import type { Candidate } from '../../domain/candidate/candidate.js';
+import { createDownloadPolicy } from '../../domain/policy/policies.js';
 import type { DownloadPolicy } from '../../domain/policy/policies.js';
 import type { DownloadProgress } from '../../application/ports/outbound-ports.js';
 import type { HttpClient, HttpResponse } from '../support/http.js';
@@ -13,7 +15,7 @@ const STAGING = '/staging';
 const DOWNLOADS_ROOT = '/downloads';
 const ACQ = 'acq-1';
 const candidate: Candidate = {
-  identity: { username: 'u1', path: '@@a\\Album', sizeBytes: 200 },
+  identity: asCandidateIdentity({ username: 'u1', path: '@@a\\Album', sizeBytes: 200 }),
   files: [
     { name: '01.flac', sizeBytes: 100 },
     { name: '02.flac', sizeBytes: 100 },
@@ -21,10 +23,8 @@ const candidate: Candidate = {
   source: { speedBytesPerSec: 0, freeSlots: 1, queueLength: 0 },
 };
 
-const policy = (stallTimeoutMs: number, maxQueueWaitMs: number): DownloadPolicy => ({
-  stallTimeoutMs,
-  maxQueueWaitMs,
-});
+const policy = (stallTimeoutMs: number, maxQueueWaitMs: number): DownloadPolicy =>
+  createDownloadPolicy({ stallTimeoutMs, maxQueueWaitMs })._unsafeUnwrap();
 
 function transfer(name: string, extra: Record<string, unknown> = {}): Record<string, unknown> {
   return { id: name, filename: `@@a\\Album\\${name}`, ...extra };

--- a/packages/downloader/src/adapters/slskd/mapping.test.ts
+++ b/packages/downloader/src/adapters/slskd/mapping.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { asCandidateIdentity } from '../../domain/shared/__fixtures__/candidate-identity.js';
 import { baseName, mapSearchResponses, remoteFilename } from './mapping.js';
 
 const richFile = {
@@ -58,45 +59,48 @@ describe('mapSearchResponses', () => {
     ]);
   });
 
-  it('splits files across folders, folding sizeless/nameless files into the root group', () => {
+  it('splits files across folders, dropping the rootless group with no addressable path', () => {
+    // `loose` and the nameless file fold into the root group (path ''); an empty path yields no
+    // sound dedup key, so `parseCandidateIdentity` rejects that group and the ACL drops it. The
+    // kept folder also carries `notes` (no extension, no advertised size) to exercise the file
+    // mapping's codec/size fallbacks.
     const candidates = mapSearchResponses(
-      [{ files: [richFile, { filename: 'loose', size: 40 }, {}] }],
+      [
+        {
+          username: 'u2',
+          files: [richFile, { filename: '@@a\\Album\\notes' }, { filename: 'loose', size: 40 }, {}],
+        },
+      ],
       'album',
     );
 
     expect(candidates).toEqual([
       {
-        identity: { username: '', path: '@@a\\Album', sizeBytes: 100 },
-        files: [expect.objectContaining({ name: '01 Track.FLAC' })],
-        source: { speedBytesPerSec: 0, freeSlots: 0, queueLength: 0 },
-      },
-      {
-        identity: { username: '', path: '', sizeBytes: 40 },
+        identity: asCandidateIdentity({ username: 'u2', path: '@@a\\Album', sizeBytes: 100 }),
         files: [
-          expect.objectContaining({ name: 'loose', codec: undefined }),
-          expect.objectContaining({ name: '', sizeBytes: 0 }),
+          expect.objectContaining({ name: '01 Track.FLAC' }),
+          expect.objectContaining({ name: 'notes', codec: undefined, sizeBytes: 0 }),
         ],
         source: { speedBytesPerSec: 0, freeSlots: 0, queueLength: 0 },
       },
     ]);
   });
 
-  it('ignores a response that advertises no files', () => {
-    expect(mapSearchResponses([{ username: 'u3' }], 'album')).toEqual([]);
+  it('ignores a response that advertises neither a username nor any files', () => {
+    expect(mapSearchResponses([{}], 'album')).toEqual([]);
   });
 
-  it('yields one candidate per file for a track target', () => {
+  it('yields one candidate per file for a track target, dropping a nameless (pathless) file', () => {
     const candidates = mapSearchResponses([{ username: 'u1', files: [richFile, {}] }], 'track');
 
     expect(candidates).toEqual([
       {
-        identity: { username: 'u1', path: '@@a\\Album\\01 Track.FLAC', sizeBytes: 100 },
+        identity: asCandidateIdentity({
+          username: 'u1',
+          path: '@@a\\Album\\01 Track.FLAC',
+          sizeBytes: 100,
+        }),
         files: [expect.objectContaining({ name: '01 Track.FLAC' })],
-        source: { speedBytesPerSec: 0, freeSlots: 0, queueLength: 0 },
-      },
-      {
-        identity: { username: 'u1', path: '', sizeBytes: 0 },
-        files: [expect.objectContaining({ name: '', sizeBytes: 0 })],
         source: { speedBytesPerSec: 0, freeSlots: 0, queueLength: 0 },
       },
     ]);

--- a/packages/downloader/src/adapters/slskd/mapping.ts
+++ b/packages/downloader/src/adapters/slskd/mapping.ts
@@ -1,7 +1,7 @@
+import { parseCandidateIdentity } from '../../domain/candidate/candidate.js';
 import type {
   Candidate,
   CandidateFile,
-  CandidateIdentity,
   SourceReliability,
 } from '../../domain/candidate/candidate.js';
 import type { TargetType } from '../../domain/target/target.js';
@@ -36,8 +36,8 @@ function codecOf(filename: string): string | undefined {
   return dot === -1 ? undefined : filename.slice(dot + 1).toLowerCase();
 }
 
-function toCandidateFile(file: SlskdSearchFile): CandidateFile {
-  const filename = file.filename ?? '';
+/** The resolved name is threaded in from the caller — only files with a name survive to here. */
+function toCandidateFile(file: SlskdSearchFile, filename: string): CandidateFile {
   return {
     name: baseName(filename),
     sizeBytes: file.size ?? 0,
@@ -62,13 +62,17 @@ function trackCandidates(
   files: readonly SlskdSearchFile[],
   source: SourceReliability,
 ): Candidate[] {
-  return files.map((file) => {
-    const identity: CandidateIdentity = {
+  return files.flatMap((file) => {
+    // Parse at this ACL edge: a file with no username/path is unaddressable, so it is dropped
+    // rather than admitted with a blank (collision-prone) dedup key.
+    const filename = file.filename ?? '';
+    const identity = parseCandidateIdentity({
       username,
-      path: file.filename ?? '',
+      path: filename,
       sizeBytes: file.size ?? 0,
-    };
-    return { identity, files: [toCandidateFile(file)], source };
+    });
+    if (identity.isErr()) return [];
+    return [{ identity: identity.value, files: [toCandidateFile(file, filename)], source }];
   });
 }
 
@@ -77,20 +81,29 @@ function folderCandidates(
   files: readonly SlskdSearchFile[],
   source: SourceReliability,
 ): Candidate[] {
-  const byFolder = new Map<string, SlskdSearchFile[]>();
+  const byFolder = new Map<string, { file: SlskdSearchFile; filename: string }[]>();
   for (const file of files) {
-    const folder = folderOf(file.filename ?? '');
+    const filename = file.filename ?? '';
+    const folder = folderOf(filename);
+    const entry = { file, filename };
     const bucket = byFolder.get(folder);
-    if (bucket === undefined) byFolder.set(folder, [file]);
-    else bucket.push(file);
+    if (bucket === undefined) byFolder.set(folder, [entry]);
+    else bucket.push(entry);
   }
-  return [...byFolder].map(([folder, folderFiles]) => {
-    const identity: CandidateIdentity = {
+  return [...byFolder].flatMap(([folder, entries]) => {
+    const identity = parseCandidateIdentity({
       username,
       path: folder,
-      sizeBytes: folderFiles.reduce((sum, file) => sum + (file.size ?? 0), 0),
-    };
-    return { identity, files: folderFiles.map(toCandidateFile), source };
+      sizeBytes: entries.reduce((sum, entry) => sum + (entry.file.size ?? 0), 0),
+    });
+    if (identity.isErr()) return [];
+    return [
+      {
+        identity: identity.value,
+        files: entries.map((entry) => toCandidateFile(entry.file, entry.filename)),
+        source,
+      },
+    ];
   });
 }
 

--- a/packages/downloader/src/adapters/sqlite/event-store.test.ts
+++ b/packages/downloader/src/adapters/sqlite/event-store.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync } from 'node:fs';
+import { asCandidateIdentity } from '../../domain/shared/__fixtures__/candidate-identity.js';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -13,7 +14,7 @@ const META: EventMetadata = { acquisitionId: 'acq-1', occurredAt: '2026-07-03T12
 
 const IMPORTED: AcquisitionEvent = {
   type: 'Imported',
-  candidate: { username: 'peer', path: '/incoming/album', sizeBytes: 1024 },
+  candidate: asCandidateIdentity({ username: 'peer', path: '/incoming/album', sizeBytes: 1024 }),
   location: '/library/album',
 };
 const FULFILLED: AcquisitionEvent = { type: 'AcquisitionFulfilled', location: '/library/album' };

--- a/packages/downloader/src/application/acquisition/interpreter.test.ts
+++ b/packages/downloader/src/application/acquisition/interpreter.test.ts
@@ -4,7 +4,8 @@ import { interpretEffect } from './interpreter.js';
 import type { EffectPorts, InterpreterDeps } from './interpreter.js';
 import { FakeEventStore, fixedClock } from '../__fixtures__/fakes.js';
 import { infraError } from '../ports/errors.js';
-import { DEFAULT_DOWNLOAD_POLICY } from '../../domain/policy/policies.js';
+import { createMatchPolicy, DEFAULT_DOWNLOAD_POLICY } from '../../domain/policy/policies.js';
+import { asMbid } from '../../domain/shared/__fixtures__/mbid.js';
 import type { DownloadProgress } from '../ports/outbound-ports.js';
 import type { AcquisitionEvent } from '../../domain/acquisition/events.js';
 import {
@@ -76,7 +77,7 @@ describe('interpretEffect — metadata resolution', () => {
     });
     await interpretEffect(deps(ports), 'acq-1', {
       type: 'ResolveMetadata',
-      request: { kind: 'musicbrainz', mbid: 'x', targetType: 'album' },
+      request: { kind: 'musicbrainz', mbid: asMbid('x'), targetType: 'album' },
     });
     expect(appendedTypes()).toContain('MetadataResolutionFailed');
   });
@@ -107,7 +108,10 @@ describe('interpretEffect — metadata resolution', () => {
   });
 
   it('resolves the chosen edition on the resume path and records the target', async () => {
-    await seed([...awaitingSelectionHistory(), { type: 'EditionSelected', releaseMbid: 'boot-1' }]);
+    await seed([
+      ...awaitingSelectionHistory(),
+      { type: 'EditionSelected', releaseMbid: asMbid('boot-1') },
+    ]);
     const ports = stubPorts({
       metadata: {
         resolve: vi.fn(() => okAsync({ kind: 'resolved' as const, target: sampleTarget })),
@@ -116,7 +120,7 @@ describe('interpretEffect — metadata resolution', () => {
     // The effect `react` emits for EditionSelected: the direct-by-release-id request.
     await interpretEffect(deps(ports), 'acq-1', {
       type: 'ResolveMetadata',
-      request: { kind: 'musicbrainz', mbid: 'boot-1', targetType: 'album' },
+      request: { kind: 'musicbrainz', mbid: asMbid('boot-1'), targetType: 'album' },
     });
     const resolved = store
       .all()
@@ -135,7 +139,7 @@ describe('interpretEffect — metadata resolution', () => {
     });
     const result = await interpretEffect(deps(ports), 'acq-1', {
       type: 'ResolveMetadata',
-      request: { kind: 'musicbrainz', mbid: 'x', targetType: 'album' },
+      request: { kind: 'musicbrainz', mbid: asMbid('x'), targetType: 'album' },
     });
     expect(result._unsafeUnwrapErr()).toMatchObject({ kind: 'InfraError' });
   });
@@ -281,7 +285,7 @@ describe('interpretEffect — validation', () => {
       type: 'Validate',
       files: sampleFiles,
       target: sampleTarget,
-      matchPolicy: { threshold: 0.5 },
+      matchPolicy: createMatchPolicy(0.5)._unsafeUnwrap(),
     });
     expect(appendedTypes()).toContain('ValidationPassed');
   });
@@ -297,7 +301,7 @@ describe('interpretEffect — validation', () => {
       type: 'Validate',
       files: sampleFiles,
       target: sampleTarget,
-      matchPolicy: { threshold: 0.9 },
+      matchPolicy: createMatchPolicy(0.9)._unsafeUnwrap(),
     });
     expect(appendedTypes()).toContain('ValidationFailed');
   });

--- a/packages/downloader/src/application/acquisition/use-cases.test.ts
+++ b/packages/downloader/src/application/acquisition/use-cases.test.ts
@@ -10,6 +10,7 @@ import {
 } from './use-cases.js';
 import type { UseCaseDeps } from './use-cases.js';
 import { FakeEventStore, fixedClock, sequentialIds } from '../__fixtures__/fakes.js';
+import { asMbid } from '../../domain/shared/__fixtures__/mbid.js';
 import {
   AcquisitionStatusProjection,
   ProgressReadModel,
@@ -70,14 +71,14 @@ describe('selectEdition', () => {
 
   it('appends the selection for an acquisition awaiting one', async () => {
     const d = await awaitingDeps();
-    const result = await selectEdition(d, 'acq-1', 'boot-1');
+    const result = await selectEdition(d, 'acq-1', asMbid('boot-1'));
     expect(result.isOk()).toBe(true);
     expect((d.store as FakeEventStore).all().map((e) => e.type)).toContain('EditionSelected');
   });
 
   it('surfaces the modeled rejection for an off-menu edition', async () => {
     const d = await awaitingDeps();
-    const result = await selectEdition(d, 'acq-1', 'not-on-the-menu');
+    const result = await selectEdition(d, 'acq-1', asMbid('not-on-the-menu'));
     expect(result._unsafeUnwrapErr()).toEqual({
       kind: 'UnknownEdition',
       releaseMbid: 'not-on-the-menu',
@@ -90,7 +91,7 @@ describe('selectEdition', () => {
     const { acquisitionId } = (
       await submitAcquisition(d, { request: sampleRequest, policies: defaultPolicies() })
     )._unsafeUnwrap();
-    const result = await selectEdition(d, acquisitionId, 'boot-1');
+    const result = await selectEdition(d, acquisitionId, asMbid('boot-1'));
     expect(result._unsafeUnwrapErr()).toMatchObject({
       kind: 'IllegalTransition',
       command: 'SelectEdition',

--- a/packages/downloader/src/application/acquisition/use-cases.ts
+++ b/packages/downloader/src/application/acquisition/use-cases.ts
@@ -2,6 +2,7 @@ import type { ResultAsync } from 'neverthrow';
 import type { AcquisitionRequest } from '../../domain/acquisition/events.js';
 import type { CandidateRef } from '../../domain/candidate/candidate.js';
 import type { AcquisitionPolicies } from '../../domain/policy/policies.js';
+import type { Mbid } from '../../domain/shared/mbid.js';
 import type { DownloadProgress } from '../ports/outbound-ports.js';
 import type { IdGenerator } from '../ports/system-ports.js';
 import type {
@@ -56,7 +57,7 @@ export function cancelAcquisition(
 export function selectEdition(
   deps: CommandDeps,
   acquisitionId: string,
-  releaseMbid: string,
+  releaseMbid: Mbid,
 ): ResultAsync<void, CommandError> {
   return applyCommand(deps, acquisitionId, { type: 'SelectEdition', releaseMbid }).map(
     () => undefined,

--- a/packages/downloader/src/application/projections/read-models.test.ts
+++ b/packages/downloader/src/application/projections/read-models.test.ts
@@ -7,6 +7,7 @@ import {
   projectStatus,
 } from './read-models.js';
 import { FakeEventStore } from '../__fixtures__/fakes.js';
+import { asMbid } from '../../domain/shared/__fixtures__/mbid.js';
 import type { AcquisitionEvent } from '../../domain/acquisition/events.js';
 import type { StoredEvent } from '../ports/event-store-port.js';
 import {
@@ -104,7 +105,7 @@ describe('projectStatus — awaiting manual edition selection', () => {
   it('drops the candidates once an edition is selected and the flow resumes', () => {
     const view = projectStatus('acq-1', [
       ...awaitingSelectionHistory(),
-      { type: 'EditionSelected', releaseMbid: 'boot-1' },
+      { type: 'EditionSelected', releaseMbid: asMbid('boot-1') },
     ]);
     expect(view.status).toBe('Pending');
     expect(view.candidates).toBeUndefined();

--- a/packages/downloader/src/composition/e2e.test.ts
+++ b/packages/downloader/src/composition/e2e.test.ts
@@ -60,7 +60,13 @@ const ABANDONED: DownloadResult = { kind: 'failed', reason: 'Stalled', files: PA
 const IMPORTED: ImportResult = { kind: 'imported', location: '/library/Radiohead/Kid A (2000)' };
 const CONFLICT: ImportResult = { kind: 'conflict', location: '/library/Radiohead/Kid A (2000)' };
 
-const SUBMIT_BODY = { request: { kind: 'musicbrainz', mbid: 'mbid-1', targetType: 'album' } };
+const SUBMIT_BODY = {
+  request: {
+    kind: 'musicbrainz',
+    mbid: '11111111-1111-4111-8111-111111111111',
+    targetType: 'album',
+  },
+};
 
 function candidateWithSpeed(username: string, speedBytesPerSec: number): Candidate {
   const base = matchingCandidate(username);

--- a/packages/downloader/src/composition/runtime.test.ts
+++ b/packages/downloader/src/composition/runtime.test.ts
@@ -62,7 +62,13 @@ function fakePorts(): EffectPorts {
   };
 }
 
-const SUBMIT = { request: { kind: 'musicbrainz', mbid: 'mbid-1', targetType: 'album' } };
+const SUBMIT = {
+  request: {
+    kind: 'musicbrainz',
+    mbid: '11111111-1111-4111-8111-111111111111',
+    targetType: 'album',
+  },
+};
 
 const cleanups: (() => void | Promise<void>)[] = [];
 afterEach(async () => {

--- a/packages/downloader/src/domain/acquisition/__fixtures__/acquisition-fixtures.ts
+++ b/packages/downloader/src/domain/acquisition/__fixtures__/acquisition-fixtures.ts
@@ -8,6 +8,8 @@ import type { AcquisitionPolicies } from '../../policy/policies.js';
 import { DEFAULT_QUALITY_POLICY } from '../../policy/quality-policy.js';
 import { rankCandidates } from '../../ranking/ranking.js';
 import type { RankedCandidate } from '../../ranking/ranking.js';
+import { asCandidateIdentity } from '../../shared/__fixtures__/candidate-identity.js';
+import { asMbid } from '../../shared/__fixtures__/mbid.js';
 import { createTarget } from '../../target/target.js';
 import type { Target } from '../../target/target.js';
 import type {
@@ -32,7 +34,7 @@ export const sampleTarget: Target = createTarget({
 
 export const sampleRequest: AcquisitionRequest = {
   kind: 'musicbrainz',
-  mbid: 'mbid-1',
+  mbid: asMbid('mbid-1'),
   targetType: 'album',
 };
 
@@ -54,7 +56,11 @@ export function defaultPolicies(overrides: Partial<AcquisitionPolicies> = {}): A
 /** A lossless, structurally-aligned candidate that clears both gates for {@link sampleTarget}. */
 export function matchingCandidate(username: string): Candidate {
   return {
-    identity: { username, path: `${username}/Radiohead - Kid A (2000) [FLAC]`, sizeBytes: 1000 },
+    identity: asCandidateIdentity({
+      username,
+      path: `${username}/Radiohead - Kid A (2000) [FLAC]`,
+      sizeBytes: 1000,
+    }),
     files: [
       {
         name: '01 Everything in Its Right Place.flac',
@@ -83,21 +89,21 @@ export function requestedHistory(
 
 export const sampleGroupRequest: AcquisitionRequest = {
   kind: 'release-group',
-  mbid: 'rg-1',
+  mbid: asMbid('rg-1'),
   targetType: 'album',
 };
 
 /** The candidate editions of a group with no official edition, as resolution would present them. */
 export const sampleEditionCandidates: readonly EditionCandidate[] = [
   {
-    releaseMbid: 'boot-1',
+    releaseMbid: asMbid('boot-1'),
     title: 'Live at Budokan',
     date: '1995-05-01',
     country: 'JP',
     format: 'CD',
     trackCount: 12,
   },
-  { releaseMbid: 'boot-2', title: 'Promo Sampler', trackCount: 12 },
+  { releaseMbid: asMbid('boot-2'), title: 'Promo Sampler', trackCount: 12 },
 ];
 
 /** History paused for a human's edition choice — an AwaitingManualSelection state. */

--- a/packages/downloader/src/domain/acquisition/acquisition.test.ts
+++ b/packages/downloader/src/domain/acquisition/acquisition.test.ts
@@ -3,6 +3,8 @@ import { Acquisition } from './acquisition.js';
 import type { Effect } from './acquisition.js';
 import type { AcquisitionCommand } from './commands.js';
 import type { AcquisitionEvent, AcquisitionRequest } from './events.js';
+import { createRetryPolicy } from '../policy/policies.js';
+import { asMbid } from '../shared/__fixtures__/mbid.js';
 import {
   awaitingSelectionHistory,
   defaultPolicies,
@@ -127,7 +129,9 @@ describe('Acquisition.execute — happy path', () => {
 
   it('exhausts only once the search-round budget is spent on empty rounds', () => {
     // Two prior empty rounds + this one spend the whole (explicitly pinned) three-round budget.
-    const threeRounds = defaultPolicies({ retry: { maxSearchRounds: 3, maxTotalAttempts: 15 } });
+    const threeRounds = defaultPolicies({
+      retry: createRetryPolicy({ maxSearchRounds: 3, maxTotalAttempts: 15 })._unsafeUnwrap(),
+    });
     const emptyRound = (round: number): AcquisitionEvent[] => [
       { type: 'SearchCompleted', round, candidates: [] },
       { type: 'CandidatesRanked', ranked: [] },
@@ -160,7 +164,9 @@ describe('Acquisition.execute — happy path', () => {
   });
 
   it('exhausts on an empty round when the policy allows a single round', () => {
-    const oneRound = defaultPolicies({ retry: { maxSearchRounds: 1, maxTotalAttempts: 15 } });
+    const oneRound = defaultPolicies({
+      retry: createRetryPolicy({ maxSearchRounds: 1, maxTotalAttempts: 15 })._unsafeUnwrap(),
+    });
     const events = Acquisition.fromHistory(resolvedHistory(oneRound))
       .execute({ type: 'RecordSearchResults', candidates: [] })
       ._unsafeUnwrap();
@@ -233,7 +239,9 @@ describe('Acquisition.execute — retry loop', () => {
   });
 
   it('exhausts when the working set empties and no search rounds remain', () => {
-    const oneRound = defaultPolicies({ retry: { maxSearchRounds: 1, maxTotalAttempts: 15 } });
+    const oneRound = defaultPolicies({
+      retry: createRetryPolicy({ maxSearchRounds: 1, maxTotalAttempts: 15 })._unsafeUnwrap(),
+    });
     const events = Acquisition.fromHistory(selectedHistory([matchingCandidate('a')], oneRound))
       .execute({ type: 'RecordDownloadFailed', reason: 'Stalled' })
       ._unsafeUnwrap();
@@ -241,7 +249,9 @@ describe('Acquisition.execute — retry loop', () => {
   });
 
   it('exhausts when the total-attempts budget is spent even with candidates left', () => {
-    const oneAttempt = defaultPolicies({ retry: { maxSearchRounds: 3, maxTotalAttempts: 1 } });
+    const oneAttempt = defaultPolicies({
+      retry: createRetryPolicy({ maxSearchRounds: 3, maxTotalAttempts: 1 })._unsafeUnwrap(),
+    });
     const events = Acquisition.fromHistory(
       selectedHistory([matchingCandidate('a'), matchingCandidate('b')], oneAttempt),
     )
@@ -302,7 +312,9 @@ describe('Acquisition.execute — an external validation failure revives fulfilm
   });
 
   it('exhausts when no candidate remains and the search budget is spent', () => {
-    const oneRound = defaultPolicies({ retry: { maxSearchRounds: 1, maxTotalAttempts: 15 } });
+    const oneRound = defaultPolicies({
+      retry: createRetryPolicy({ maxSearchRounds: 1, maxTotalAttempts: 15 })._unsafeUnwrap(),
+    });
     const events = Acquisition.fromHistory(fulfilledHistory([a], oneRound))
       .execute(verdict(a.identity))
       ._unsafeUnwrap();
@@ -314,7 +326,9 @@ describe('Acquisition.execute — an external validation failure revives fulfilm
   });
 
   it('exhausts when the attempts budget is spent even with candidates left', () => {
-    const oneAttempt = defaultPolicies({ retry: { maxSearchRounds: 3, maxTotalAttempts: 1 } });
+    const oneAttempt = defaultPolicies({
+      retry: createRetryPolicy({ maxSearchRounds: 3, maxTotalAttempts: 1 })._unsafeUnwrap(),
+    });
     const events = Acquisition.fromHistory(fulfilledHistory([a, b], oneAttempt))
       .execute(verdict(a.identity))
       ._unsafeUnwrap();
@@ -575,7 +589,7 @@ describe('Acquisition.reactTo — the event → effect table', () => {
   it('resolves metadata for a release-group request, carrying it verbatim to the effect', () => {
     const request: AcquisitionRequest = {
       kind: 'release-group',
-      mbid: 'rg-1',
+      mbid: asMbid('rg-1'),
       targetType: 'album',
     };
     const effects = Acquisition.fromHistory([
@@ -913,14 +927,14 @@ describe('Acquisition.execute — manual edition selection', () => {
 
   it('selecting a retained candidate records the choice', () => {
     const events = Acquisition.fromHistory(awaitingSelectionHistory())
-      .execute({ type: 'SelectEdition', releaseMbid: 'boot-1' })
+      .execute({ type: 'SelectEdition', releaseMbid: asMbid('boot-1') })
       ._unsafeUnwrap();
     expect(events).toEqual([{ type: 'EditionSelected', releaseMbid: 'boot-1' }]);
   });
 
   it('rejects selecting an edition that is not among the retained candidates', () => {
     const acq = Acquisition.fromHistory(awaitingSelectionHistory());
-    const result = acq.execute({ type: 'SelectEdition', releaseMbid: 'not-a-candidate' });
+    const result = acq.execute({ type: 'SelectEdition', releaseMbid: asMbid('not-a-candidate') });
     expect(result._unsafeUnwrapErr()).toEqual({
       kind: 'UnknownEdition',
       releaseMbid: 'not-a-candidate',
@@ -930,7 +944,7 @@ describe('Acquisition.execute — manual edition selection', () => {
   it('rejects a selection on an acquisition that is not awaiting one', () => {
     const result = Acquisition.fromHistory(resolvedHistory()).execute({
       type: 'SelectEdition',
-      releaseMbid: 'boot-1',
+      releaseMbid: asMbid('boot-1'),
     });
     expect(result._unsafeUnwrapErr()).toEqual({
       kind: 'IllegalTransition',
@@ -943,7 +957,7 @@ describe('Acquisition.execute — manual edition selection', () => {
     const cancelled = [...awaitingSelectionHistory(), { type: 'AcquisitionCancelled' } as const];
     const result = Acquisition.fromHistory(cancelled).execute({
       type: 'SelectEdition',
-      releaseMbid: 'boot-1',
+      releaseMbid: asMbid('boot-1'),
     });
     expect(result._unsafeUnwrapErr()).toEqual({
       kind: 'IllegalTransition',
@@ -955,7 +969,7 @@ describe('Acquisition.execute — manual edition selection', () => {
   it('a resolved target after the selection resumes the normal flow', () => {
     const resumed = [
       ...awaitingSelectionHistory(),
-      { type: 'EditionSelected', releaseMbid: 'boot-1' } as const,
+      { type: 'EditionSelected', releaseMbid: asMbid('boot-1') } as const,
     ];
     const events = Acquisition.fromHistory(resumed)
       .execute({ type: 'RecordTarget', target: sampleTarget })
@@ -980,11 +994,11 @@ describe('Acquisition.execute — manual edition selection', () => {
   it('a recorded selection resolves the chosen release directly (the resume effect)', () => {
     const resumed = [
       ...awaitingSelectionHistory(),
-      { type: 'EditionSelected', releaseMbid: 'boot-1' } as const,
+      { type: 'EditionSelected', releaseMbid: asMbid('boot-1') } as const,
     ];
     const effects = Acquisition.fromHistory(resumed).reactTo({
       type: 'EditionSelected',
-      releaseMbid: 'boot-1',
+      releaseMbid: asMbid('boot-1'),
     });
     expect(effects).toEqual([
       {

--- a/packages/downloader/src/domain/acquisition/commands.ts
+++ b/packages/downloader/src/domain/acquisition/commands.ts
@@ -1,5 +1,6 @@
 import type { Candidate, CandidateRef } from '../candidate/candidate.js';
 import type { AcquisitionPolicies } from '../policy/policies.js';
+import type { Mbid } from '../shared/mbid.js';
 import type { Target } from '../target/target.js';
 import type { ValidationVerdict } from '../validation/verdict.js';
 import type {
@@ -29,7 +30,7 @@ export type AcquisitionCommand =
   | {
       // The user's choice among the retained candidates (valid only while awaiting selection).
       readonly type: 'SelectEdition';
-      readonly releaseMbid: string;
+      readonly releaseMbid: Mbid;
     }
   | { readonly type: 'RecordSearchResults'; readonly candidates: readonly Candidate[] }
   | { readonly type: 'RecordDownloadCompleted'; readonly files: readonly DownloadedFile[] }

--- a/packages/downloader/src/domain/acquisition/events.ts
+++ b/packages/downloader/src/domain/acquisition/events.ts
@@ -1,6 +1,7 @@
 import type { Candidate, CandidateIdentity } from '../candidate/candidate.js';
 import type { AcquisitionPolicies } from '../policy/policies.js';
 import type { RankedCandidate } from '../ranking/ranking.js';
+import type { Mbid } from '../shared/mbid.js';
 import type { Target, TargetType } from '../target/target.js';
 import type { ValidationVerdict } from '../validation/verdict.js';
 
@@ -16,8 +17,8 @@ import type { ValidationVerdict } from '../validation/verdict.js';
  * selection when none is official), or a structured descriptor to resolve (D12).
  */
 export type AcquisitionRequest =
-  | { readonly kind: 'musicbrainz'; readonly mbid: string; readonly targetType: TargetType }
-  | { readonly kind: 'release-group'; readonly mbid: string; readonly targetType: 'album' }
+  | { readonly kind: 'musicbrainz'; readonly mbid: Mbid; readonly targetType: TargetType }
+  | { readonly kind: 'release-group'; readonly mbid: Mbid; readonly targetType: 'album' }
   | {
       readonly kind: 'descriptor';
       readonly targetType: TargetType;
@@ -49,7 +50,7 @@ export interface DownloadedFile {
  * 0 (the mapping sums per-medium counts, unknown contributing nothing).
  */
 export interface EditionCandidate {
-  readonly releaseMbid: string;
+  readonly releaseMbid: Mbid;
   readonly title?: string;
   readonly date?: string;
   readonly country?: string;
@@ -74,7 +75,7 @@ export type AcquisitionEvent =
   | {
       // The human chose: resolve exactly this release, identical to a direct-by-release-id request.
       readonly type: 'EditionSelected';
-      readonly releaseMbid: string;
+      readonly releaseMbid: Mbid;
     }
   | { readonly type: 'SearchRequested'; readonly round: number }
   | {

--- a/packages/downloader/src/domain/acquisition/state.test.ts
+++ b/packages/downloader/src/domain/acquisition/state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { AcquisitionEvent } from './events.js';
 import { evolve, foldEvents } from './state.js';
+import { asMbid } from '../shared/__fixtures__/mbid.js';
 import type { AcquisitionPhase, AcquisitionState } from './state.js';
 import {
   awaitingSelectionHistory,
@@ -52,7 +53,7 @@ const allEvents: AcquisitionEvent[] = [
   { type: 'TargetResolved', target: sampleTarget },
   { type: 'MetadataResolutionFailed' },
   { type: 'ManualSelectionRequested', candidates: sampleEditionCandidates },
-  { type: 'EditionSelected', releaseMbid: 'boot-1' },
+  { type: 'EditionSelected', releaseMbid: asMbid('boot-1') },
   { type: 'SearchRequested', round: 2 },
   { type: 'SearchCompleted', round: 1, candidates: [] },
   { type: 'CandidatesRanked', ranked: [] },
@@ -266,7 +267,7 @@ describe('evolve — manual edition selection pauses and resumes', () => {
   it('folds an edition selection back to Pending, keeping the original request', () => {
     const state = foldEvents([
       ...awaitingSelectionHistory(),
-      { type: 'EditionSelected', releaseMbid: 'boot-1' },
+      { type: 'EditionSelected', releaseMbid: asMbid('boot-1') },
     ]);
     expect(state).toMatchObject({ phase: 'Pending', request: sampleGroupRequest });
     expect('candidates' in state).toBe(false);
@@ -275,7 +276,7 @@ describe('evolve — manual edition selection pauses and resumes', () => {
   it('resolves to Searching once the selected edition yields a target (the normal flow)', () => {
     const state = foldEvents([
       ...awaitingSelectionHistory(),
-      { type: 'EditionSelected', releaseMbid: 'boot-1' },
+      { type: 'EditionSelected', releaseMbid: asMbid('boot-1') },
       { type: 'TargetResolved', target: sampleTarget },
     ]);
     expect(state).toMatchObject({ phase: 'Searching', target: sampleTarget });

--- a/packages/downloader/src/domain/candidate/candidate.test.ts
+++ b/packages/downloader/src/domain/candidate/candidate.test.ts
@@ -1,8 +1,48 @@
 import { describe, expect, it } from 'vitest';
-import { candidateKey, fileCount, refersTo, sameCandidate } from './candidate.js';
+import {
+  candidateKey,
+  fileCount,
+  parseCandidateIdentity,
+  refersTo,
+  sameCandidate,
+} from './candidate.js';
 import type { Candidate, CandidateIdentity } from './candidate.js';
 
-const identity: CandidateIdentity = { username: 'peer1', path: '/music/album', sizeBytes: 4200 };
+const identity: CandidateIdentity = parseCandidateIdentity({
+  username: 'peer1',
+  path: '/music/album',
+  sizeBytes: 4200,
+})._unsafeUnwrap();
+
+describe('parseCandidateIdentity', () => {
+  it('accepts a well-formed identity, preserving its fields', () => {
+    expect(
+      parseCandidateIdentity({ username: 'peer1', path: '/a', sizeBytes: 0 })._unsafeUnwrap(),
+    ).toEqual({ username: 'peer1', path: '/a', sizeBytes: 0 });
+  });
+
+  it('rejects an empty username or path', () => {
+    expect(
+      parseCandidateIdentity({ username: '  ', path: '/a', sizeBytes: 1 })._unsafeUnwrapErr(),
+    ).toEqual({ kind: 'EmptyUsername' });
+    expect(
+      parseCandidateIdentity({ username: 'peer1', path: '', sizeBytes: 1 })._unsafeUnwrapErr(),
+    ).toEqual({ kind: 'EmptyPath' });
+  });
+
+  it('rejects a negative or non-finite size (the dedup key must be sound)', () => {
+    expect(
+      parseCandidateIdentity({ username: 'peer1', path: '/a', sizeBytes: -1 })._unsafeUnwrapErr(),
+    ).toEqual({ kind: 'InvalidSize' });
+    expect(
+      parseCandidateIdentity({
+        username: 'peer1',
+        path: '/a',
+        sizeBytes: Number.NaN,
+      })._unsafeUnwrapErr(),
+    ).toEqual({ kind: 'InvalidSize' });
+  });
+});
 
 function candidate(overrides: Partial<Candidate> = {}): Candidate {
   return {

--- a/packages/downloader/src/domain/candidate/candidate.ts
+++ b/packages/downloader/src/domain/candidate/candidate.ts
@@ -1,3 +1,8 @@
+import { err, ok } from 'neverthrow';
+import type { Result } from 'neverthrow';
+import { branded } from '../shared/brand.js';
+import type { Brand } from '../shared/brand.js';
+
 /**
  * A source-agnostic candidate: one peer's copy of the target, already grouped to the
  * target's granularity by the SearchPort (D11). A fileset (folder) for a release, a single
@@ -5,11 +10,49 @@
  * (D5) inspects the actual bytes later.
  */
 
-/** Stable cross-round identity: `(username, path, size)` (D6). Drives dedup and the rejected-set. */
-export interface CandidateIdentity {
+/**
+ * Stable cross-round identity: `(username, path, size)` (D6). Drives dedup and the rejected-set —
+ * so it is branded (compile-time only, runtime-erased) and can only be minted through
+ * {@link parseCandidateIdentity}, which proves the key is sound before it ever seeds a Set/Map.
+ * The value serializes on events as a plain object, unchanged.
+ */
+export type CandidateIdentity = Brand<
+  {
+    readonly username: string;
+    readonly path: string;
+    readonly sizeBytes: number;
+  },
+  'CandidateIdentity'
+>;
+
+/** The unvalidated shape a source reports, parsed at the adapter edge into a {@link CandidateIdentity}. */
+export interface CandidateIdentityInput {
   readonly username: string;
   readonly path: string;
   readonly sizeBytes: number;
+}
+
+export type InvalidCandidateIdentity =
+  | { readonly kind: 'EmptyUsername' }
+  | { readonly kind: 'EmptyPath' }
+  | { readonly kind: 'InvalidSize' };
+
+/** Parse-don't-validate: reject a blank username/path or a negative/non-finite size at the edge. */
+export function parseCandidateIdentity(
+  input: CandidateIdentityInput,
+): Result<CandidateIdentity, InvalidCandidateIdentity> {
+  if (input.username.trim() === '') return err({ kind: 'EmptyUsername' });
+  if (input.path.trim() === '') return err({ kind: 'EmptyPath' });
+  if (!Number.isFinite(input.sizeBytes) || input.sizeBytes < 0) {
+    return err({ kind: 'InvalidSize' });
+  }
+  return ok(
+    branded<CandidateIdentity>({
+      username: input.username,
+      path: input.path,
+      sizeBytes: input.sizeBytes,
+    }),
+  );
 }
 
 export interface CandidateFile {

--- a/packages/downloader/src/domain/matching/match-scorer.test.ts
+++ b/packages/downloader/src/domain/matching/match-scorer.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { asCandidateIdentity } from '../shared/__fixtures__/candidate-identity.js';
 import {
   audioFiles,
   candidateText,
@@ -28,7 +29,7 @@ function candidate(
   path = 'Portishead - Dummy (1994) [FLAC]',
 ): Candidate {
   return {
-    identity: { username: 'peer', path, sizeBytes: 1000 },
+    identity: asCandidateIdentity({ username: 'peer', path, sizeBytes: 1000 }),
     files,
     source: { speedBytesPerSec: 1, freeSlots: 1, queueLength: 0 },
   };

--- a/packages/downloader/src/domain/policy/policies.ts
+++ b/packages/downloader/src/domain/policy/policies.ts
@@ -1,5 +1,7 @@
 import { err, ok } from 'neverthrow';
 import type { Result } from 'neverthrow';
+import { branded } from '../shared/brand.js';
+import type { Brand } from '../shared/brand.js';
 import type { QualityPolicy } from './quality-policy.js';
 
 /**
@@ -10,28 +12,32 @@ import type { QualityPolicy } from './quality-policy.js';
 
 // --- MatchPolicy: the validation/search confidence threshold (D5) -----------------------------
 
-export interface MatchPolicy {
-  readonly threshold: number; // confidence in [0, 1]
-}
-
-export const DEFAULT_MATCH_POLICY: MatchPolicy = { threshold: 0.7 };
+/**
+ * Branded so a validated policy cannot be forged from a raw `{ threshold }` literal: the only way
+ * to obtain a `MatchPolicy` is through {@link createMatchPolicy}, which proves the invariant. The
+ * brand is compile-time only and erases at runtime, so the value still round-trips as plain JSON.
+ */
+export type MatchPolicy = Brand<{ readonly threshold: number }, 'MatchPolicy'>; // confidence in [0, 1]
 
 export type MatchPolicyError = { readonly kind: 'ThresholdOutOfRange' };
 
 export function createMatchPolicy(threshold: number): Result<MatchPolicy, MatchPolicyError> {
   if (!(threshold >= 0 && threshold <= 1)) return err({ kind: 'ThresholdOutOfRange' });
-  return ok({ threshold });
+  return ok(branded<MatchPolicy>({ threshold }));
 }
+
+export const DEFAULT_MATCH_POLICY: MatchPolicy = createMatchPolicy(0.7)._unsafeUnwrap();
 
 // --- RetryPolicy: the retry-loop termination bounds (D6) ---------------------------------------
 
-export interface RetryPolicy {
-  readonly maxSearchRounds: number;
-  readonly maxTotalAttempts: number;
-  readonly timeBudgetMs?: number; // optional; off by default
-}
-
-export const DEFAULT_RETRY_POLICY: RetryPolicy = { maxSearchRounds: 3, maxTotalAttempts: 15 };
+export type RetryPolicy = Brand<
+  {
+    readonly maxSearchRounds: number;
+    readonly maxTotalAttempts: number;
+    readonly timeBudgetMs?: number; // optional; off by default
+  },
+  'RetryPolicy'
+>;
 
 export type RetryPolicyError =
   | { readonly kind: 'NonPositiveSearchRounds' }
@@ -50,24 +56,29 @@ export function createRetryPolicy(input: RetryPolicyInput): Result<RetryPolicy, 
   if (input.timeBudgetMs !== undefined && input.timeBudgetMs <= 0) {
     return err({ kind: 'NonPositiveTimeBudget' });
   }
-  return ok({
-    maxSearchRounds: input.maxSearchRounds,
-    maxTotalAttempts: input.maxTotalAttempts,
-    timeBudgetMs: input.timeBudgetMs,
-  });
+  return ok(
+    branded<RetryPolicy>({
+      maxSearchRounds: input.maxSearchRounds,
+      maxTotalAttempts: input.maxTotalAttempts,
+      timeBudgetMs: input.timeBudgetMs,
+    }),
+  );
 }
+
+export const DEFAULT_RETRY_POLICY: RetryPolicy = createRetryPolicy({
+  maxSearchRounds: 3,
+  maxTotalAttempts: 15,
+})._unsafeUnwrap();
 
 // --- DownloadPolicy: transfer timeout thresholds (D10) -----------------------------------------
 
-export interface DownloadPolicy {
-  readonly stallTimeoutMs: number;
-  readonly maxQueueWaitMs: number;
-}
-
-export const DEFAULT_DOWNLOAD_POLICY: DownloadPolicy = {
-  stallTimeoutMs: 60_000,
-  maxQueueWaitMs: 600_000,
-};
+export type DownloadPolicy = Brand<
+  {
+    readonly stallTimeoutMs: number;
+    readonly maxQueueWaitMs: number;
+  },
+  'DownloadPolicy'
+>;
 
 export type DownloadPolicyError =
   { readonly kind: 'NonPositiveStallTimeout' } | { readonly kind: 'NonPositiveQueueWait' };
@@ -82,8 +93,18 @@ export function createDownloadPolicy(
 ): Result<DownloadPolicy, DownloadPolicyError> {
   if (input.stallTimeoutMs <= 0) return err({ kind: 'NonPositiveStallTimeout' });
   if (input.maxQueueWaitMs <= 0) return err({ kind: 'NonPositiveQueueWait' });
-  return ok({ stallTimeoutMs: input.stallTimeoutMs, maxQueueWaitMs: input.maxQueueWaitMs });
+  return ok(
+    branded<DownloadPolicy>({
+      stallTimeoutMs: input.stallTimeoutMs,
+      maxQueueWaitMs: input.maxQueueWaitMs,
+    }),
+  );
 }
+
+export const DEFAULT_DOWNLOAD_POLICY: DownloadPolicy = createDownloadPolicy({
+  stallTimeoutMs: 60_000,
+  maxQueueWaitMs: 600_000,
+})._unsafeUnwrap();
 
 // --- The bundle carried on an acquisition ------------------------------------------------------
 

--- a/packages/downloader/src/domain/policy/quality-policy.test.ts
+++ b/packages/downloader/src/domain/policy/quality-policy.test.ts
@@ -72,9 +72,9 @@ describe('bucketRank / meetsFloor / compareQuality', () => {
 
   it('ranks by position, with absent buckets worst', () => {
     expect(bucketRank(policy, 'LOSSLESS_HIRES')).toBe(0);
-    expect(bucketRank({ order: ['LOSSLESS'], floor: 'LOSSLESS' }, 'UNKNOWN')).toBe(
-      Number.POSITIVE_INFINITY,
-    );
+    expect(
+      bucketRank(createQualityPolicy(['LOSSLESS'], 'LOSSLESS')._unsafeUnwrap(), 'UNKNOWN'),
+    ).toBe(Number.POSITIVE_INFINITY);
   });
 
   it('admits buckets at or above the floor and excludes those below', () => {

--- a/packages/downloader/src/domain/policy/quality-policy.ts
+++ b/packages/downloader/src/domain/policy/quality-policy.ts
@@ -1,5 +1,7 @@
 import { err, ok } from 'neverthrow';
 import type { Result } from 'neverthrow';
+import { branded } from '../shared/brand.js';
+import type { Brand } from '../shared/brand.js';
 
 /**
  * Quality as ordered buckets + a hard floor (D11), not a continuous scalar — so hi-res never
@@ -69,15 +71,13 @@ export function resolveQualityBucket(attrs: QualityAttributes): QualityBucket {
   return 'LOSSY_LOW';
 }
 
-export interface QualityPolicy {
-  readonly order: readonly QualityBucket[];
-  readonly floor: QualityBucket;
-}
-
-export const DEFAULT_QUALITY_POLICY: QualityPolicy = {
-  order: QUALITY_BUCKETS,
-  floor: 'LOSSY_LOW',
-};
+export type QualityPolicy = Brand<
+  {
+    readonly order: readonly QualityBucket[];
+    readonly floor: QualityBucket;
+  },
+  'QualityPolicy'
+>;
 
 export type QualityPolicyError =
   { readonly kind: 'EmptyOrder' } | { readonly kind: 'FloorNotInOrder' };
@@ -88,8 +88,13 @@ export function createQualityPolicy(
 ): Result<QualityPolicy, QualityPolicyError> {
   if (order.length === 0) return err({ kind: 'EmptyOrder' });
   if (!order.includes(floor)) return err({ kind: 'FloorNotInOrder' });
-  return ok({ order: [...order], floor });
+  return ok(branded<QualityPolicy>({ order: [...order], floor }));
 }
+
+export const DEFAULT_QUALITY_POLICY: QualityPolicy = createQualityPolicy(
+  QUALITY_BUCKETS,
+  'LOSSY_LOW',
+)._unsafeUnwrap();
 
 /** Rank within the policy order; absent buckets sort worst (Infinity). Lower rank = higher quality. */
 export function bucketRank(policy: QualityPolicy, bucket: QualityBucket): number {

--- a/packages/downloader/src/domain/ranking/ranking.test.ts
+++ b/packages/downloader/src/domain/ranking/ranking.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import { asCandidateIdentity } from '../shared/__fixtures__/candidate-identity.js';
 import { candidateQualityBucket, rankCandidates } from './ranking.js';
 import type { Candidate, CandidateFile } from '../candidate/candidate.js';
-import { DEFAULT_MATCH_POLICY } from '../policy/policies.js';
-import { DEFAULT_QUALITY_POLICY } from '../policy/quality-policy.js';
+import { createMatchPolicy, DEFAULT_MATCH_POLICY } from '../policy/policies.js';
+import { createQualityPolicy, DEFAULT_QUALITY_POLICY } from '../policy/quality-policy.js';
 import { createTarget } from '../target/target.js';
 import type { Target } from '../target/target.js';
 
@@ -38,11 +39,11 @@ function candidate(overrides: {
     bitrate: overrides.bitrate ?? file.bitrate,
   }));
   return {
-    identity: {
+    identity: asCandidateIdentity({
       username: overrides.username ?? 'peer',
       path: overrides.path ?? 'Radiohead - Kid A (2000)',
       sizeBytes: 1000,
-    },
+    }),
     files,
     source: {
       speedBytesPerSec: overrides.speed ?? 100,
@@ -71,7 +72,10 @@ describe('candidateQualityBucket', () => {
 
 describe('rankCandidates', () => {
   it('excludes candidates below the quality floor', () => {
-    const losslessFloor = { order: DEFAULT_QUALITY_POLICY.order, floor: 'LOSSLESS' as const };
+    const losslessFloor = createQualityPolicy(
+      DEFAULT_QUALITY_POLICY.order,
+      'LOSSLESS',
+    )._unsafeUnwrap();
     const lossy = candidate({ codec: 'mp3', bitrate: 320000 });
     expect(rankCandidates([lossy], target, losslessFloor, DEFAULT_MATCH_POLICY)).toHaveLength(0);
   });
@@ -80,7 +84,7 @@ describe('rankCandidates', () => {
     const wrong = candidate({
       files: [{ name: 'unrelated.flac', sizeBytes: 1, durationMs: 5000 }],
     });
-    const strict = { threshold: 0.9 };
+    const strict = createMatchPolicy(0.9)._unsafeUnwrap();
     expect(rankCandidates([wrong], target, DEFAULT_QUALITY_POLICY, strict)).toHaveLength(0);
   });
 

--- a/packages/downloader/src/domain/shared/__fixtures__/candidate-identity.ts
+++ b/packages/downloader/src/domain/shared/__fixtures__/candidate-identity.ts
@@ -1,0 +1,11 @@
+import { branded } from '../brand.js';
+import type { CandidateIdentity, CandidateIdentityInput } from '../../candidate/candidate.js';
+
+/**
+ * Brand a raw identity shape as a {@link CandidateIdentity} for tests. Well-formedness is an edge
+ * concern (the slskd adapter parses it with `parseCandidateIdentity`); domain tests just need *some*
+ * identity, so they mint one directly without threading a parse Result through every fixture.
+ */
+export function asCandidateIdentity(input: CandidateIdentityInput): CandidateIdentity {
+  return branded<CandidateIdentity>(input);
+}

--- a/packages/downloader/src/domain/shared/__fixtures__/mbid.ts
+++ b/packages/downloader/src/domain/shared/__fixtures__/mbid.ts
@@ -1,0 +1,11 @@
+import { branded } from '../brand.js';
+import type { Mbid } from '../mbid.js';
+
+/**
+ * Brand an arbitrary string as an {@link Mbid} for tests. UUID well-formedness is an edge concern
+ * (the facade/adapter parse it with `parseMbid`); the domain only needs *some* mbid, so tests mint
+ * one directly without threading a valid UUID through every fixture.
+ */
+export function asMbid(value: string): Mbid {
+  return branded<Mbid>(value);
+}

--- a/packages/downloader/src/domain/shared/brand.ts
+++ b/packages/downloader/src/domain/shared/brand.ts
@@ -1,0 +1,17 @@
+/**
+ * A phantom brand — a compile-time-only tag that makes a validated value distinct from its raw
+ * structural shape, so the value can only originate from its smart constructor
+ * (validate-don't-parse). The tag is a type-level fiction: it is erased at runtime, so a branded
+ * value *is* its underlying value and JSON round-tripping of events that carry branded values is
+ * byte-identical to the unbranded shape.
+ */
+export type Brand<T, B extends string> = T & { readonly __brand: B };
+
+/**
+ * Mint a branded value from its already-validated base (the branded shape minus the phantom tag).
+ * This is the single sanctioned cast: call it only from a smart constructor, right where the
+ * invariant has just been proven. Runtime identity — the brand is erased, so the value is untouched.
+ */
+export function branded<B extends Brand<unknown, string>>(base: Omit<B, '__brand'>): B {
+  return base as unknown as B;
+}

--- a/packages/downloader/src/domain/shared/mbid.test.ts
+++ b/packages/downloader/src/domain/shared/mbid.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { parseMbid } from './mbid.js';
+
+describe('parseMbid', () => {
+  it('accepts a canonical UUID and preserves its text', () => {
+    const raw = 'b1392450-e666-3926-a536-22c65f834433';
+    expect(parseMbid(raw)._unsafeUnwrap()).toBe(raw);
+  });
+
+  it('lower-cases an upper-case UUID so ids compare canonically', () => {
+    expect(parseMbid('B1392450-E666-3926-A536-22C65F834433')._unsafeUnwrap()).toBe(
+      'b1392450-e666-3926-a536-22c65f834433',
+    );
+  });
+
+  it('rejects an empty string', () => {
+    expect(parseMbid('')._unsafeUnwrapErr()).toEqual({ kind: 'InvalidMbid', value: '' });
+  });
+
+  it('rejects a non-UUID string', () => {
+    expect(parseMbid('not-a-uuid')._unsafeUnwrapErr()).toEqual({
+      kind: 'InvalidMbid',
+      value: 'not-a-uuid',
+    });
+  });
+});

--- a/packages/downloader/src/domain/shared/mbid.ts
+++ b/packages/downloader/src/domain/shared/mbid.ts
@@ -1,0 +1,22 @@
+import { err, ok } from 'neverthrow';
+import type { Result } from 'neverthrow';
+import { branded } from './brand.js';
+import type { Brand } from './brand.js';
+
+/**
+ * A MusicBrainz identifier: a well-formed UUID, parsed once at the edge so the domain only ever
+ * holds ids it can trust. Branded (compile-time only, runtime-erased) so a raw `string` cannot be
+ * passed where an mbid is expected; the value serializes on events as a plain string unchanged.
+ */
+export type Mbid = Brand<string, 'Mbid'>;
+
+export type InvalidMbid = { readonly kind: 'InvalidMbid'; readonly value: string };
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/** Parse-don't-validate: a UUID-shaped string becomes an {@link Mbid}, anything else an error value. */
+export function parseMbid(value: string): Result<Mbid, InvalidMbid> {
+  const canonical = value.trim().toLowerCase();
+  if (!UUID_PATTERN.test(canonical)) return err({ kind: 'InvalidMbid', value });
+  return ok(branded<Mbid>(canonical));
+}

--- a/packages/downloader/src/domain/target/target.test.ts
+++ b/packages/downloader/src/domain/target/target.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createTarget, totalDurationMs, trackCount } from './target.js';
 import type { TargetInput } from './target.js';
+import { asMbid } from '../shared/__fixtures__/mbid.js';
 
 function albumInput(overrides: Partial<TargetInput> = {}): TargetInput {
   return {
@@ -8,7 +9,7 @@ function albumInput(overrides: Partial<TargetInput> = {}): TargetInput {
     artist: 'Boards of Canada',
     title: 'Music Has the Right to Children',
     year: 1998,
-    mbid: 'b1392450-e666-3926-a536-22c65f834433',
+    mbid: asMbid('b1392450-e666-3926-a536-22c65f834433'),
     tracks: [
       { position: 1, title: 'Wildlife Analysis', durationMs: 78000 },
       { position: 2, title: 'An Eagle in Your Mind', durationMs: 380000 },

--- a/packages/downloader/src/domain/target/target.ts
+++ b/packages/downloader/src/domain/target/target.ts
@@ -1,5 +1,8 @@
 import { err, ok } from 'neverthrow';
 import type { Result } from 'neverthrow';
+import { branded } from '../shared/brand.js';
+import type { Brand } from '../shared/brand.js';
+import type { Mbid } from '../shared/mbid.js';
 
 /**
  * The normalized, source-agnostic description of what a caller wants to acquire (D11).
@@ -14,16 +17,32 @@ export interface TrackMetadata {
   readonly durationMs: number;
 }
 
-export interface Target {
+/**
+ * Branded (compile-time only, runtime-erased) so a validated target cannot be forged from a raw
+ * object literal — the only source is {@link createTarget}. The value still serializes on events
+ * as plain JSON.
+ */
+export type Target = Brand<
+  {
+    readonly type: TargetType;
+    readonly artist: string;
+    readonly title: string;
+    readonly tracks: readonly TrackMetadata[];
+    readonly year?: number;
+    readonly mbid?: Mbid;
+  },
+  'Target'
+>;
+
+/** The unvalidated shape accepted by {@link createTarget}: the target fields without the brand. */
+export interface TargetInput {
   readonly type: TargetType;
   readonly artist: string;
   readonly title: string;
   readonly tracks: readonly TrackMetadata[];
   readonly year?: number;
-  readonly mbid?: string;
+  readonly mbid?: Mbid;
 }
-
-export type TargetInput = Target;
 
 export type TargetError =
   | { readonly kind: 'EmptyArtist' }
@@ -47,14 +66,16 @@ export function createTarget(input: TargetInput): Result<Target, TargetError> {
     }
   }
 
-  return ok({
-    type: input.type,
-    artist,
-    title,
-    tracks: input.tracks,
-    year: input.year,
-    mbid: input.mbid,
-  });
+  return ok(
+    branded<Target>({
+      type: input.type,
+      artist,
+      title,
+      tracks: input.tracks,
+      year: input.year,
+      mbid: input.mbid,
+    }),
+  );
 }
 
 export function trackCount(target: Target): number {

--- a/packages/downloader/src/domain/validation/validation.test.ts
+++ b/packages/downloader/src/domain/validation/validation.test.ts
@@ -3,6 +3,7 @@ import { combineVerdict, verdictPasses } from './verdict.js';
 import type { ValidatorOutcome } from './verdict.js';
 import { playabilityValidator, structuralIdentityValidator } from './validators.js';
 import type { ProbedAudio } from './validators.js';
+import { createMatchPolicy } from '../policy/policies.js';
 import { createTarget } from '../target/target.js';
 import type { Target } from '../target/target.js';
 
@@ -79,7 +80,7 @@ describe('verdictPasses', () => {
       playabilityValidator(probes),
       structuralIdentityValidator(probes, target),
     ]);
-    expect(verdictPasses(verdict, { threshold: 0.5 })).toBe(true);
-    expect(verdictPasses(verdict, { threshold: 0.95 })).toBe(false);
+    expect(verdictPasses(verdict, createMatchPolicy(0.5)._unsafeUnwrap())).toBe(true);
+    expect(verdictPasses(verdict, createMatchPolicy(0.95)._unsafeUnwrap())).toBe(false);
   });
 });

--- a/packages/downloader/src/facade/facade.ts
+++ b/packages/downloader/src/facade/facade.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { CommandError } from '../application/acquisition/command-handler.js';
+import { parseMbid } from '../domain/shared/mbid.js';
 import {
   cancelAcquisition as cancelAcquisitionUseCase,
   getAcquisition as getAcquisitionUseCase,
@@ -110,10 +111,17 @@ export function createDownloaderFacade(deps: UseCaseDeps): DownloaderFacade {
     async submitAcquisition(input) {
       const parsed = submitAcquisitionRequestSchema.safeParse(input);
       if (!parsed.success) return validationFailed(parsed.error);
+      const request = requestToDomain(parsed.data.request);
+      if (request.isErr()) {
+        return fail({
+          kind: 'ValidationFailed',
+          message: 'request carries a malformed MusicBrainz id',
+        });
+      }
       const policies = resolvePolicies(parsed.data);
       if (policies.isErr()) return fail({ kind: 'InvalidPolicy' });
       const result = await submitAcquisitionUseCase(deps, {
-        request: requestToDomain(parsed.data.request),
+        request: request.value,
         policies: policies.value,
       });
       return result.match(
@@ -135,7 +143,14 @@ export function createDownloaderFacade(deps: UseCaseDeps): DownloaderFacade {
     async selectEdition(input) {
       const parsed = selectEditionInputSchema.safeParse(input);
       if (!parsed.success) return validationFailed(parsed.error);
-      const result = await selectEditionUseCase(deps, parsed.data.id, parsed.data.releaseMbid);
+      const releaseMbid = parseMbid(parsed.data.releaseMbid);
+      if (releaseMbid.isErr()) {
+        return fail({
+          kind: 'ValidationFailed',
+          message: 'releaseMbid is not a valid MusicBrainz id',
+        });
+      }
+      const result = await selectEditionUseCase(deps, parsed.data.id, releaseMbid.value);
       return result.match(
         () => ok({ acquisitionId: parsed.data.id }),
         (error) => fail(toFacadeError(error)),

--- a/packages/downloader/src/facade/index.test.ts
+++ b/packages/downloader/src/facade/index.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from 'vitest';
 import type { EventStorePort } from '../application/ports/event-store-port.js';
 import {
   awaitingSelectionHistory,
+  defaultPolicies,
   sampleEditionCandidates,
+  sampleGroupRequest,
 } from '../domain/acquisition/__fixtures__/acquisition-fixtures.js';
+import { asMbid } from '../domain/shared/__fixtures__/mbid.js';
 import { testWiring } from './__fixtures__/wiring.js';
 import type { TestWiring } from './__fixtures__/wiring.js';
 import {
@@ -24,8 +27,13 @@ import {
  * failure is a modeled error value, never a throw.
  */
 
+// User-supplied mbids cross the facade edge as UUIDs (parsed with parseMbid); tests use real ones.
+const MBID_1 = '11111111-1111-4111-8111-111111111111';
+const RETAINED_EDITION = '22222222-2222-4222-8222-222222222222';
+const OFF_MENU_EDITION = '33333333-3333-4333-8333-333333333333';
+
 const VALID_SUBMIT = {
-  request: { kind: 'musicbrainz', mbid: 'mbid-1', targetType: 'album' },
+  request: { kind: 'musicbrainz', mbid: MBID_1, targetType: 'album' },
 } as const;
 
 /** Round-trip a value through JSON and assert nothing was lost. */
@@ -50,6 +58,19 @@ describe('createDownloaderFacade', () => {
     it('returns a modeled validation error for schema-invalid input, without throwing', async () => {
       const facade = createDownloaderFacade(testWiring().deps);
       const result = await facade.submitAcquisition({ request: { kind: 'nonsense' } });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.kind).toBe('ValidationFailed');
+        expect(downloaderFacadeErrorSchema.parse(roundTrip(result.error))).toEqual(result.error);
+      }
+    });
+
+    it('rejects a schema-valid but non-UUID MusicBrainz id as a validation error', async () => {
+      const facade = createDownloaderFacade(testWiring().deps);
+      const result = await facade.submitAcquisition({
+        request: { kind: 'musicbrainz', mbid: 'not-a-uuid', targetType: 'album' },
+      });
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -152,17 +173,32 @@ describe('createDownloaderFacade', () => {
   describe('selectEdition', () => {
     async function awaitingWiring(): Promise<TestWiring> {
       const wiring = testWiring();
-      await wiring.store.append('acq-1', 0, awaitingSelectionHistory(), {
-        acquisitionId: 'acq-1',
-        occurredAt: 't',
-      });
+      await wiring.store.append(
+        'acq-1',
+        0,
+        [
+          {
+            type: 'AcquisitionRequested',
+            request: sampleGroupRequest,
+            policies: defaultPolicies(),
+          },
+          {
+            type: 'ManualSelectionRequested',
+            candidates: [{ releaseMbid: asMbid(RETAINED_EDITION), trackCount: 12 }],
+          },
+        ],
+        { acquisitionId: 'acq-1', occurredAt: 't' },
+      );
       wiring.sync();
       return wiring;
     }
 
     it('accepts a retained candidate and resumes the acquisition', async () => {
       const wiring = await awaitingWiring();
-      const result = await wiring.facade.selectEdition({ id: 'acq-1', releaseMbid: 'boot-1' });
+      const result = await wiring.facade.selectEdition({
+        id: 'acq-1',
+        releaseMbid: RETAINED_EDITION,
+      });
 
       expect(result.ok).toBe(true);
       if (result.ok) {
@@ -175,11 +211,14 @@ describe('createDownloaderFacade', () => {
 
     it('returns the modeled UnknownEdition rejection for an off-menu choice', async () => {
       const wiring = await awaitingWiring();
-      const result = await wiring.facade.selectEdition({ id: 'acq-1', releaseMbid: 'off-menu' });
+      const result = await wiring.facade.selectEdition({
+        id: 'acq-1',
+        releaseMbid: OFF_MENU_EDITION,
+      });
 
       expect(result.ok).toBe(false);
       if (!result.ok) {
-        expect(result.error).toEqual({ kind: 'UnknownEdition', releaseMbid: 'off-menu' });
+        expect(result.error).toEqual({ kind: 'UnknownEdition', releaseMbid: OFF_MENU_EDITION });
         expect(downloaderFacadeErrorSchema.parse(roundTrip(result.error))).toEqual(result.error);
       }
     });
@@ -191,7 +230,7 @@ describe('createDownloaderFacade', () => {
 
       const result = await wiring.facade.selectEdition({
         id: submitted.value.acquisitionId,
-        releaseMbid: 'boot-1',
+        releaseMbid: RETAINED_EDITION,
       });
 
       expect(result.ok).toBe(false);
@@ -203,6 +242,14 @@ describe('createDownloaderFacade', () => {
     it('rejects invalid input as a modeled validation error', async () => {
       const facade = createDownloaderFacade(testWiring().deps);
       const result = await facade.selectEdition({ id: 'acq-1' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error.kind).toBe('ValidationFailed');
+    });
+
+    it('rejects a non-UUID releaseMbid as a modeled validation error', async () => {
+      const wiring = await awaitingWiring();
+      const result = await wiring.facade.selectEdition({ id: 'acq-1', releaseMbid: 'not-a-uuid' });
 
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.error.kind).toBe('ValidationFailed');

--- a/packages/downloader/src/facade/mapping.test.ts
+++ b/packages/downloader/src/facade/mapping.test.ts
@@ -1,23 +1,42 @@
 import { describe, expect, it } from 'vitest';
+import { asCandidateIdentity } from '../domain/shared/__fixtures__/candidate-identity.js';
 import { DEFAULT_MATCH_POLICY } from '../domain/policy/policies.js';
 import type { AcquisitionStatusView } from '../application/projections/read-models.js';
 import { progressToDto, requestToDomain, resolvePolicies, statusViewToDto } from './mapping.js';
 
 describe('requestToDomain', () => {
-  it('carries the wire request through to the domain shape', () => {
-    expect(requestToDomain({ kind: 'musicbrainz', mbid: 'rel-1', targetType: 'album' })).toEqual({
-      kind: 'musicbrainz',
-      mbid: 'rel-1',
-      targetType: 'album',
-    });
+  const MBID = '11111111-1111-4111-8111-111111111111';
+
+  it('parses a musicbrainz request id into a domain mbid', () => {
+    expect(
+      requestToDomain({ kind: 'musicbrainz', mbid: MBID, targetType: 'album' })._unsafeUnwrap(),
+    ).toEqual({ kind: 'musicbrainz', mbid: MBID, targetType: 'album' });
   });
 
-  it('carries a release-group request through to the domain shape', () => {
-    expect(requestToDomain({ kind: 'release-group', mbid: 'rg-1', targetType: 'album' })).toEqual({
-      kind: 'release-group',
-      mbid: 'rg-1',
-      targetType: 'album',
-    });
+  it('parses a release-group request id into a domain mbid', () => {
+    expect(
+      requestToDomain({ kind: 'release-group', mbid: MBID, targetType: 'album' })._unsafeUnwrap(),
+    ).toEqual({ kind: 'release-group', mbid: MBID, targetType: 'album' });
+  });
+
+  it('carries a descriptor request through unchanged (no id to parse)', () => {
+    const descriptor = {
+      kind: 'descriptor' as const,
+      targetType: 'album' as const,
+      artist: 'Radiohead',
+      title: 'Kid A',
+    };
+    expect(requestToDomain(descriptor)._unsafeUnwrap()).toEqual(descriptor);
+  });
+
+  it('rejects a malformed MusicBrainz id as a modeled error', () => {
+    expect(
+      requestToDomain({
+        kind: 'musicbrainz',
+        mbid: 'not-a-uuid',
+        targetType: 'album',
+      })._unsafeUnwrapErr(),
+    ).toEqual({ kind: 'InvalidMbid', value: 'not-a-uuid' });
   });
 });
 
@@ -58,7 +77,7 @@ describe('resolvePolicies', () => {
 });
 
 describe('statusViewToDto', () => {
-  const candidate = { username: 'u1', path: 'p', sizeBytes: 100 };
+  const candidate = asCandidateIdentity({ username: 'u1', path: 'p', sizeBytes: 100 });
 
   it('maps every history-entry kind and the current candidate', () => {
     const view: AcquisitionStatusView = {

--- a/packages/downloader/src/facade/mapping.ts
+++ b/packages/downloader/src/facade/mapping.ts
@@ -1,5 +1,7 @@
-import { Result } from 'neverthrow';
+import { Result, ok } from 'neverthrow';
 import type { AcquisitionRequest } from '../domain/acquisition/events.js';
+import { parseMbid } from '../domain/shared/mbid.js';
+import type { InvalidMbid } from '../domain/shared/mbid.js';
 import type { AcquisitionPolicies } from '../domain/policy/policies.js';
 import {
   DEFAULT_DOWNLOAD_POLICY,
@@ -31,9 +33,13 @@ import type {
 
 type HistoryDto = AcquisitionStatusResponseDto['history'][number];
 
-export function requestToDomain(dto: AcquisitionRequestDto): AcquisitionRequest {
-  // The wire request mirrors the domain request today; the explicit boundary lets them diverge.
-  return dto;
+export function requestToDomain(
+  dto: AcquisitionRequestDto,
+): Result<AcquisitionRequest, InvalidMbid> {
+  // The wire request mirrors the domain request today, but its id crosses the anti-corruption
+  // boundary here: parse it once into an Mbid so the domain only ever holds well-formed ids.
+  if (dto.kind === 'descriptor') return ok(dto);
+  return parseMbid(dto.mbid).map((mbid) => ({ ...dto, mbid }));
 }
 
 export function resolvePolicies(

--- a/packages/downloader/src/interfaces/contracts/events/mapping.test.ts
+++ b/packages/downloader/src/interfaces/contracts/events/mapping.test.ts
@@ -7,6 +7,8 @@ import {
   sampleFiles,
   sampleTarget,
 } from '../../../domain/acquisition/__fixtures__/acquisition-fixtures.js';
+import { asMbid } from '../../../domain/shared/__fixtures__/mbid.js';
+import { createTarget } from '../../../domain/target/target.js';
 import type { Target } from '../../../domain/target/target.js';
 import { publishedEventMapping } from './mapping.js';
 
@@ -52,7 +54,10 @@ describe('publishedEventMapping.publishes', () => {
 
 describe('publishedEventMapping.render — acquisition.fulfilled', () => {
   it('renders the fat payload from the stream prefix', () => {
-    const target: Target = { ...sampleTarget, mbid: 'release-mbid-1' };
+    const target: Target = createTarget({
+      ...sampleTarget,
+      mbid: asMbid('release-mbid-1'),
+    })._unsafeUnwrap();
     const rendered = renderLast(fulfilledHistory(target))._unsafeUnwrap();
 
     expect(rendered.type).toBe('acquisition.fulfilled');

--- a/packages/importer/src/adapters/beets/bridge-adapter.ts
+++ b/packages/importer/src/adapters/beets/bridge-adapter.ts
@@ -2,6 +2,8 @@ import { fileURLToPath } from 'node:url';
 import { ResultAsync, errAsync, okAsync } from 'neverthrow';
 import type { z } from 'zod';
 import type { ApplyMode } from '../../domain/import/events.js';
+import { branded } from '../../domain/shared/brand.js';
+import type { Distance } from '../../domain/shared/distance.js';
 import type { Logger } from '../../application/logging/logger.js';
 import { infraError } from '../../application/ports/errors.js';
 import type { InfraError } from '../../application/ports/errors.js';
@@ -89,8 +91,12 @@ export class BeetsBridge implements TaggerPort {
           ref: { dataSource: candidate.data_source, albumId: candidate.album_id },
           artist: candidate.artist,
           album: candidate.album,
-          distance: candidate.distance,
-          penalties: candidate.penalties,
+          // The schema's [0, 1] bound is the parse edge; brand the validated numbers as Distance.
+          distance: branded<Distance>(candidate.distance),
+          penalties: candidate.penalties.map((penalty) => ({
+            name: penalty.name,
+            amount: branded<Distance>(penalty.amount),
+          })),
           tracks: candidate.tracks,
         })),
         duplicates: output.duplicates,

--- a/packages/importer/src/adapters/beets/schemas.ts
+++ b/packages/importer/src/adapters/beets/schemas.ts
@@ -9,7 +9,9 @@ import { z } from 'zod';
 
 export const bridgePenaltySchema = z.object({
   name: z.string(),
-  amount: z.number(),
+  // A distance component: the [0, 1] bound (which also rejects NaN/Infinity) is the parse edge for
+  // the domain's branded Distance, so a drifted bridge surfaces as an InfraError, never a misroute.
+  amount: z.number().min(0).max(1),
 });
 
 export const bridgeTrackSchema = z.object({
@@ -23,7 +25,9 @@ export const bridgeCandidateSchema = z.object({
   album_id: z.string().min(1),
   artist: z.string(),
   album: z.string(),
-  distance: z.number().min(0),
+  // The overall match distance; the [0, 1] bound (rejecting NaN/Infinity) is the parse edge for the
+  // domain's branded Distance that the auto-apply routing turns on.
+  distance: z.number().min(0).max(1),
   penalties: z.array(bridgePenaltySchema),
   tracks: z.array(bridgeTrackSchema),
 });

--- a/packages/importer/src/application/import/reactor.test.ts
+++ b/packages/importer/src/application/import/reactor.test.ts
@@ -6,6 +6,7 @@ import {
   candidate,
   requested,
 } from '../../domain/import/__fixtures__/import-fixtures.js';
+import { asDistance } from '../../domain/shared/__fixtures__/distance.js';
 import type { ImportEvent } from '../../domain/import/events.js';
 import { infraError } from '../ports/errors.js';
 import {
@@ -93,7 +94,7 @@ describe('Reactor', () => {
         propose: vi.fn(() =>
           okAsync({
             kind: 'proposal' as const,
-            candidates: [candidate({ distance: 0.01 })],
+            candidates: [candidate({ distance: asDistance(0.01) })],
             duplicates: [],
           }),
         ),
@@ -212,10 +213,10 @@ describe('Reactor', () => {
             [
               {
                 type: 'CandidatesProposed',
-                candidates: [candidate({ distance: 0.01 })],
+                candidates: [candidate({ distance: asDistance(0.01) })],
                 duplicates: [],
               },
-              { type: 'AutoApplySelected', ref: candidate().ref, distance: 0.01 },
+              { type: 'AutoApplySelected', ref: candidate().ref, distance: asDistance(0.01) },
             ],
             { importId, occurredAt: 't' },
           )
@@ -391,8 +392,12 @@ describe('Reactor', () => {
     const ref = candidate().ref;
     await seed([
       requested(),
-      { type: 'CandidatesProposed', candidates: [candidate({ distance: 0.01 })], duplicates: [] },
-      { type: 'AutoApplySelected', ref, distance: 0.01 },
+      {
+        type: 'CandidatesProposed',
+        candidates: [candidate({ distance: asDistance(0.01) })],
+        duplicates: [],
+      },
+      { type: 'AutoApplySelected', ref, distance: asDistance(0.01) },
       { type: 'ImportApplied', location: '/library/Artist/Album' },
     ]);
     const interpret = vi.fn(() => okAsync([]));

--- a/packages/importer/src/application/projections/read-models.test.ts
+++ b/packages/importer/src/application/projections/read-models.test.ts
@@ -17,6 +17,7 @@ import {
   requested,
   resolved,
 } from '../../domain/import/__fixtures__/import-fixtures.js';
+import { asDistance } from '../../domain/shared/__fixtures__/distance.js';
 import type { ImportEvent } from '../../domain/import/events.js';
 import type { StoredEvent } from '../ports/event-store-port.js';
 import { ImportStatusProjection, projectStatus } from './read-models.js';
@@ -50,7 +51,7 @@ describe('projectStatus', () => {
     expect(view.history).toEqual([
       { kind: 'requested', hints: HINTS },
       { kind: 'proposed', candidateCount: 1, pinnedId: 'mb-1' },
-      { kind: 'auto-apply-selected', candidate: candidate().ref, distance: 0.05 },
+      { kind: 'auto-apply-selected', candidate: candidate().ref, distance: asDistance(0.05) },
       { kind: 'applied', location: '/library/Artist/Album' },
     ]);
   });
@@ -135,7 +136,7 @@ describe('ImportStatusProjection', () => {
       directory: DIRECTORY,
       review: {
         cause: { kind: 'match-review' },
-        candidates: [candidate({ distance: 0.5 })],
+        candidates: [candidate({ distance: asDistance(0.5) })],
       },
     });
   });

--- a/packages/importer/src/composition/runtime.test.ts
+++ b/packages/importer/src/composition/runtime.test.ts
@@ -94,6 +94,22 @@ describe('createImporterRuntime', () => {
     expect(startupError.detail).toContain('bad yaml');
   });
 
+  it('refuses to boot on an out-of-range auto-apply threshold', async () => {
+    const result = await createImporterRuntime(
+      config({ autoApplyThreshold: 1.5 }),
+      silentLogger(),
+      {
+        tagger: fakeTagger(),
+      },
+    );
+    expect(result.isErr()).toBe(true);
+    const startupError = result._unsafeUnwrapErr();
+    expect(startupError.kind).toBe('InvalidAutoApplyThreshold');
+    if (startupError.kind === 'InvalidAutoApplyThreshold') {
+      expect(startupError.detail).toContain('1.5');
+    }
+  });
+
   it('consumes a downloader fulfilment over the connected feed into a native import', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'intake-'));
     cleanups.push(() => rmSync(dir, { recursive: true, force: true }));

--- a/packages/importer/src/composition/runtime.ts
+++ b/packages/importer/src/composition/runtime.ts
@@ -8,6 +8,7 @@ import { FilesystemIntake } from '../adapters/filesystem/intake.js';
 import { InProcessEventBus } from '../adapters/sqlite/event-bus.js';
 import { SqliteCheckpointStore, SqliteEventStore } from '../adapters/sqlite/event-store.js';
 import { SqliteDeadLetterStore } from '../adapters/sqlite/dead-letters.js';
+import { parseDistance } from '../domain/shared/distance.js';
 import { openEventDatabase } from '../adapters/sqlite/schema.js';
 import { UpcasterRegistry } from '../adapters/sqlite/upcaster.js';
 import { interpretEffect } from '../application/import/interpreter.js';
@@ -95,7 +96,8 @@ export interface ImporterRuntime {
 
 export type ImporterStartupError =
   | { readonly kind: 'BeetsConfigUnusable'; readonly detail: string }
-  | { readonly kind: 'ProjectionRebuildFailed'; readonly detail: string };
+  | { readonly kind: 'ProjectionRebuildFailed'; readonly detail: string }
+  | { readonly kind: 'InvalidAutoApplyThreshold'; readonly detail: string };
 
 /** True only for the "the directory is not there (yet)" errnos — everything else is a real fault. */
 function isDirectoryAbsent(error: unknown): boolean {
@@ -121,6 +123,16 @@ export async function createImporterRuntime(
   overrides: ImporterRuntimeOverrides = {},
 ): Promise<Result<ImporterRuntime, ImporterStartupError>> {
   const clock = overrides.clock ?? { now: () => new Date() };
+
+  // The configured auto-apply threshold crosses the edge here: parse it into a branded Distance so
+  // the domain's `distance > threshold` routing can never turn on an out-of-range or NaN bound.
+  const autoApplyThreshold = parseDistance(config.autoApplyThreshold);
+  if (autoApplyThreshold.isErr()) {
+    return err({
+      kind: 'InvalidAutoApplyThreshold',
+      detail: `autoApplyThreshold must be within [0, 1], got ${config.autoApplyThreshold}`,
+    });
+  }
 
   const tagger =
     overrides.tagger ??
@@ -180,7 +192,7 @@ export async function createImporterRuntime(
     store,
     clock,
     status,
-    policy: { autoApplyThreshold: config.autoApplyThreshold },
+    policy: { autoApplyThreshold: autoApplyThreshold.value },
   };
   const facade = createImporterFacade(deps);
   const feed = new OutboundFeed(store, publishedEventMapping);

--- a/packages/importer/src/domain/import/__fixtures__/import-fixtures.ts
+++ b/packages/importer/src/domain/import/__fixtures__/import-fixtures.ts
@@ -10,10 +10,11 @@ import type {
   ProposedCandidate,
   Resolution,
 } from '../events.js';
+import { asDistance } from '../../shared/__fixtures__/distance.js';
 
 /** Deterministic builders for domain tests. */
 
-export const POLICY: ImportPolicy = { autoApplyThreshold: 0.1 };
+export const POLICY: ImportPolicy = { autoApplyThreshold: asDistance(0.1) };
 export const DIRECTORY = '/intake/Artist - Album';
 export const HINTS: ImportHints = { mbReleaseId: 'mb-release-1', artist: 'Artist', album: 'Album' };
 
@@ -31,8 +32,8 @@ export function candidate(overrides: Partial<ProposedCandidate> = {}): ProposedC
     ref: { dataSource: 'MusicBrainz', albumId: 'album-1' },
     artist: 'Artist',
     album: 'Album',
-    distance: 0.05,
-    penalties: [{ name: 'tracks', amount: 0.05 }],
+    distance: asDistance(0.05),
+    penalties: [{ name: 'tracks', amount: asDistance(0.05) }],
     tracks: [{ path: `${DIRECTORY}/01 Track.flac`, title: 'Track', index: 1 }],
     ...overrides,
   };
@@ -74,7 +75,7 @@ export function resolved(resolution: Resolution): ImportEvent {
 export const AUTO_APPLIED: ImportEvent = {
   type: 'AutoApplySelected',
   ref: { dataSource: 'MusicBrainz', albumId: 'album-1' },
-  distance: 0.05,
+  distance: asDistance(0.05),
 };
 
 export const MATCH_REVIEW: ImportEvent = {
@@ -92,12 +93,16 @@ export const REMEDIATION: ImportEvent = { type: 'RemediationRequired', failures:
 
 /** A history that lands in `awaiting-review` (weak match) with one listed candidate. */
 export function awaitingMatchReview(): ImportEvent[] {
-  return [requested(), proposed([candidate({ distance: 0.5 })]), MATCH_REVIEW];
+  return [requested(), proposed([candidate({ distance: asDistance(0.5) })]), MATCH_REVIEW];
 }
 
 /** As above, but downloader-delivered with a retained candidate (verdict-capable). */
 export function awaitingReviewWithCandidate(): ImportEvent[] {
-  return [requested({ source: SOURCE }), proposed([candidate({ distance: 0.5 })]), MATCH_REVIEW];
+  return [
+    requested({ source: SOURCE }),
+    proposed([candidate({ distance: asDistance(0.5) })]),
+    MATCH_REVIEW,
+  ];
 }
 
 /** A history that auto-applied and landed `applied`. */

--- a/packages/importer/src/domain/import/events.ts
+++ b/packages/importer/src/domain/import/events.ts
@@ -1,3 +1,5 @@
+import type { Distance } from '../shared/distance.js';
+
 /**
  * Domain events — the facts that make up an import's history (event-sourcing). They narrate the
  * import *process* only: beets' library database remains the system of record for the library
@@ -13,7 +15,7 @@ export interface ImportHints {
 
 /** The policy stamped onto the request: distance at or below the threshold auto-applies. */
 export interface ImportPolicy {
-  readonly autoApplyThreshold: number;
+  readonly autoApplyThreshold: Distance;
 }
 
 /**
@@ -56,7 +58,7 @@ export function candidateRefKey(ref: CandidateRef): string {
 /** One component of beets' distance breakdown (e.g. `tracks`, `missing_tracks`, `year`). */
 export interface CandidatePenalty {
   readonly name: string;
-  readonly amount: number;
+  readonly amount: Distance;
 }
 
 /** One entry of the item-to-track mapping beets computed for a candidate. */
@@ -71,7 +73,7 @@ export interface ProposedCandidate {
   readonly ref: CandidateRef;
   readonly artist: string;
   readonly album: string;
-  readonly distance: number;
+  readonly distance: Distance;
   readonly penalties: readonly CandidatePenalty[];
   readonly tracks: readonly TrackMapping[];
 }
@@ -163,7 +165,7 @@ export type ImportEvent =
       readonly duplicates: readonly DuplicateIncumbent[];
       readonly pinnedId?: string;
     }
-  | { readonly type: 'AutoApplySelected'; readonly ref: CandidateRef; readonly distance: number }
+  | { readonly type: 'AutoApplySelected'; readonly ref: CandidateRef; readonly distance: Distance }
   | { readonly type: 'ReviewRequired'; readonly cause: ReviewCause }
   | { readonly type: 'ReviewResolved'; readonly resolution: Resolution }
   | { readonly type: 'ImportApplied'; readonly location: string }

--- a/packages/importer/src/domain/import/import.test.ts
+++ b/packages/importer/src/domain/import/import.test.ts
@@ -20,6 +20,7 @@ import {
   requested,
   resolved,
 } from './__fixtures__/import-fixtures.js';
+import { asDistance } from '../shared/__fixtures__/distance.js';
 import type { ImportCommand } from './commands.js';
 import type { ImportEvent } from './events.js';
 import { Import } from './import.js';
@@ -82,10 +83,10 @@ describe('recording a proposal', () => {
   ): ImportCommand => ({ type: 'RecordProposal', candidates, duplicates, pinnedId });
 
   it('auto-applies the best candidate at or under the threshold', () => {
-    const strong = candidate({ distance: 0.02 });
+    const strong = candidate({ distance: asDistance(0.02) });
     const weaker = candidate({
       ref: { dataSource: 'MusicBrainz', albumId: 'album-2' },
-      distance: 0.4,
+      distance: asDistance(0.4),
     });
     const events = given([requested()])
       .execute(record([weaker, strong]))
@@ -97,7 +98,7 @@ describe('recording a proposal', () => {
         duplicates: [],
         pinnedId: undefined,
       },
-      { type: 'AutoApplySelected', ref: strong.ref, distance: 0.02 },
+      { type: 'AutoApplySelected', ref: strong.ref, distance: asDistance(0.02) },
     ]);
     // Order-independent: the best candidate wins from either position.
     const reversed = given([requested()])
@@ -107,7 +108,7 @@ describe('recording a proposal', () => {
   });
 
   it('routes a weak match to review with the best candidate named', () => {
-    const weak = candidate({ distance: 0.6 });
+    const weak = candidate({ distance: asDistance(0.6) });
     const events = given([requested()])
       .execute(record([weak]))
       ._unsafeUnwrap();
@@ -118,7 +119,7 @@ describe('recording a proposal', () => {
   });
 
   it('marks a hint-contradicted weak match as hinted (distance governs, D4)', () => {
-    const weak = candidate({ distance: 0.6 });
+    const weak = candidate({ distance: asDistance(0.6) });
     const events = given([requested({ hints: HINTS })])
       .execute(record([weak]))
       ._unsafeUnwrap();
@@ -131,14 +132,14 @@ describe('recording a proposal', () => {
       resolved({ kind: 'supply-id', mbReleaseId: 'mb-2' }),
     ];
     const events = given(history)
-      .execute(record([candidate({ distance: 0.6 })]))
+      .execute(record([candidate({ distance: asDistance(0.6) })]))
       ._unsafeUnwrap();
     expect(events[1]).toMatchObject({ cause: { kind: 'match-review', hinted: true } });
   });
 
   it('marks the proposal hinted when the interpreter reports the pinned id', () => {
     const events = given([requested()])
-      .execute(record([candidate({ distance: 0.6 })], [], 'mb-9'))
+      .execute(record([candidate({ distance: asDistance(0.6) })], [], 'mb-9'))
       ._unsafeUnwrap();
     expect(events[0]).toMatchObject({ type: 'CandidatesProposed', pinnedId: 'mb-9' });
     expect(events[1]).toMatchObject({ cause: { hinted: true } });
@@ -151,7 +152,7 @@ describe('recording a proposal', () => {
 
   it('routes a strong match with an incumbent to duplicate review, never auto-replace', () => {
     const events = given([requested()])
-      .execute(record([candidate({ distance: 0.01 })], [INCUMBENT]))
+      .execute(record([candidate({ distance: asDistance(0.01) })], [INCUMBENT]))
       ._unsafeUnwrap();
     expect(events[1]).toEqual({
       type: 'ReviewRequired',
@@ -284,7 +285,7 @@ describe('resolving a review', () => {
 
   it('accepts each verb against an open match review', () => {
     for (const resolution of [
-      { kind: 'apply-candidate', ref: candidate({ distance: 0.5 }).ref },
+      { kind: 'apply-candidate', ref: candidate({ distance: asDistance(0.5) }).ref },
       { kind: 'supply-id', mbReleaseId: 'mb-2' },
       { kind: 'refresh-candidates' },
       { kind: 'manual-tags', tags: MANUAL_TAGS },
@@ -347,7 +348,7 @@ describe('resolving a review', () => {
     ).toEqual({ kind: 'NoRetainedCandidate' });
     const legacy = [
       requested({ source: { acquisitionId: 'acq-legacy' } }),
-      proposed([candidate({ distance: 0.5 })]),
+      proposed([candidate({ distance: asDistance(0.5) })]),
       MATCH_REVIEW,
     ];
     expect(
@@ -658,7 +659,7 @@ describe('the snapshot projection', () => {
     const snapshot = given(awaitingMatchReview()).snapshot;
     expect(snapshot.openReview).toEqual({
       cause: { kind: 'match-review', hinted: false, best: candidate().ref },
-      candidates: [candidate({ distance: 0.5 })],
+      candidates: [candidate({ distance: asDistance(0.5) })],
     });
   });
 

--- a/packages/importer/src/domain/import/state.test.ts
+++ b/packages/importer/src/domain/import/state.test.ts
@@ -19,6 +19,7 @@ import {
   requested,
   resolved,
 } from './__fixtures__/import-fixtures.js';
+import { asDistance } from '../shared/__fixtures__/distance.js';
 import type { ImportEvent } from './events.js';
 import { candidateRefKey } from './events.js';
 import { evolve, foldEvents, initialState, isTerminal } from './state.js';
@@ -82,7 +83,7 @@ describe('evolve — the tolerant, total fold', () => {
     expect(state).toMatchObject({
       phase: 'awaiting-review',
       cause: { kind: 'match-review' },
-      candidates: [candidate({ distance: 0.5 })],
+      candidates: [candidate({ distance: asDistance(0.5) })],
     });
   });
 

--- a/packages/importer/src/domain/shared/__fixtures__/distance.ts
+++ b/packages/importer/src/domain/shared/__fixtures__/distance.ts
@@ -1,0 +1,11 @@
+import { branded } from '../brand.js';
+import type { Distance } from '../distance.js';
+
+/**
+ * Brand an arbitrary number as a {@link Distance} for tests. Range validity is an edge concern (the
+ * beets adapter/config parse it); tests that exercise the domain just need *some* distance, so they
+ * mint one directly without threading a parse Result through every fixture.
+ */
+export function asDistance(value: number): Distance {
+  return branded<Distance>(value);
+}

--- a/packages/importer/src/domain/shared/brand.ts
+++ b/packages/importer/src/domain/shared/brand.ts
@@ -1,0 +1,17 @@
+/**
+ * A phantom brand — a compile-time-only tag that makes a validated value distinct from its raw
+ * structural shape, so the value can only originate from its smart constructor
+ * (validate-don't-parse). The tag is a type-level fiction: it is erased at runtime, so a branded
+ * value *is* its underlying value and JSON round-tripping of events that carry branded values is
+ * byte-identical to the unbranded shape.
+ */
+export type Brand<T, B extends string> = T & { readonly __brand: B };
+
+/**
+ * Mint a branded value from its already-validated base (the branded shape minus the phantom tag).
+ * This is the single sanctioned cast: call it only from a smart constructor, right where the
+ * invariant has just been proven. Runtime identity — the brand is erased, so the value is untouched.
+ */
+export function branded<B extends Brand<unknown, string>>(base: Omit<B, '__brand'>): B {
+  return base as unknown as B;
+}

--- a/packages/importer/src/domain/shared/distance.test.ts
+++ b/packages/importer/src/domain/shared/distance.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { parseDistance } from './distance.js';
+
+describe('parseDistance', () => {
+  it('accepts the closed unit interval, preserving the value', () => {
+    expect(parseDistance(0)._unsafeUnwrap()).toBe(0);
+    expect(parseDistance(0.42)._unsafeUnwrap()).toBe(0.42);
+    expect(parseDistance(1)._unsafeUnwrap()).toBe(1);
+  });
+
+  it('rejects a value below 0 or above 1', () => {
+    expect(parseDistance(-0.01)._unsafeUnwrapErr()).toEqual({
+      kind: 'InvalidDistance',
+      value: -0.01,
+    });
+    expect(parseDistance(1.5)._unsafeUnwrapErr()).toEqual({ kind: 'InvalidDistance', value: 1.5 });
+  });
+
+  it('rejects a non-finite value so it can never silently misroute auto-apply', () => {
+    expect(parseDistance(Number.NaN)._unsafeUnwrapErr()).toEqual({
+      kind: 'InvalidDistance',
+      value: Number.NaN,
+    });
+    expect(parseDistance(Number.POSITIVE_INFINITY)._unsafeUnwrapErr()).toEqual({
+      kind: 'InvalidDistance',
+      value: Number.POSITIVE_INFINITY,
+    });
+  });
+});

--- a/packages/importer/src/domain/shared/distance.ts
+++ b/packages/importer/src/domain/shared/distance.ts
@@ -1,0 +1,23 @@
+import { err, ok } from 'neverthrow';
+import type { Result } from 'neverthrow';
+import { branded } from './brand.js';
+import type { Brand } from './brand.js';
+
+/**
+ * A beets match distance: a scalar in the closed unit interval [0, 1] where 0 is a perfect match.
+ * Branded (compile-time only, runtime-erased) because the auto-apply routing turns on
+ * `distance > threshold` — a `NaN` or out-of-range value would silently misroute. Parsing at the
+ * edge guarantees every distance the domain compares is finite and in range. The value still
+ * serializes on events as a plain number, unchanged.
+ */
+export type Distance = Brand<number, 'Distance'>;
+
+export type InvalidDistance = { readonly kind: 'InvalidDistance'; readonly value: number };
+
+/** Parse-don't-validate: a finite in-range number becomes a {@link Distance}, anything else an error. */
+export function parseDistance(value: number): Result<Distance, InvalidDistance> {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    return err({ kind: 'InvalidDistance', value });
+  }
+  return ok(branded<Distance>(value));
+}


### PR DESCRIPTION
Deferred follow-up to the review-hardening change (#92). Pushes validated-value invariants **into the types** via phantom-branded value objects, so a raw structural literal can no longer forge a validated domain value ("parse, don't validate"). Written test-first; full gate green.

## Brand helper
Each package is self-contained, so a minimal per-package util was added — `packages/{downloader,importer}/src/domain/shared/brand.ts`: a compile-time-only `Brand<T,B>` plus a single sanctioned `branded()` mint. Pure types/identity — **no runtime shape change**, so event-log JSON round-trips byte-identically (verified by both contract tiers).

## Value objects (core set)
- **Branded policy/`Target` constructors** — `MatchPolicy`/`RetryPolicy`/`DownloadPolicy`/`QualityPolicy`/`Target` are now branded; their smart constructors are the only mint. The `DEFAULT_*` values are produced **through** the constructors (were raw literals bypassing validation). These ride on `AcquisitionRequested`; serialized shape unchanged.
- **`Mbid`** (`string & brand`) + `parseMbid` (UUID shape) — applied to request/edition/target mbids. Parsed at the **facade** edge (untrusted user input → `ValidationFailed` on a malformed id); MusicBrainz ids are branded directly at the adapter as the authoritative issuer.
- **`Distance`** (0..1) + `parseDistance` (rejects non-finite/out-of-range) — applied to `autoApplyThreshold`, candidate `distance`, penalty `amount`. Fixes the load-bearing `best.distance > autoApplyThreshold` routing, which a `NaN`/out-of-range value silently misrouted. Parsed at the beets bridge schema (`.min(0).max(1)`) and the composition root (`InvalidAutoApplyThreshold` startup error).
- **`CandidateIdentity`** smart constructor — rejects blank username/path and negative/non-finite `sizeBytes` (the load-bearing dedup key). Parsed at the slskd adapter edge; files with no addressable identity are dropped rather than admitted with a collision-prone blank key.

## Deferred (rationale)
- **`Unit` (0..1)** for confidence/score/weight scalars — highest-value tail item but ripples through matching/ranking/validation like a core item; deferred to keep this PR green and reviewable.
- **importer branded ids** (`AcquisitionId`/`ImportId`) — lower value.
- **Representability fixes** (`EditionCandidate.trackCount` optional; `match-review.best` required; positive-int track/disc numbers) — these touch **serialized event/wire shapes** (consumer-breaking or unsafe against legacy stored events), so not safe "cheap" changes; left for a deliberate schema-evolution change.

## Gate
`pnpm check` green: 1552 tests at 100% coverage (branches 1881/1881), downloader contract 69, importer contract 51, release scripts 46, lint clean. No branding altered a serialized event's runtime shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
