### PR TITLE
refactor(domain): value-object tail — Unit(0..1) brand, branded ids, representability tightenings

### DIFF
--- a/packages/downloader/src/application/projections/read-models.test.ts
+++ b/packages/downloader/src/application/projections/read-models.test.ts
@@ -8,6 +8,7 @@ import {
 } from './read-models.js';
 import { FakeEventStore } from '../__fixtures__/fakes.js';
 import { asMbid } from '../../domain/shared/__fixtures__/mbid.js';
+import { asUnit } from '../../domain/shared/__fixtures__/unit.js';
 import type { AcquisitionEvent } from '../../domain/acquisition/events.js';
 import type { StoredEvent } from '../ports/event-store-port.js';
 import {
@@ -37,12 +38,16 @@ const history: AcquisitionEvent[] = [
   {
     type: 'ValidationFailed',
     candidate: b.identity,
-    verdict: { confidence: 0, reasons: ['DurationMismatch'] },
+    verdict: { confidence: asUnit(0), reasons: ['DurationMismatch'] },
   },
   { type: 'CandidateRejected', candidate: b.identity },
   { type: 'CandidateSelected', candidate: c },
   { type: 'DownloadCompleted', candidate: c.identity, files: [] },
-  { type: 'ValidationPassed', candidate: c.identity, verdict: { confidence: 1, reasons: [] } },
+  {
+    type: 'ValidationPassed',
+    candidate: c.identity,
+    verdict: { confidence: asUnit(1), reasons: [] },
+  },
   { type: 'Imported', candidate: c.identity, location: '/lib/c' },
   { type: 'AcquisitionFulfilled', location: '/lib/c' },
 ];

--- a/packages/downloader/src/domain/acquisition/__fixtures__/acquisition-fixtures.ts
+++ b/packages/downloader/src/domain/acquisition/__fixtures__/acquisition-fixtures.ts
@@ -10,6 +10,7 @@ import { rankCandidates } from '../../ranking/ranking.js';
 import type { RankedCandidate } from '../../ranking/ranking.js';
 import { asCandidateIdentity } from '../../shared/__fixtures__/candidate-identity.js';
 import { asMbid } from '../../shared/__fixtures__/mbid.js';
+import { asUnit } from '../../shared/__fixtures__/unit.js';
 import { createTarget } from '../../target/target.js';
 import type { Target } from '../../target/target.js';
 import type {
@@ -161,7 +162,7 @@ export function importingHistory(
     {
       type: 'ValidationPassed',
       candidate: selected.identity,
-      verdict: { confidence: 1, reasons: [] },
+      verdict: { confidence: asUnit(1), reasons: [] },
     },
   ];
 }

--- a/packages/downloader/src/domain/acquisition/acquisition.test.ts
+++ b/packages/downloader/src/domain/acquisition/acquisition.test.ts
@@ -5,6 +5,7 @@ import type { AcquisitionCommand } from './commands.js';
 import type { AcquisitionEvent, AcquisitionRequest } from './events.js';
 import { createRetryPolicy } from '../policy/policies.js';
 import { asMbid } from '../shared/__fixtures__/mbid.js';
+import { asUnit } from '../shared/__fixtures__/unit.js';
 import {
   awaitingSelectionHistory,
   defaultPolicies,
@@ -69,7 +70,11 @@ const rejectedThenSelecting: AcquisitionEvent[] = [
 ];
 const validationFailedThenSelecting: AcquisitionEvent[] = [
   ...validatingHistory([a, matchingCandidate('b')]),
-  { type: 'ValidationFailed', candidate: a.identity, verdict: { confidence: 0, reasons: [] } },
+  {
+    type: 'ValidationFailed',
+    candidate: a.identity,
+    verdict: { confidence: asUnit(0), reasons: [] },
+  },
   { type: 'CandidateRejected', candidate: a.identity },
 ];
 
@@ -185,7 +190,10 @@ describe('Acquisition.execute — happy path', () => {
     expect(
       types(
         Acquisition.fromHistory(validatingHistory([a]))
-          .execute({ type: 'RecordValidationPassed', verdict: { confidence: 1, reasons: [] } })
+          .execute({
+            type: 'RecordValidationPassed',
+            verdict: { confidence: asUnit(1), reasons: [] },
+          })
           ._unsafeUnwrap(),
       ),
     ).toEqual(['ValidationPassed']);
@@ -225,7 +233,7 @@ describe('Acquisition.execute — retry loop', () => {
     )
       .execute({
         type: 'RecordValidationFailed',
-        verdict: { confidence: 0, reasons: ['DurationMismatch'] },
+        verdict: { confidence: asUnit(0), reasons: ['DurationMismatch'] },
       })
       ._unsafeUnwrap();
     expect(types(events)).toEqual(['ValidationFailed', 'CandidateRejected', 'CandidateSelected']);
@@ -410,7 +418,11 @@ describe('Acquisition.execute — an external validation failure revives fulfilm
       { type: 'CandidateRejected', candidate: a.identity, files: [] },
       { type: 'CandidateSelected', candidate: b },
       { type: 'DownloadCompleted', candidate: b.identity, files: sampleFiles },
-      { type: 'ValidationPassed', candidate: b.identity, verdict: { confidence: 1, reasons: [] } },
+      {
+        type: 'ValidationPassed',
+        candidate: b.identity,
+        verdict: { confidence: asUnit(1), reasons: [] },
+      },
       { type: 'Imported', candidate: b.identity, location: '/library/x' },
       { type: 'AcquisitionFulfilled', location: '/library/x', candidate: b.identity },
     ]);
@@ -442,8 +454,8 @@ describe('Acquisition.execute — cancellation and guards', () => {
     { type: 'RecordSearchResults', candidates: [] },
     { type: 'RecordDownloadCompleted', files: [] },
     { type: 'RecordDownloadFailed', reason: 'Stalled' },
-    { type: 'RecordValidationPassed', verdict: { confidence: 1, reasons: [] } },
-    { type: 'RecordValidationFailed', verdict: { confidence: 0, reasons: [] } },
+    { type: 'RecordValidationPassed', verdict: { confidence: asUnit(1), reasons: [] } },
+    { type: 'RecordValidationFailed', verdict: { confidence: asUnit(0), reasons: [] } },
     { type: 'RecordImported', location: '/x' },
     { type: 'RecordImportConflict', location: '/x' },
     { type: 'CancelAcquisition' },
@@ -458,8 +470,8 @@ describe('Acquisition.execute — cancellation and guards', () => {
     { type: 'RecordSearchResults', candidates: [] },
     { type: 'RecordDownloadCompleted', files: [] },
     { type: 'RecordDownloadFailed', reason: 'Stalled' },
-    { type: 'RecordValidationPassed', verdict: { confidence: 1, reasons: [] } },
-    { type: 'RecordValidationFailed', verdict: { confidence: 0, reasons: [] } },
+    { type: 'RecordValidationPassed', verdict: { confidence: asUnit(1), reasons: [] } },
+    { type: 'RecordValidationFailed', verdict: { confidence: asUnit(0), reasons: [] } },
     { type: 'RecordImported', location: '/x' },
     { type: 'RecordImportConflict', location: '/x' },
   ];
@@ -518,7 +530,7 @@ describe('Acquisition.execute — cleanup events carry the staged files (D3)', (
 
   it('stamps the validating candidate’s staged files onto its rejection', () => {
     const events = Acquisition.fromHistory(validatingHistory([a, matchingCandidate('b')]))
-      .execute({ type: 'RecordValidationFailed', verdict: { confidence: 0, reasons: [] } })
+      .execute({ type: 'RecordValidationFailed', verdict: { confidence: asUnit(0), reasons: [] } })
       ._unsafeUnwrap();
     expect(eventOf(events, 'CandidateRejected').files).toEqual(sampleFiles);
   });
@@ -637,7 +649,7 @@ describe('Acquisition.reactTo — the event → effect table', () => {
     const effects = Acquisition.fromHistory(importingHistory([a])).reactTo({
       type: 'ValidationPassed',
       candidate: a.identity,
-      verdict: { confidence: 1, reasons: [] },
+      verdict: { confidence: asUnit(1), reasons: [] },
     });
     expect(effectTypes(effects)).toEqual(['Import']);
   });
@@ -647,7 +659,11 @@ describe('Acquisition.reactTo — the event → effect table', () => {
     { type: 'SearchCompleted', round: 1, candidates: [] },
     { type: 'CandidatesRanked', ranked: [] },
     { type: 'DownloadFailed', candidate: a.identity, reason: 'Stalled' },
-    { type: 'ValidationFailed', candidate: a.identity, verdict: { confidence: 0, reasons: [] } },
+    {
+      type: 'ValidationFailed',
+      candidate: a.identity,
+      verdict: { confidence: asUnit(0), reasons: [] },
+    },
     { type: 'AcquisitionFulfilled', location: '/x' },
     // A revival needs no effect of its own: the co-emitted CandidateRejected drives cleanup, and
     // CandidateSelected/SearchRequested drive the revival's work.
@@ -775,7 +791,7 @@ describe('Acquisition.reactTo — the event → effect table', () => {
       empty.reactTo({
         type: 'ValidationPassed',
         candidate: a.identity,
-        verdict: { confidence: 1, reasons: [] },
+        verdict: { confidence: asUnit(1), reasons: [] },
       }),
     ).toEqual([]);
     expect(empty.reactTo({ type: 'ImportConflicted', location: '/x' })).toEqual([]);

--- a/packages/downloader/src/domain/acquisition/state.test.ts
+++ b/packages/downloader/src/domain/acquisition/state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { AcquisitionEvent } from './events.js';
 import { evolve, foldEvents } from './state.js';
 import { asMbid } from '../shared/__fixtures__/mbid.js';
+import { asUnit } from '../shared/__fixtures__/unit.js';
 import type { AcquisitionPhase, AcquisitionState } from './state.js';
 import {
   awaitingSelectionHistory,
@@ -61,8 +62,16 @@ const allEvents: AcquisitionEvent[] = [
   { type: 'DownloadCompleted', candidate: a.identity, files: [] },
   { type: 'DownloadFailed', candidate: a.identity, reason: 'Stalled' },
   { type: 'CandidateRejected', candidate: a.identity },
-  { type: 'ValidationPassed', candidate: a.identity, verdict: { confidence: 1, reasons: [] } },
-  { type: 'ValidationFailed', candidate: a.identity, verdict: { confidence: 0, reasons: [] } },
+  {
+    type: 'ValidationPassed',
+    candidate: a.identity,
+    verdict: { confidence: asUnit(1), reasons: [] },
+  },
+  {
+    type: 'ValidationFailed',
+    candidate: a.identity,
+    verdict: { confidence: asUnit(0), reasons: [] },
+  },
   { type: 'Imported', candidate: a.identity, location: '/x' },
   { type: 'AcquisitionFulfilled', location: '/x' },
   { type: 'FulfillmentRejected', candidate: a.identity, reasons: [] },
@@ -125,7 +134,11 @@ describe('evolve — cleanup events carry inert staged files (D3, additive/optio
   it('folds a rejection identically whether or not it carries staged files', () => {
     const base: AcquisitionEvent[] = [
       ...validatingHistory([a, b]),
-      { type: 'ValidationFailed', candidate: a.identity, verdict: { confidence: 0, reasons: [] } },
+      {
+        type: 'ValidationFailed',
+        candidate: a.identity,
+        verdict: { confidence: asUnit(0), reasons: [] },
+      },
     ];
     const withFiles = foldEvents([
       ...base,

--- a/packages/downloader/src/domain/matching/match-scorer.ts
+++ b/packages/downloader/src/domain/matching/match-scorer.ts
@@ -1,6 +1,8 @@
 import type { Candidate, CandidateFile } from '../candidate/candidate.js';
 import type { Target } from '../target/target.js';
 import { alignmentScore } from '../shared/duration.js';
+import { clampUnit } from '../shared/unit.js';
+import type { Unit } from '../shared/unit.js';
 import { containmentScore, normalizeText, tokenize } from './text.js';
 
 /**
@@ -11,9 +13,10 @@ import { containmentScore, normalizeText, tokenize } from './text.js';
  */
 export interface MatchSignal {
   readonly name: string;
-  readonly weight: number;
+  /** The signal's relative pull on the weighted mean, in [0, 1] (mint via `clampUnit`/`parseUnit`). */
+  readonly weight: Unit;
   /** A score in [0, 1], or `null` when the signal cannot be evaluated for this candidate. */
-  readonly score: (target: Target, candidate: Candidate) => number | null;
+  readonly score: (target: Target, candidate: Candidate) => Unit | null;
 }
 
 const AUDIO_EXTENSIONS: ReadonlySet<string> = new Set([
@@ -62,11 +65,11 @@ export function candidateText(candidate: Candidate): string {
   return normalizeText(`${basename(candidate.identity.path)} ${names}`);
 }
 
-const TRACK_COUNT_WEIGHT = 0.35;
-const DURATION_WEIGHT = 0.35;
-const TITLE_WEIGHT = 0.15;
-const ARTIST_WEIGHT = 0.1;
-const YEAR_WEIGHT = 0.05;
+const TRACK_COUNT_WEIGHT = clampUnit(0.35);
+const DURATION_WEIGHT = clampUnit(0.35);
+const TITLE_WEIGHT = clampUnit(0.15);
+const ARTIST_WEIGHT = clampUnit(0.1);
+const YEAR_WEIGHT = clampUnit(0.05);
 
 export const trackCountSignal: MatchSignal = {
   name: 'trackCount',
@@ -74,7 +77,7 @@ export const trackCountSignal: MatchSignal = {
   score: (target, candidate) => {
     const actual = audioFiles(candidate).length;
     const expected = target.tracks.length;
-    return Math.max(0, 1 - Math.abs(actual - expected) / expected);
+    return clampUnit(Math.max(0, 1 - Math.abs(actual - expected) / expected));
   },
 };
 
@@ -86,9 +89,11 @@ export const durationSignal: MatchSignal = {
       .map((file) => file.durationMs)
       .filter((duration): duration is number => duration !== undefined);
     if (durations.length === 0) return null;
-    return alignmentScore(
-      target.tracks.map((track) => track.durationMs),
-      durations,
+    return clampUnit(
+      alignmentScore(
+        target.tracks.map((track) => track.durationMs),
+        durations,
+      ),
     );
   },
 };
@@ -97,14 +102,14 @@ export const titleSignal: MatchSignal = {
   name: 'title',
   weight: TITLE_WEIGHT,
   score: (target, candidate) =>
-    containmentScore(tokenize(target.title), tokenize(candidateText(candidate))),
+    clampUnit(containmentScore(tokenize(target.title), tokenize(candidateText(candidate)))),
 };
 
 export const artistSignal: MatchSignal = {
   name: 'artist',
   weight: ARTIST_WEIGHT,
   score: (target, candidate) =>
-    containmentScore(tokenize(target.artist), tokenize(candidateText(candidate))),
+    clampUnit(containmentScore(tokenize(target.artist), tokenize(candidateText(candidate)))),
 };
 
 export const yearSignal: MatchSignal = {
@@ -112,7 +117,7 @@ export const yearSignal: MatchSignal = {
   weight: YEAR_WEIGHT,
   score: (target, candidate) => {
     if (target.year === undefined) return null;
-    return candidateText(candidate).includes(String(target.year)) ? 1 : 0;
+    return clampUnit(candidateText(candidate).includes(String(target.year)) ? 1 : 0);
   },
 };
 
@@ -129,7 +134,7 @@ export function scoreMatch(
   target: Target,
   candidate: Candidate,
   signals: readonly MatchSignal[] = DEFAULT_MATCH_SIGNALS,
-): number {
+): Unit {
   let weighted = 0;
   let totalWeight = 0;
   for (const signal of signals) {
@@ -138,5 +143,5 @@ export function scoreMatch(
     weighted += score * signal.weight;
     totalWeight += signal.weight;
   }
-  return totalWeight === 0 ? 0 : weighted / totalWeight;
+  return clampUnit(totalWeight === 0 ? 0 : weighted / totalWeight);
 }

--- a/packages/downloader/src/domain/policy/policies.ts
+++ b/packages/downloader/src/domain/policy/policies.ts
@@ -2,6 +2,8 @@ import { err, ok } from 'neverthrow';
 import type { Result } from 'neverthrow';
 import { branded } from '../shared/brand.js';
 import type { Brand } from '../shared/brand.js';
+import { parseUnit } from '../shared/unit.js';
+import type { Unit } from '../shared/unit.js';
 import type { QualityPolicy } from './quality-policy.js';
 
 /**
@@ -17,13 +19,14 @@ import type { QualityPolicy } from './quality-policy.js';
  * to obtain a `MatchPolicy` is through {@link createMatchPolicy}, which proves the invariant. The
  * brand is compile-time only and erases at runtime, so the value still round-trips as plain JSON.
  */
-export type MatchPolicy = Brand<{ readonly threshold: number }, 'MatchPolicy'>; // confidence in [0, 1]
+export type MatchPolicy = Brand<{ readonly threshold: Unit }, 'MatchPolicy'>; // confidence in [0, 1]
 
 export type MatchPolicyError = { readonly kind: 'ThresholdOutOfRange' };
 
 export function createMatchPolicy(threshold: number): Result<MatchPolicy, MatchPolicyError> {
-  if (!(threshold >= 0 && threshold <= 1)) return err({ kind: 'ThresholdOutOfRange' });
-  return ok(branded<MatchPolicy>({ threshold }));
+  return parseUnit(threshold)
+    .map((bounded) => branded<MatchPolicy>({ threshold: bounded }))
+    .mapErr(() => ({ kind: 'ThresholdOutOfRange' as const }));
 }
 
 export const DEFAULT_MATCH_POLICY: MatchPolicy = createMatchPolicy(0.7)._unsafeUnwrap();

--- a/packages/downloader/src/domain/ranking/ranking.ts
+++ b/packages/downloader/src/domain/ranking/ranking.ts
@@ -9,6 +9,7 @@ import {
   resolveQualityBucket,
 } from '../policy/quality-policy.js';
 import type { QualityAttributes, QualityBucket, QualityPolicy } from '../policy/quality-policy.js';
+import type { Unit } from '../shared/unit.js';
 import type { Target } from '../target/target.js';
 
 /**
@@ -17,7 +18,7 @@ import type { Target } from '../target/target.js';
  */
 export interface RankedCandidate {
   readonly candidate: Candidate;
-  readonly matchConfidence: number;
+  readonly matchConfidence: Unit;
   readonly qualityBucket: QualityBucket;
 }
 

--- a/packages/downloader/src/domain/shared/__fixtures__/unit.ts
+++ b/packages/downloader/src/domain/shared/__fixtures__/unit.ts
@@ -1,0 +1,12 @@
+import { branded } from '../brand.js';
+import type { Unit } from '../unit.js';
+
+/**
+ * Brand an arbitrary number as a {@link Unit} for tests. Range validity is an edge/construction
+ * concern (production mints via `parseUnit`/`clampUnit`); tests that exercise the domain just need
+ * *some* unit-scalar stimulus, so they mint one directly — including deliberately out-of-range
+ * values the domain type otherwise forbids.
+ */
+export function asUnit(value: number): Unit {
+  return branded<Unit>(value);
+}

--- a/packages/downloader/src/domain/shared/unit.test.ts
+++ b/packages/downloader/src/domain/shared/unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { clampUnit, parseUnit } from './unit.js';
+
+describe('parseUnit', () => {
+  it('accepts the closed unit interval, preserving the value', () => {
+    expect(parseUnit(0)._unsafeUnwrap()).toBe(0);
+    expect(parseUnit(0.42)._unsafeUnwrap()).toBe(0.42);
+    expect(parseUnit(1)._unsafeUnwrap()).toBe(1);
+  });
+
+  it('rejects a value below 0 or above 1', () => {
+    expect(parseUnit(-0.01)._unsafeUnwrapErr()).toEqual({ kind: 'OutOfUnitRange', value: -0.01 });
+    expect(parseUnit(1.5)._unsafeUnwrapErr()).toEqual({ kind: 'OutOfUnitRange', value: 1.5 });
+  });
+
+  it('rejects a non-finite value so a range can never be forged from NaN', () => {
+    expect(parseUnit(Number.NaN)._unsafeUnwrapErr()).toEqual({
+      kind: 'OutOfUnitRange',
+      value: Number.NaN,
+    });
+    expect(parseUnit(Number.POSITIVE_INFINITY)._unsafeUnwrapErr()).toEqual({
+      kind: 'OutOfUnitRange',
+      value: Number.POSITIVE_INFINITY,
+    });
+  });
+});
+
+describe('clampUnit', () => {
+  it('passes an in-range value through unchanged', () => {
+    expect(clampUnit(0)).toBe(0);
+    expect(clampUnit(0.42)).toBe(0.42);
+    expect(clampUnit(1)).toBe(1);
+  });
+
+  it('clamps an out-of-range computed value to the nearest bound', () => {
+    expect(clampUnit(-0.3)).toBe(0);
+    expect(clampUnit(1.2)).toBe(1);
+  });
+});

--- a/packages/downloader/src/domain/shared/unit.ts
+++ b/packages/downloader/src/domain/shared/unit.ts
@@ -1,0 +1,37 @@
+import { err, ok } from 'neverthrow';
+import type { Result } from 'neverthrow';
+import { branded } from './brand.js';
+import type { Brand } from './brand.js';
+
+/**
+ * A scalar in the closed unit interval [0, 1] — a confidence, a match score, or a signal weight.
+ * Branded (compile-time only, runtime-erased) so a bare `number` cannot stand in for a value the
+ * matching/validation/ranking code trusts to be in range: an out-of-range or `NaN` confidence would
+ * silently misorder the walk or misroute the auto-apply gate. The value serializes on events as a
+ * plain number, unchanged.
+ *
+ * Two sanctioned mints, mirroring how {@link Distance} is minted: {@link parseUnit} at an untrusted
+ * edge (config/authored input — reject out of range) and {@link clampUnit} for a value the domain
+ * computes and bounds by construction (a weighted mean, a `Math.min`).
+ */
+export type Unit = Brand<number, 'Unit'>;
+
+export type OutOfUnitRange = { readonly kind: 'OutOfUnitRange'; readonly value: number };
+
+/** Parse-don't-validate: a finite in-range number becomes a {@link Unit}, anything else an error. */
+export function parseUnit(value: number): Result<Unit, OutOfUnitRange> {
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    return err({ kind: 'OutOfUnitRange', value });
+  }
+  return ok(branded<Unit>(value));
+}
+
+/**
+ * Mint a {@link Unit} from a value the domain computed and already bounds to [0, 1] by construction
+ * (a weighted mean of Units, a `Math.min` of Units), pinning any floating-point overshoot to the
+ * nearest bound. Use this — not {@link parseUnit} — where a range violation would be a domain bug,
+ * not authored input to reject.
+ */
+export function clampUnit(value: number): Unit {
+  return branded<Unit>(Math.min(1, Math.max(0, value)));
+}

--- a/packages/downloader/src/domain/validation/validation.test.ts
+++ b/packages/downloader/src/domain/validation/validation.test.ts
@@ -6,6 +6,7 @@ import type { ProbedAudio } from './validators.js';
 import { createMatchPolicy } from '../policy/policies.js';
 import { createTarget } from '../target/target.js';
 import type { Target } from '../target/target.js';
+import { asUnit } from '../shared/__fixtures__/unit.js';
 
 const target: Target = createTarget({
   type: 'album',
@@ -61,8 +62,8 @@ describe('structuralIdentityValidator', () => {
 describe('combineVerdict', () => {
   it('takes the weakest link and unions the reasons', () => {
     const outcomes: ValidatorOutcome[] = [
-      { name: 'playability', score: 1 },
-      { name: 'structuralIdentity', score: 0.5, reason: 'DurationMismatch' },
+      { name: 'playability', score: asUnit(1) },
+      { name: 'structuralIdentity', score: asUnit(0.5), reason: 'DurationMismatch' },
     ];
     expect(combineVerdict(outcomes)).toEqual({ confidence: 0.5, reasons: ['DurationMismatch'] });
   });

--- a/packages/downloader/src/domain/validation/validators.ts
+++ b/packages/downloader/src/domain/validation/validators.ts
@@ -1,4 +1,5 @@
 import { alignmentScore } from '../shared/duration.js';
+import { clampUnit } from '../shared/unit.js';
 import type { Target } from '../target/target.js';
 import type { ValidatorOutcome } from './verdict.js';
 
@@ -22,8 +23,8 @@ export interface ProbedAudio {
 export function playabilityValidator(probes: readonly ProbedAudio[]): ValidatorOutcome {
   const allPlayable = probes.length > 0 && probes.every((probe) => probe.decodedCleanly);
   return allPlayable
-    ? { name: 'playability', score: 1 }
-    : { name: 'playability', score: 0, reason: 'Unplayable' };
+    ? { name: 'playability', score: clampUnit(1) }
+    : { name: 'playability', score: clampUnit(0), reason: 'Unplayable' };
 }
 
 /** MVP validator 2 — structural identity: track count + decoded durations vs the target (D5 axis 2a). */
@@ -32,13 +33,15 @@ export function structuralIdentityValidator(
   target: Target,
 ): ValidatorOutcome {
   if (probes.length !== target.tracks.length) {
-    return { name: 'structuralIdentity', score: 0, reason: 'WrongTrackCount' };
+    return { name: 'structuralIdentity', score: clampUnit(0), reason: 'WrongTrackCount' };
   }
-  const score = alignmentScore(
-    target.tracks.map((track) => track.durationMs),
-    probes.map((probe) => probe.durationMs),
+  const score = clampUnit(
+    alignmentScore(
+      target.tracks.map((track) => track.durationMs),
+      probes.map((probe) => probe.durationMs),
+    ),
   );
   return score >= 1
-    ? { name: 'structuralIdentity', score: 1 }
+    ? { name: 'structuralIdentity', score: clampUnit(1) }
     : { name: 'structuralIdentity', score, reason: 'DurationMismatch' };
 }

--- a/packages/downloader/src/domain/validation/verdict.ts
+++ b/packages/downloader/src/domain/validation/verdict.ts
@@ -1,4 +1,6 @@
 import type { MatchPolicy } from '../policy/policies.js';
+import { clampUnit } from '../shared/unit.js';
+import type { Unit } from '../shared/unit.js';
 
 /**
  * The composable validation verdict (D5). Validators each produce an outcome; the pipeline
@@ -13,13 +15,13 @@ export type ValidationReason =
   | 'QualityNotAuthentic'; // transcode tier — seam only
 
 export interface ValidationVerdict {
-  readonly confidence: number;
+  readonly confidence: Unit;
   readonly reasons: readonly ValidationReason[];
 }
 
 export interface ValidatorOutcome {
   readonly name: string;
-  readonly score: number; // this validator's confidence in [0, 1]
+  readonly score: Unit; // this validator's confidence in [0, 1]
   readonly reason?: ValidationReason; // present when the validator objects
 }
 
@@ -30,8 +32,8 @@ export interface ValidatorOutcome {
  * vouch for anything, so it yields zero confidence.
  */
 export function combineVerdict(outcomes: readonly ValidatorOutcome[]): ValidationVerdict {
-  if (outcomes.length === 0) return { confidence: 0, reasons: [] };
-  const confidence = Math.min(...outcomes.map((outcome) => outcome.score));
+  if (outcomes.length === 0) return { confidence: clampUnit(0), reasons: [] };
+  const confidence = clampUnit(Math.min(...outcomes.map((outcome) => outcome.score)));
   const reasons = outcomes.flatMap((outcome) =>
     outcome.reason !== undefined ? [outcome.reason] : [],
   );

--- a/packages/importer/src/adapters/beets/bridge-adapter.test.ts
+++ b/packages/importer/src/adapters/beets/bridge-adapter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { silentLogger } from '../../application/__fixtures__/fakes.js';
-import type { ApplyMode } from '../../domain/import/events.js';
+import type { ApplyMode, ManualTags } from '../../domain/import/events.js';
+import { toPositiveInt } from '../../domain/shared/positive-int.js';
 import { BeetsBridge, defaultBridgeScript } from './bridge-adapter.js';
 import type { BeetsBridgeConfig } from './bridge-adapter.js';
 import type { CommandResult, CommandRunner } from './runner.js';
@@ -221,10 +222,10 @@ describe('apply', () => {
 
   it('serializes a manual tag payload onto the command line', async () => {
     const runner = runnerReturning(APPLIED);
-    const tags = {
+    const tags: ManualTags = {
       albumArtist: 'Jake Tape',
       album: 'Handmade',
-      tracks: [{ path: 'a.mp3', title: 'First', trackNumber: 1 }],
+      tracks: [{ path: 'a.mp3', title: 'First', trackNumber: toPositiveInt(1) }],
     };
     await bridge(runner).apply('/intake/a', { kind: 'manual-tags', tags });
     expect(runner.calls[0]!.slice(-2)).toEqual(['--tags', JSON.stringify(tags)]);

--- a/packages/importer/src/application/import/use-cases.test.ts
+++ b/packages/importer/src/application/import/use-cases.test.ts
@@ -8,6 +8,9 @@ import {
   remediationHistory,
 } from '../../domain/import/__fixtures__/import-fixtures.js';
 import type { ImportEvent } from '../../domain/import/events.js';
+import { toAcquisitionId } from '../../domain/shared/acquisition-id.js';
+import { toImportId } from '../../domain/shared/import-id.js';
+import type { ImportId } from '../../domain/shared/import-id.js';
 import { ImportStatusProjection } from '../projections/read-models.js';
 import { FakeEventStore, fixedClock } from '../__fixtures__/fakes.js';
 import type { UseCaseDeps } from './use-cases.js';
@@ -31,7 +34,10 @@ function deps(): UseCaseDeps & { store: FakeEventStore; status: ImportStatusProj
   };
 }
 
-async function seed(d: ReturnType<typeof deps>, history: readonly ImportEvent[]): Promise<string> {
+async function seed(
+  d: ReturnType<typeof deps>,
+  history: readonly ImportEvent[],
+): Promise<ImportId> {
   const importId = importIdFor(DIRECTORY);
   await d.store.append(importId, 0, history, { importId, occurredAt: 't' });
   d.status.rebuild(d.store.all());
@@ -75,14 +81,17 @@ describe('submitImport', () => {
 
   it('records the acquisition source so the linkage is queryable from the log', async () => {
     const d = deps();
-    await submitImport(d, { directory: DIRECTORY, source: { acquisitionId: 'acq-1' } });
+    await submitImport(d, {
+      directory: DIRECTORY,
+      source: { acquisitionId: toAcquisitionId('acq-1') },
+    });
     expect(d.store.all()[0]!.event).toMatchObject({
       type: 'ImportRequested',
       source: { acquisitionId: 'acq-1' },
     });
     d.status.rebuild(d.store.all());
-    expect(findAcquisitionImport(d, 'acq-1')).toBe(importIdFor(DIRECTORY));
-    expect(findAcquisitionImport(d, 'acq-2')).toBeUndefined();
+    expect(findAcquisitionImport(d, toAcquisitionId('acq-1'))).toBe(importIdFor(DIRECTORY));
+    expect(findAcquisitionImport(d, toAcquisitionId('acq-2'))).toBeUndefined();
   });
 });
 
@@ -97,7 +106,7 @@ describe('resolveReview', () => {
 
   it('surfaces the domain refusal for an unknown import', async () => {
     const d = deps();
-    const result = await resolveReview(d, 'imp-missing', { kind: 'import-as-is' });
+    const result = await resolveReview(d, toImportId('imp-missing'), { kind: 'import-as-is' });
     expect(result._unsafeUnwrapErr()).toEqual({ kind: 'UnknownImport' });
   });
 });
@@ -107,7 +116,7 @@ describe('queries', () => {
     const d = deps();
     const importId = await seed(d, awaitingMatchReview());
     expect(getImport(d, importId)?.phase).toBe('awaiting-review');
-    expect(getImport(d, 'imp-unknown')).toBeUndefined();
+    expect(getImport(d, toImportId('imp-unknown'))).toBeUndefined();
     expect(listImports(d).map((view) => view.importId)).toEqual([importId]);
   });
 

--- a/packages/importer/src/application/import/use-cases.ts
+++ b/packages/importer/src/application/import/use-cases.ts
@@ -6,6 +6,10 @@ import type {
   ImportSource,
   Resolution,
 } from '../../domain/import/events.js';
+import { toImportId } from '../../domain/shared/import-id.js';
+import type { ImportId } from '../../domain/shared/import-id.js';
+import { toAcquisitionId } from '../../domain/shared/acquisition-id.js';
+import type { AcquisitionId } from '../../domain/shared/acquisition-id.js';
 import type {
   ImportStatusProjection,
   ImportStatusView,
@@ -32,9 +36,9 @@ function normalizeDirectory(directory: string): string {
 }
 
 /** The deterministic stream id for a directory: stable, URL-safe, collision-resistant. */
-export function importIdFor(directory: string): string {
+export function importIdFor(directory: string): ImportId {
   const digest = createHash('sha256').update(normalizeDirectory(directory)).digest('hex');
-  return `imp-${digest.slice(0, 24)}`;
+  return toImportId(`imp-${digest.slice(0, 24)}`);
 }
 
 export interface SubmitImportInput {
@@ -47,7 +51,7 @@ export interface SubmitImportInput {
 export function submitImport(
   deps: UseCaseDeps,
   input: SubmitImportInput,
-): ResultAsync<{ readonly importId: string }, CommandError> {
+): ResultAsync<{ readonly importId: ImportId }, CommandError> {
   const directory = normalizeDirectory(input.directory);
   const importId = importIdFor(directory);
   return applyCommand(deps, importId, {
@@ -62,20 +66,20 @@ export function submitImport(
 /** The import an acquisition already submitted, if any — the intake consumer's convergence check. */
 export function findAcquisitionImport(
   deps: UseCaseDeps,
-  acquisitionId: string,
-): string | undefined {
+  acquisitionId: AcquisitionId,
+): ImportId | undefined {
   return deps.status.importIdForAcquisition(acquisitionId);
 }
 
 export function resolveReview(
   deps: UseCaseDeps,
-  importId: string,
+  importId: ImportId,
   resolution: Resolution,
 ): ResultAsync<void, CommandError> {
   return applyCommand(deps, importId, { type: 'ResolveReview', resolution }).map(() => undefined);
 }
 
-export function getImport(deps: UseCaseDeps, importId: string): ImportStatusView | undefined {
+export function getImport(deps: UseCaseDeps, importId: ImportId): ImportStatusView | undefined {
   return deps.status.get(importId);
 }
 
@@ -88,7 +92,7 @@ export function getImportForAcquisition(
   deps: UseCaseDeps,
   acquisitionId: string,
 ): ImportStatusView | undefined {
-  const importId = deps.status.importIdForAcquisition(acquisitionId);
+  const importId = deps.status.importIdForAcquisition(toAcquisitionId(acquisitionId));
   return importId === undefined ? undefined : deps.status.get(importId);
 }
 

--- a/packages/importer/src/application/projections/read-models.test.ts
+++ b/packages/importer/src/application/projections/read-models.test.ts
@@ -18,6 +18,8 @@ import {
   resolved,
 } from '../../domain/import/__fixtures__/import-fixtures.js';
 import { asDistance } from '../../domain/shared/__fixtures__/distance.js';
+import { toAcquisitionId } from '../../domain/shared/acquisition-id.js';
+import { toImportId } from '../../domain/shared/import-id.js';
 import type { ImportEvent } from '../../domain/import/events.js';
 import type { StoredEvent } from '../ports/event-store-port.js';
 import { ImportStatusProjection, projectStatus } from './read-models.js';
@@ -46,7 +48,7 @@ describe('projectStatus', () => {
       AUTO_APPLIED,
       APPLIED,
     ];
-    const view = projectStatus('imp-1', storedAll('imp-1', history));
+    const view = projectStatus(toImportId('imp-1'), storedAll('imp-1', history));
     expect(view).toMatchObject({
       importId: 'imp-1',
       directory: DIRECTORY,
@@ -68,7 +70,7 @@ describe('projectStatus', () => {
 
   it('stamps each history entry with its event occurrence time', () => {
     const view = projectStatus(
-      'imp-1',
+      toImportId('imp-1'),
       storedAll('imp-1', appliedHistory(), 0, (index) => `2026-01-01T00:00:0${index}Z`),
     );
     expect(view.history.map((entry) => entry.at)).toEqual([
@@ -81,12 +83,12 @@ describe('projectStatus', () => {
 
   it('carries the originating acquisition id when the import came from one', () => {
     const withSource = projectStatus(
-      'imp-1',
+      toImportId('imp-1'),
       storedAll('imp-1', [requested({ source: SOURCE }), proposed([candidate()])]),
     );
     expect(withSource.acquisitionId).toBe('acq-1');
 
-    const manual = projectStatus('imp-2', storedAll('imp-2', appliedHistory()));
+    const manual = projectStatus(toImportId('imp-2'), storedAll('imp-2', appliedHistory()));
     expect(manual.acquisitionId).toBeUndefined();
   });
 
@@ -96,7 +98,7 @@ describe('projectStatus', () => {
       resolved({ kind: 'reject', reason: 'wrong rip' }),
       { type: 'ImportRejected', reason: 'wrong rip', filesDeleted: true } as const,
     ];
-    const view = projectStatus('imp-1', storedAll('imp-1', history));
+    const view = projectStatus(toImportId('imp-1'), storedAll('imp-1', history));
     expect(view.history).toContainEqual({
       kind: 'review-required',
       at: 't',
@@ -113,7 +115,7 @@ describe('projectStatus', () => {
   });
 
   it('records remediation entries', () => {
-    const view = projectStatus('imp-1', storedAll('imp-1', remediationHistory()));
+    const view = projectStatus(toImportId('imp-1'), storedAll('imp-1', remediationHistory()));
     expect(view.history).toContainEqual({
       kind: 'remediation-required',
       at: 't',
@@ -132,7 +134,7 @@ describe('projectStatus', () => {
         reasons: ['corrupt rip'],
       } as const,
     ];
-    const view = projectStatus('imp-1', storedAll('imp-1', history));
+    const view = projectStatus(toImportId('imp-1'), storedAll('imp-1', history));
     expect(view.history).toContainEqual({
       kind: 'review-resolved',
       at: 't',
@@ -150,22 +152,24 @@ describe('projectStatus', () => {
 describe('ImportStatusProjection', () => {
   it('indexes acquisition-sourced requests and forgets them on rebuild', () => {
     const projection = new ImportStatusProjection();
-    projection.apply(storedAll('imp-a', [requested({ source: { acquisitionId: 'acq-1' } })])[0]!);
+    projection.apply(
+      storedAll('imp-a', [requested({ source: { acquisitionId: toAcquisitionId('acq-1') } })])[0]!,
+    );
     projection.apply(storedAll('imp-b', [requested()], 10)[0]!);
 
-    expect(projection.importIdForAcquisition('acq-1')).toBe('imp-a');
-    expect(projection.importIdForAcquisition('acq-unknown')).toBeUndefined();
+    expect(projection.importIdForAcquisition(toAcquisitionId('acq-1'))).toBe('imp-a');
+    expect(projection.importIdForAcquisition(toAcquisitionId('acq-unknown'))).toBeUndefined();
 
     projection.rebuild(storedAll('imp-b', [requested()]));
-    expect(projection.importIdForAcquisition('acq-1')).toBeUndefined();
+    expect(projection.importIdForAcquisition(toAcquisitionId('acq-1'))).toBeUndefined();
   });
 
   it('follows applied events and serves get/list', () => {
     const projection = new ImportStatusProjection();
     for (const stored of storedAll('imp-1', awaitingMatchReview())) projection.apply(stored);
 
-    expect(projection.get('imp-1')?.phase).toBe('awaiting-review');
-    expect(projection.get('imp-2')).toBeUndefined();
+    expect(projection.get(toImportId('imp-1'))?.phase).toBe('awaiting-review');
+    expect(projection.get(toImportId('imp-2'))).toBeUndefined();
     expect(projection.list().map((view) => view.importId)).toEqual(['imp-1']);
   });
 
@@ -192,8 +196,8 @@ describe('ImportStatusProjection', () => {
 
     projection.rebuild(storedAll('imp-1', appliedHistory()));
 
-    expect(projection.get('imp-old')).toBeUndefined();
-    expect(projection.get('imp-1')?.phase).toBe('applied');
+    expect(projection.get(toImportId('imp-old'))).toBeUndefined();
+    expect(projection.get(toImportId('imp-1'))?.phase).toBe('applied');
   });
 
   it('never lists a review for a stream that only holds an unfitting event', () => {

--- a/packages/importer/src/application/projections/read-models.ts
+++ b/packages/importer/src/application/projections/read-models.ts
@@ -9,6 +9,9 @@ import type {
   ResolutionKind,
   ReviewKind,
 } from '../../domain/import/events.js';
+import { toImportId } from '../../domain/shared/import-id.js';
+import type { ImportId } from '../../domain/shared/import-id.js';
+import type { AcquisitionId } from '../../domain/shared/acquisition-id.js';
 import type { StoredEvent } from '../ports/event-store-port.js';
 
 /**
@@ -36,7 +39,7 @@ type HistoryPayload =
   | { readonly kind: 'rejected'; readonly reason: string; readonly filesDeleted: boolean }
   | {
       readonly kind: 'release-verdict-recorded';
-      readonly acquisitionId: string;
+      readonly acquisitionId: AcquisitionId;
       readonly reasons: readonly string[];
     };
 
@@ -48,7 +51,7 @@ type HistoryPayload =
 export type StatusHistoryEntry = HistoryPayload & { readonly at: string };
 
 export interface ImportStatusView {
-  readonly importId: string;
+  readonly importId: ImportId;
   /** The originating acquisition, when this import arrived from one — the web-side correlation key. */
   readonly acquisitionId?: string;
   readonly directory?: string;
@@ -61,7 +64,7 @@ export interface ImportStatusView {
 
 /** One resolvable item of the pending-review queue, with its kind-specific carried context. */
 export interface PendingReviewView {
-  readonly importId: string;
+  readonly importId: ImportId;
   readonly directory: string;
   readonly review: OpenReview;
 }
@@ -103,7 +106,10 @@ function acquisitionIdOf(events: readonly ImportEvent[]): string | undefined {
   return requested?.type === 'ImportRequested' ? requested.source?.acquisitionId : undefined;
 }
 
-export function projectStatus(importId: string, stored: readonly StoredEvent[]): ImportStatusView {
+export function projectStatus(
+  importId: ImportId,
+  stored: readonly StoredEvent[],
+): ImportStatusView {
   const events = stored.map((entry) => entry.event);
   const snapshot = Import.fromHistory(events).snapshot;
   return {
@@ -122,15 +128,18 @@ export function projectStatus(importId: string, stored: readonly StoredEvent[]):
 }
 
 export class ImportStatusProjection {
-  private readonly streams = new Map<string, StoredEvent[]>();
-  private readonly acquisitions = new Map<string, string>();
+  private readonly streams = new Map<ImportId, StoredEvent[]>();
+  private readonly acquisitions = new Map<AcquisitionId, ImportId>();
 
   apply(stored: StoredEvent): void {
-    const list = this.streams.get(stored.streamId) ?? [];
+    // The event store speaks a generic streamId; the import read model reads it as the ImportId that
+    // wrote the stream — the single ACL between the two, lifted once here.
+    const importId = toImportId(stored.streamId);
+    const list = this.streams.get(importId) ?? [];
     list.push(stored);
-    this.streams.set(stored.streamId, list);
+    this.streams.set(importId, list);
     if (stored.event.type === 'ImportRequested' && stored.event.source !== undefined) {
-      this.acquisitions.set(stored.event.source.acquisitionId, stored.streamId);
+      this.acquisitions.set(stored.event.source.acquisitionId, importId);
     }
   }
 
@@ -138,11 +147,11 @@ export class ImportStatusProjection {
    * The import an acquisition already submitted, if any — the durable idempotency check for the
    * intake seam consumer. Rebuilt from the log, so redelivery converges across restarts.
    */
-  importIdForAcquisition(acquisitionId: string): string | undefined {
+  importIdForAcquisition(acquisitionId: AcquisitionId): ImportId | undefined {
     return this.acquisitions.get(acquisitionId);
   }
 
-  get(importId: string): ImportStatusView | undefined {
+  get(importId: ImportId): ImportStatusView | undefined {
     const stored = this.streams.get(importId);
     return stored === undefined ? undefined : projectStatus(importId, stored);
   }

--- a/packages/importer/src/domain/import/__fixtures__/import-fixtures.ts
+++ b/packages/importer/src/domain/import/__fixtures__/import-fixtures.ts
@@ -11,6 +11,8 @@ import type {
   Resolution,
 } from '../events.js';
 import { asDistance } from '../../shared/__fixtures__/distance.js';
+import { toAcquisitionId } from '../../shared/acquisition-id.js';
+import { toPositiveInt } from '../../shared/positive-int.js';
 
 /** Deterministic builders for domain tests. */
 
@@ -25,7 +27,10 @@ export const DELIVERED_CANDIDATE: DeliveredCandidate = {
 };
 
 /** Provenance of a downloader-delivered import, retained candidate included. */
-export const SOURCE: ImportSource = { acquisitionId: 'acq-1', candidate: DELIVERED_CANDIDATE };
+export const SOURCE: ImportSource = {
+  acquisitionId: toAcquisitionId('acq-1'),
+  candidate: DELIVERED_CANDIDATE,
+};
 
 export function candidate(overrides: Partial<ProposedCandidate> = {}): ProposedCandidate {
   return {
@@ -51,7 +56,7 @@ export const MANUAL_TAGS: ManualTags = {
   albumArtist: 'Artist',
   album: 'Album',
   year: 2020,
-  tracks: [{ path: `${DIRECTORY}/01 Track.flac`, title: 'Track', trackNumber: 1 }],
+  tracks: [{ path: `${DIRECTORY}/01 Track.flac`, title: 'Track', trackNumber: toPositiveInt(1) }],
 };
 
 export function requested(

--- a/packages/importer/src/domain/import/decide.ts
+++ b/packages/importer/src/domain/import/decide.ts
@@ -3,6 +3,8 @@ import { err, ok } from 'neverthrow';
 import type { ImportCommand } from './commands.js';
 import { candidateRefKey } from './events.js';
 import type { DuplicateIncumbent, ImportEvent, ProposedCandidate, Resolution } from './events.js';
+import { isNonEmpty } from '../shared/non-empty-array.js';
+import type { NonEmptyReadonlyArray } from '../shared/non-empty-array.js';
 import { isTerminal } from './state.js';
 import type { AppliedState, AwaitingReviewState, ImportState } from './state.js';
 
@@ -24,7 +26,7 @@ type Decision = Result<readonly ImportEvent[], DomainError>;
 const NOTHING: Decision = ok([]);
 
 /** The lowest-distance candidate — beets' ordering, re-derived so `decide` never trusts input order. */
-function bestOf(candidates: readonly ProposedCandidate[]): ProposedCandidate {
+function bestOf(candidates: NonEmptyReadonlyArray<ProposedCandidate>): ProposedCandidate {
   return candidates.reduce((best, next) => (next.distance < best.distance ? next : best));
 }
 
@@ -36,7 +38,7 @@ function decideProposal(
 ): Decision {
   if (state.phase !== 'requested' && state.phase !== 'proposing') return NOTHING; // stale outcome
   const proposed: ImportEvent = { type: 'CandidatesProposed', candidates, duplicates, pinnedId };
-  if (candidates.length === 0) {
+  if (!isNonEmpty(candidates)) {
     return ok([proposed, { type: 'ReviewRequired', cause: { kind: 'no-match' } }]);
   }
   const best = bestOf(candidates);
@@ -61,7 +63,7 @@ function decideProposal(
       },
     ]);
   }
-  if (duplicates.length > 0) {
+  if (isNonEmpty(duplicates)) {
     // Strong match, but the library already has it: never auto-replace in this change (D5).
     return ok([
       proposed,
@@ -158,14 +160,14 @@ export function decide(command: ImportCommand, state: ImportState): Decision {
       const retrying = state.phase === 'applied' && state.remediation?.status === 'retrying';
       if (state.phase !== 'applying' && !retrying) return NOTHING; // stale outcome
       const applied: ImportEvent = { type: 'ImportApplied', location: command.location };
-      return command.failures.length === 0
-        ? ok([applied])
-        : ok([applied, { type: 'RemediationRequired', failures: command.failures }]);
+      return isNonEmpty(command.failures)
+        ? ok([applied, { type: 'RemediationRequired', failures: command.failures }])
+        : ok([applied]);
     }
     case 'RecordApplySkippedDuplicate':
       // Beets refused to import over an incumbent it only saw at apply time: route to review.
       if (state.phase !== 'applying') return NOTHING;
-      if (command.incumbents.length === 0) {
+      if (!isNonEmpty(command.incumbents)) {
         // A skipped-duplicate with no incumbent is contradictory: there is nothing to compare in a
         // duplicate review, and the import must not strand in `applying`. Doom it (terminal, files
         // untouched) so the deposited directory can be investigated and resubmitted.

--- a/packages/importer/src/domain/import/events.ts
+++ b/packages/importer/src/domain/import/events.ts
@@ -1,4 +1,7 @@
+import type { AcquisitionId } from '../shared/acquisition-id.js';
 import type { Distance } from '../shared/distance.js';
+import type { NonEmptyReadonlyArray } from '../shared/non-empty-array.js';
+import type { PositiveInt } from '../shared/positive-int.js';
 
 /**
  * Domain events — the facts that make up an import's history (event-sourcing). They narrate the
@@ -37,7 +40,7 @@ export interface DeliveredCandidate {
  * cannot emit a release verdict.
  */
 export interface ImportSource {
-  readonly acquisitionId: string;
+  readonly acquisitionId: AcquisitionId;
   readonly candidate?: DeliveredCandidate;
 }
 
@@ -159,9 +162,9 @@ export type ReviewCause =
   | { readonly kind: 'no-match' }
   | {
       readonly kind: 'duplicate-review';
-      readonly incumbents: readonly DuplicateIncumbent[];
+      readonly incumbents: NonEmptyReadonlyArray<DuplicateIncumbent>;
     }
-  | { readonly kind: 'remediation-review'; readonly failures: readonly ApplyFailure[] };
+  | { readonly kind: 'remediation-review'; readonly failures: NonEmptyReadonlyArray<ApplyFailure> };
 
 export type ReviewKind = ReviewCause['kind'];
 
@@ -170,8 +173,8 @@ export interface ManualTrackTags {
   readonly path: string;
   readonly title: string;
   readonly artist?: string;
-  readonly trackNumber: number;
-  readonly discNumber?: number;
+  readonly trackNumber: PositiveInt;
+  readonly discNumber?: PositiveInt;
 }
 
 /** A full manual tag payload with an explicit track mapping. */
@@ -179,7 +182,7 @@ export interface ManualTags {
   readonly albumArtist: string;
   readonly album: string;
   readonly year?: number;
-  readonly tracks: readonly ManualTrackTags[];
+  readonly tracks: NonEmptyReadonlyArray<ManualTrackTags>;
 }
 
 /** How to settle a duplicate: replace the incumbent, or keep both. */
@@ -231,7 +234,7 @@ export type ImportEvent =
   | { readonly type: 'ReviewRequired'; readonly cause: ReviewCause }
   | { readonly type: 'ReviewResolved'; readonly resolution: Resolution }
   | { readonly type: 'ImportApplied'; readonly location: string }
-  | { readonly type: 'RemediationRequired'; readonly failures: readonly ApplyFailure[] }
+  | { readonly type: 'RemediationRequired'; readonly failures: NonEmptyReadonlyArray<ApplyFailure> }
   | { readonly type: 'ImportRejected'; readonly reason: string; readonly filesDeleted: boolean }
   | {
       /**
@@ -240,7 +243,7 @@ export type ImportEvent =
        * decision as the rejection's `ReviewResolved`; drives no effect and no state change.
        */
       readonly type: 'ReleaseVerdictRecorded';
-      readonly acquisitionId: string;
+      readonly acquisitionId: AcquisitionId;
       readonly candidate: DeliveredCandidate;
       readonly reasons: readonly string[];
     };

--- a/packages/importer/src/domain/import/import.test.ts
+++ b/packages/importer/src/domain/import/import.test.ts
@@ -21,6 +21,7 @@ import {
   resolved,
 } from './__fixtures__/import-fixtures.js';
 import { asDistance } from '../shared/__fixtures__/distance.js';
+import { toAcquisitionId } from '../shared/acquisition-id.js';
 import type { ImportCommand } from './commands.js';
 import type { ImportEvent } from './events.js';
 import { Import } from './import.js';
@@ -49,7 +50,7 @@ describe('submission', () => {
 
   it('stamps the acquisition source onto an event-driven request', () => {
     const events = given([])
-      .execute({ ...SUBMIT, source: { acquisitionId: 'acq-1' } })
+      .execute({ ...SUBMIT, source: { acquisitionId: toAcquisitionId('acq-1') } })
       ._unsafeUnwrap();
     expect(events[0]).toMatchObject({
       type: 'ImportRequested',
@@ -351,7 +352,7 @@ describe('resolving a review', () => {
         ._unsafeUnwrapErr(),
     ).toEqual({ kind: 'NoRetainedCandidate' });
     const legacy = [
-      requested({ source: { acquisitionId: 'acq-legacy' } }),
+      requested({ source: { acquisitionId: toAcquisitionId('acq-legacy') } }),
       proposed([candidate({ distance: asDistance(0.5) })]),
       MATCH_REVIEW,
     ];
@@ -643,7 +644,7 @@ describe('react — the reflex', () => {
     expect(agg.reactTo(proposed([]))).toEqual([]);
     expect(agg.reactTo(MATCH_REVIEW)).toEqual([]);
     expect(agg.reactTo(APPLIED)).toEqual([]);
-    expect(agg.reactTo({ type: 'RemediationRequired', failures: [] })).toEqual([]);
+    expect(agg.reactTo({ type: 'RemediationRequired', failures: [FAILURE] })).toEqual([]);
     expect(agg.reactTo(REJECTED)).toEqual([]);
   });
 });

--- a/packages/importer/src/domain/import/state.test.ts
+++ b/packages/importer/src/domain/import/state.test.ts
@@ -5,6 +5,7 @@ import {
   DELIVERED_CANDIDATE,
   DIRECTORY,
   FAILURE,
+  INCUMBENT,
   MANUAL_TAGS,
   MATCH_REVIEW,
   POLICY,
@@ -20,6 +21,7 @@ import {
   resolved,
 } from './__fixtures__/import-fixtures.js';
 import { asDistance } from '../shared/__fixtures__/distance.js';
+import { toAcquisitionId } from '../shared/acquisition-id.js';
 import type { ImportEvent } from './events.js';
 import { candidateRefKey } from './events.js';
 import { evolve, foldEvents, initialState, isTerminal } from './state.js';
@@ -92,7 +94,7 @@ describe('evolve — the tolerant, total fold', () => {
       requested(),
       proposed([candidate()]),
       AUTO_APPLIED,
-      { type: 'ReviewRequired', cause: { kind: 'duplicate-review', incumbents: [] } },
+      { type: 'ReviewRequired', cause: { kind: 'duplicate-review', incumbents: [INCUMBENT] } },
     ]);
     expect(state).toMatchObject({ phase: 'awaiting-review', cause: { kind: 'duplicate-review' } });
   });
@@ -265,7 +267,7 @@ describe('evolve — the tolerant, total fold', () => {
   it('ignores ReleaseVerdictRecorded — a record-only fact — in any phase', () => {
     const verdict: ImportEvent = {
       type: 'ReleaseVerdictRecorded',
-      acquisitionId: 'acq-1',
+      acquisitionId: toAcquisitionId('acq-1'),
       candidate: DELIVERED_CANDIDATE,
       reasons: ['corrupt rip'],
     };

--- a/packages/importer/src/domain/import/state.ts
+++ b/packages/importer/src/domain/import/state.ts
@@ -9,6 +9,7 @@ import type {
   Resolution,
   ReviewCause,
 } from './events.js';
+import type { NonEmptyReadonlyArray } from '../shared/non-empty-array.js';
 
 /**
  * The folded state of one import (the sole aggregate), modelled as a discriminated union on
@@ -37,7 +38,7 @@ interface Requested {
 
 /** The remediation review riding on an applied import (D7). */
 export interface RemediationState {
-  readonly failures: readonly ApplyFailure[];
+  readonly failures: NonEmptyReadonlyArray<ApplyFailure>;
   readonly status: 'open' | 'retrying';
 }
 

--- a/packages/importer/src/domain/shared/acquisition-id.test.ts
+++ b/packages/importer/src/domain/shared/acquisition-id.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { toAcquisitionId } from './acquisition-id.js';
+
+describe('toAcquisitionId', () => {
+  it('lifts a seam-validated id into the brand, preserving the string', () => {
+    expect(toAcquisitionId('acq-1')).toBe('acq-1');
+  });
+});

--- a/packages/importer/src/domain/shared/acquisition-id.ts
+++ b/packages/importer/src/domain/shared/acquisition-id.ts
@@ -1,0 +1,23 @@
+import { branded } from './brand.js';
+import type { Brand } from './brand.js';
+
+/**
+ * The downloader's acquisition identifier as it crosses the intake anti-corruption boundary — a
+ * foreign id the importer records for durable convergence, never one it mints. Branded (compile-time
+ * only, runtime-erased) so it can never be transposed with the importer's own {@link ImportId} at
+ * their junction (`importIdForAcquisition`): the two are the same shape but not interchangeable.
+ *
+ * Its only invariant is "a non-empty string", which the seam schema (`contracts/intake`) already
+ * proves at the edge — so the value is *lifted* into the brand by a trusted mint, not re-validated
+ * (a redundant `Result` would carry an unreachable failure). The id still serializes as a plain
+ * string on events, unchanged.
+ */
+export type AcquisitionId = Brand<string, 'AcquisitionId'>;
+
+/**
+ * Lift a seam-validated acquisition id into an {@link AcquisitionId}. Trusted: call it only where the
+ * intake schema has already proven the value a non-empty string (the intake ACL mapping).
+ */
+export function toAcquisitionId(value: string): AcquisitionId {
+  return branded<AcquisitionId>(value);
+}

--- a/packages/importer/src/domain/shared/import-id.test.ts
+++ b/packages/importer/src/domain/shared/import-id.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { toImportId } from './import-id.js';
+
+describe('toImportId', () => {
+  it('lifts a known import-stream id into the brand, preserving the string', () => {
+    expect(toImportId('imp-abc')).toBe('imp-abc');
+  });
+});

--- a/packages/importer/src/domain/shared/import-id.ts
+++ b/packages/importer/src/domain/shared/import-id.ts
@@ -1,0 +1,24 @@
+import { branded } from './brand.js';
+import type { Brand } from './brand.js';
+
+/**
+ * The importer's own aggregate/stream identifier: the deterministic id an import directory converges
+ * on (D5). Branded (compile-time only, runtime-erased) so it can never be transposed with a foreign
+ * {@link AcquisitionId} at their junction (`importIdForAcquisition`), and so a bare `string` cannot
+ * be threaded through the facade/use-cases where an import is addressed.
+ *
+ * It carries no invariant richer than the event store's generic `streamId` already guarantees, so it
+ * is *lifted* into the brand by a trusted mint at two proven origins — the digest `importIdFor`
+ * derives, and a `streamId` read back from the importer's own store (the read-model ACL) — rather
+ * than re-validated. The id still serializes as a plain string, unchanged.
+ */
+export type ImportId = Brand<string, 'ImportId'>;
+
+/**
+ * Lift a string already known to name an import stream into an {@link ImportId}. Trusted: call it only
+ * on the derived id `importIdFor` produces, on a `streamId` read from the importer's own event store,
+ * or on a facade id the boundary schema has already proven a non-empty string.
+ */
+export function toImportId(value: string): ImportId {
+  return branded<ImportId>(value);
+}

--- a/packages/importer/src/domain/shared/non-empty-array.test.ts
+++ b/packages/importer/src/domain/shared/non-empty-array.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { assertNonEmpty, isNonEmpty } from './non-empty-array.js';
+
+describe('isNonEmpty', () => {
+  it('narrows a populated array and rejects an empty one', () => {
+    expect(isNonEmpty([1])).toBe(true);
+    expect(isNonEmpty([])).toBe(false);
+  });
+});
+
+describe('assertNonEmpty', () => {
+  it('returns a schema-proven array unchanged as a non-empty tuple', () => {
+    const values = ['a', 'b'];
+    expect(assertNonEmpty(values)).toBe(values);
+  });
+});

--- a/packages/importer/src/domain/shared/non-empty-array.ts
+++ b/packages/importer/src/domain/shared/non-empty-array.ts
@@ -1,0 +1,27 @@
+/**
+ * A readonly array proven to hold at least one element: `readonly [T, ...T[]]`. Several domain
+ * collections are non-empty by construction — a duplicate review always names ≥ 1 incumbent, a
+ * remediation always carries ≥ 1 failure, a manual tag payload always maps ≥ 1 track, a proposal
+ * `bestOf` is only asked for a non-empty field. Lifting those into this type turns a `.length`
+ * invariant scattered across call sites into a fact the compiler carries: `reduce` without a seed is
+ * total, and a consumer never has to handle an impossible empty case. Runtime-identical to a plain
+ * array, so any such collection that rides on an event serializes byte-for-byte unchanged.
+ */
+export type NonEmptyReadonlyArray<T> = readonly [T, ...T[]];
+
+/**
+ * Narrow a readonly array to a {@link NonEmptyReadonlyArray} — the checked construction at a branch
+ * point where the empty case has its own honest handling (a no-match proposal, a doomed duplicate).
+ */
+export function isNonEmpty<T>(arr: readonly T[]): arr is NonEmptyReadonlyArray<T> {
+  return arr.length > 0;
+}
+
+/**
+ * Assert a readonly array is non-empty. Trusted: call it only where a schema or an earlier guard has
+ * already proven `length > 0` (e.g. a wire array validated `.min(1)`) — the structural analogue of a
+ * brand's smart-constructor mint, doing no runtime work so it cannot mask a real empty.
+ */
+export function assertNonEmpty<T>(arr: readonly T[]): NonEmptyReadonlyArray<T> {
+  return arr as NonEmptyReadonlyArray<T>;
+}

--- a/packages/importer/src/domain/shared/positive-int.test.ts
+++ b/packages/importer/src/domain/shared/positive-int.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { toPositiveInt } from './positive-int.js';
+
+describe('toPositiveInt', () => {
+  it('lifts a schema-validated ordinal into the brand, preserving the number', () => {
+    expect(toPositiveInt(1)).toBe(1);
+    expect(toPositiveInt(12)).toBe(12);
+  });
+});

--- a/packages/importer/src/domain/shared/positive-int.ts
+++ b/packages/importer/src/domain/shared/positive-int.ts
@@ -1,0 +1,22 @@
+import { branded } from './brand.js';
+import type { Brand } from './brand.js';
+
+/**
+ * A positive integer (≥ 1) — a track or disc number. Branded (compile-time only, runtime-erased) so
+ * a bare `number` cannot stand in where the domain expects a real 1-based ordinal; the value still
+ * serializes on events as a plain number, unchanged.
+ *
+ * Its invariant (`Number.isInteger && > 0`) is already proven by the boundary schema
+ * (`z.number().int().positive()` on the manual-tags wire shape), so the value is *lifted* into the
+ * brand by a trusted mint at the intake mapping rather than re-validated — a redundant `Result` would
+ * carry a failure branch unreachable behind that schema.
+ */
+export type PositiveInt = Brand<number, 'PositiveInt'>;
+
+/**
+ * Lift a schema-validated ordinal into a {@link PositiveInt}. Trusted: call it only where the wire
+ * schema has already proven the value a positive integer (the manual-tags intake mapping).
+ */
+export function toPositiveInt(value: number): PositiveInt {
+  return branded<PositiveInt>(value);
+}

--- a/packages/importer/src/facade/facade.ts
+++ b/packages/importer/src/facade/facade.ts
@@ -9,6 +9,7 @@ import {
   submitImport as submitImportUseCase,
 } from '../application/import/use-cases.js';
 import type { UseCaseDeps } from '../application/import/use-cases.js';
+import { toImportId } from '../domain/shared/import-id.js';
 import {
   hintsToDomain,
   pendingReviewToDto,
@@ -129,7 +130,8 @@ export function createImporterFacade(deps: UseCaseDeps): ImporterFacade {
       if (!parsed.success) return validationFailed(parsed.error);
       const result = await resolveReviewUseCase(
         deps,
-        parsed.data.id,
+        // Schema-proven non-empty above; lift the addressed id into its brand for the use-case.
+        toImportId(parsed.data.id),
         resolutionToDomain(parsed.data.resolution),
       );
       return result.match(
@@ -141,7 +143,7 @@ export function createImporterFacade(deps: UseCaseDeps): ImporterFacade {
     getImport(input) {
       const parsed = importIdInputSchema.safeParse(input);
       if (!parsed.success) return validationFailed(parsed.error);
-      const view = getImportUseCase(deps, parsed.data.id);
+      const view = getImportUseCase(deps, toImportId(parsed.data.id));
       if (view === undefined) return fail({ kind: 'NotFound' });
       return ok(statusViewToDto(view));
     },

--- a/packages/importer/src/facade/index.test.ts
+++ b/packages/importer/src/facade/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { importIdFor, submitImport } from '../application/import/use-cases.js';
+import { toAcquisitionId } from '../domain/shared/acquisition-id.js';
 import { testWiring } from './__fixtures__/wiring.js';
 import type { TestWiring } from './__fixtures__/wiring.js';
 import {
@@ -165,7 +166,10 @@ describe('createImporterFacade', () => {
   describe('getImportForAcquisition', () => {
     it('returns the view for the acquisition that submitted it, carrying the acquisition id', async () => {
       const wiring = testWiring();
-      await submitImport(wiring.deps, { directory: INTAKE, source: { acquisitionId: 'acq-9' } });
+      await submitImport(wiring.deps, {
+        directory: INTAKE,
+        source: { acquisitionId: toAcquisitionId('acq-9') },
+      });
       wiring.sync();
 
       const result = wiring.facade.getImportForAcquisition({ acquisitionId: 'acq-9' });

--- a/packages/importer/src/facade/mapping.test.ts
+++ b/packages/importer/src/facade/mapping.test.ts
@@ -6,6 +6,7 @@ import {
   candidate,
 } from '../domain/import/__fixtures__/import-fixtures.js';
 import type { ImportStatusView } from '../application/projections/read-models.js';
+import { toImportId } from '../domain/shared/import-id.js';
 import {
   hintsToDomain,
   pendingReviewToDto,
@@ -46,7 +47,10 @@ describe('resolutionToDomain', () => {
     const tags = {
       albumArtist: 'A',
       album: 'B',
-      tracks: [{ path: 'a.mp3', title: 'T', trackNumber: 1 }],
+      tracks: [
+        { path: 'a.mp3', title: 'T', trackNumber: 1, discNumber: 2 },
+        { path: 'b.mp3', title: 'U', trackNumber: 2 },
+      ],
     };
     expect(resolutionToDomain({ verb: 'manual-tags', tags })).toEqual({
       kind: 'manual-tags',
@@ -141,7 +145,7 @@ describe('reviewToDto', () => {
 
 describe('statusViewToDto / pendingReviewToDto', () => {
   const view: ImportStatusView = {
-    importId: 'imp-1',
+    importId: toImportId('imp-1'),
     acquisitionId: 'acq-1',
     directory: DIRECTORY,
     phase: 'rejected',
@@ -168,7 +172,7 @@ describe('statusViewToDto / pendingReviewToDto', () => {
 
   it('maps a status view carrying an open review', () => {
     const withReview: ImportStatusView = {
-      importId: 'imp-2',
+      importId: toImportId('imp-2'),
       directory: DIRECTORY,
       phase: 'awaiting-review',
       openReview: { cause: { kind: 'no-match' }, candidates: [] },
@@ -180,7 +184,7 @@ describe('statusViewToDto / pendingReviewToDto', () => {
   it('maps a pending review item', () => {
     expect(
       pendingReviewToDto({
-        importId: 'imp-1',
+        importId: toImportId('imp-1'),
         directory: DIRECTORY,
         review: { cause: { kind: 'no-match' }, candidates: [] },
       }),

--- a/packages/importer/src/facade/mapping.ts
+++ b/packages/importer/src/facade/mapping.ts
@@ -1,5 +1,12 @@
-import type { ImportHints, ProposedCandidate, Resolution } from '../domain/import/events.js';
+import type {
+  ImportHints,
+  ManualTags,
+  ProposedCandidate,
+  Resolution,
+} from '../domain/import/events.js';
 import type { OpenReview } from '../domain/import/import.js';
+import { assertNonEmpty } from '../domain/shared/non-empty-array.js';
+import { toPositiveInt } from '../domain/shared/positive-int.js';
 import type {
   ImportStatusView,
   PendingReviewView,
@@ -25,6 +32,26 @@ export function hintsToDomain(dto: SubmitImportRequestDto): ImportHints | undefi
   return { mbReleaseId: hints.mbReleaseId, artist: hints.artist, album: hints.album };
 }
 
+/** Lift a wire manual-tags payload into the domain shape: `.min(1)` tracks and `.int().positive()`
+ * ordinals are proven by the schema, so they are branded here rather than re-validated. */
+function manualTagsToDomain(
+  tags: Extract<ResolveReviewRequestDto, { verb: 'manual-tags' }>['tags'],
+): ManualTags {
+  const tracks = tags.tracks.map((track) => ({
+    path: track.path,
+    title: track.title,
+    artist: track.artist,
+    trackNumber: toPositiveInt(track.trackNumber),
+    discNumber: track.discNumber === undefined ? undefined : toPositiveInt(track.discNumber),
+  }));
+  return {
+    albumArtist: tags.albumArtist,
+    album: tags.album,
+    year: tags.year,
+    tracks: assertNonEmpty(tracks),
+  };
+}
+
 export function resolutionToDomain(dto: ResolveReviewRequestDto): Resolution {
   switch (dto.verb) {
     case 'apply-candidate':
@@ -38,7 +65,7 @@ export function resolutionToDomain(dto: ResolveReviewRequestDto): Resolution {
     case 'refresh-candidates':
       return { kind: 'refresh-candidates' };
     case 'manual-tags':
-      return { kind: 'manual-tags', tags: dto.tags };
+      return { kind: 'manual-tags', tags: manualTagsToDomain(dto.tags) };
     case 'import-as-is':
       return { kind: 'import-as-is' };
     case 'reject':

--- a/packages/importer/src/interfaces/contracts/events/mapping.test.ts
+++ b/packages/importer/src/interfaces/contracts/events/mapping.test.ts
@@ -7,6 +7,7 @@ import {
   awaitingReviewWithCandidate,
   resolved,
 } from '../../../domain/import/__fixtures__/import-fixtures.js';
+import { toAcquisitionId } from '../../../domain/shared/acquisition-id.js';
 import { publishedEventMapping } from './mapping.js';
 
 const OCCURRED_AT = '2026-07-18T12:00:00.000Z';
@@ -81,7 +82,9 @@ describe('publishedEventMapping.render — release.verdict', () => {
   });
 
   it('refuses a payload that violates the outbound schema (it must never leave the process)', () => {
-    const error = renderLast(verdictHistory({ acquisitionId: '' }))._unsafeUnwrapErr();
+    const error = renderLast(
+      verdictHistory({ acquisitionId: toAcquisitionId('') }),
+    )._unsafeUnwrapErr();
     expect(error.kind).toBe('RenderError');
     expect(error.message).toContain('schema');
   });

--- a/packages/importer/src/interfaces/contracts/intake/mapping.ts
+++ b/packages/importer/src/interfaces/contracts/intake/mapping.ts
@@ -1,5 +1,7 @@
 import { err, ok } from 'neverthrow';
 import type { Result } from 'neverthrow';
+import { toAcquisitionId } from '../../../domain/shared/acquisition-id.js';
+import type { AcquisitionId } from '../../../domain/shared/acquisition-id.js';
 import type { DeliveredCandidate, ImportHints } from '../../../domain/import/events.js';
 import type { AcquisitionFulfilledDto } from './schemas.js';
 
@@ -12,7 +14,7 @@ import type { AcquisitionFulfilledDto } from './schemas.js';
 
 /** What an accepted delivery translates to: the acquisition linkage plus the native submission. */
 export interface AcquisitionSubmission {
-  readonly acquisitionId: string;
+  readonly acquisitionId: AcquisitionId;
   /** The release directory in the SENDER's namespace, to be re-rooted before use. */
   readonly location: string;
   readonly hints: ImportHints;
@@ -23,7 +25,8 @@ export interface AcquisitionSubmission {
 export function fulfilledToSubmission(dto: AcquisitionFulfilledDto): AcquisitionSubmission {
   const { acquisitionId, location, target, candidate } = dto.data;
   return {
-    acquisitionId,
+    // The seam schema has already proven this non-empty; lift the foreign id into its brand here.
+    acquisitionId: toAcquisitionId(acquisitionId),
     location,
     hints: {
       mbReleaseId: target.musicbrainzReleaseId ?? undefined,


### PR DESCRIPTION
The deferred "value-object tail" from the domain-branding work (#93). Reuses the `Brand<T,B>` helper; pushes the remaining validated-value invariants into the types. Written test-first; full gate green; rebased onto `main` @ 3.8.0.

## Value objects
- **`Unit` (0..1)** — `domain/shared/unit.ts` (`parseUnit`/`clampUnit`). Applied to `MatchSignal.weight`/`score` (the OCP extension point third parties author), `RankedCandidate.matchConfidence`, `ValidationVerdict.confidence`, `ValidatorOutcome.score`, and `MatchPolicy.threshold` (parsed at the config edge). The `confidence >= threshold` / score comparisons are now same-type facts.
- **Branded importer ids** — `AcquisitionId` / `ImportId` (`domain/shared/{acquisition-id,import-id}.ts`), trusted total mints (their only invariant, non-empty, is already enforced at the seam/facade edge). `AcquisitionId` on the foreign id across the ACL; `ImportId` on the aggregate/stream id. The junction `importIdForAcquisition(AcquisitionId): ImportId` now makes transposing the two a compile error.
- **`PositiveInt`** for `ManualTrackTags.trackNumber`/`discNumber` (wire already enforces `.int().positive()`; lifted at the intake mapping).
- **`NonEmptyReadonlyArray<T>`** for the collections the domain guarantees non-empty (`RemediationState.failures`, remediation/duplicate-review collections, `ManualTags.tracks`, `bestOf`'s parameter) — constructed from checked narrowings at the edge; `bestOf`'s seedless `reduce` is now total.

All brands are runtime-erased — serialized event/wire JSON is byte-identical (contract tiers verify).

## Deferred (separate schema-evolution change)
Both change serialized event shapes, so left out to protect the event log:
- `EditionCandidate.trackCount` 0-means-unknown → optional (needs an upcaster + contract fixtures for both shapes).
- importer `match-review.best` optional → required (legacy events lack the field; needs a backfilling upcaster).

## Gate
`pnpm check` green: 100% coverage, downloader contract 69, importer contract 57, release 46. A `refactor`-only change: no version bump (`version-check` prepped for 3.8.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
