### PR TITLE
fix(domain): schema evolution — EditionCandidate.trackCount optional, match-review.best required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.8.2](https://github.com/jgchk/music-downloader/compare/v3.8.1...v3.8.2) (2026-07-23)
+
+### Bug Fixes
+
+* **domain:** schema-evolution — EditionCandidate.trackCount optional (0-was-unknown), importer match-review.best required ([f35b8c5](https://github.com/jgchk/music-downloader/commit/f35b8c517a677103428aedb3c0400f8dc27fba17))
 ## [3.8.1](https://github.com/jgchk/music-downloader/compare/v3.8.0...v3.8.1) (2026-07-23)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "private": true,
   "description": "An extensible, event-sourced music downloader and importer — a modular monolith.",
   "type": "module",

--- a/packages/downloader/src/adapters/musicbrainz/mapping.test.ts
+++ b/packages/downloader/src/adapters/musicbrainz/mapping.test.ts
@@ -697,10 +697,11 @@ describe('releaseGroupEditionCandidates', () => {
     expect(candidates[0]).toMatchObject({ trackCount: 14, format: 'CD + DVD-Video' });
   });
 
-  it('leaves presentation fields absent when the browse omits them', () => {
+  it('leaves presentation fields absent when the browse omits them, and an unknown track count absent', () => {
     const candidates = releaseGroupEditionCandidates([{ id: 'sparse' }]);
 
-    expect(candidates).toEqual([{ releaseMbid: 'sparse', trackCount: 0 }]);
+    expect(candidates).toEqual([{ releaseMbid: 'sparse' }]);
+    expect(candidates[0]).not.toHaveProperty('trackCount');
   });
 
   it('treats a null country and media format as absent (MusicBrainz reports unknowns as null)', () => {
@@ -711,12 +712,13 @@ describe('releaseGroupEditionCandidates', () => {
     expect(candidates).toEqual([{ releaseMbid: 'nulled', trackCount: 3 }]);
   });
 
-  it('treats a null title, status, and date as absent', () => {
+  it('treats a null title, status, and date as absent, and reports no track count', () => {
     const candidates = releaseGroupEditionCandidates([
       { id: 'nulled', title: null, status: null, date: null },
     ]);
 
-    expect(candidates).toEqual([{ releaseMbid: 'nulled', trackCount: 0 }]);
+    expect(candidates).toEqual([{ releaseMbid: 'nulled' }]);
+    expect(candidates[0]).not.toHaveProperty('trackCount');
   });
 
   it('orders candidates by the picker heuristic: modal track count first, then earliest date', () => {

--- a/packages/downloader/src/adapters/musicbrainz/mapping.ts
+++ b/packages/downloader/src/adapters/musicbrainz/mapping.ts
@@ -242,10 +242,10 @@ export interface ReleaseGroupEdition {
  * conservative, standard-like edition). Map iteration is insertion order, so the tie rule is applied
  * explicitly rather than relying on it. Assumes a non-empty input.
  */
-function modalTrackCount(editions: ReadonlyArray<Pick<ReleaseGroupEdition, 'trackCount'>>): number {
+function modalTrackCount(counts: readonly number[]): number {
   const frequency = new Map<number, number>();
-  for (const edition of editions) {
-    frequency.set(edition.trackCount, (frequency.get(edition.trackCount) ?? 0) + 1);
+  for (const count of counts) {
+    frequency.set(count, (frequency.get(count) ?? 0) + 1);
   }
   let modal = 0;
   let modalFrequency = 0;
@@ -274,7 +274,7 @@ export function releaseGroupEditionIds(
 ): readonly string[] {
   const official = editions.filter((edition) => edition.status === 'Official');
   if (official.length === 0) return [];
-  const modal = modalTrackCount(official);
+  const modal = modalTrackCount(official.map((edition) => edition.trackCount));
   return official
     .filter((edition) => edition.trackCount === modal)
     .sort((a, b) => compareDates(a.date, b.date))
@@ -322,7 +322,9 @@ function totalTrackCount(release: MbBrowseRelease): number {
 export function releaseGroupEditionCandidates(
   releases: readonly MbBrowseRelease[] | undefined,
 ): readonly EditionCandidate[] {
-  const candidates: EditionCandidate[] = [];
+  // The numeric count (0 = unknown) rides alongside each candidate purely for the picker's modal
+  // ranking; it never reaches the event, where an unknown count is absent (never the sentinel 0).
+  const editions: { readonly candidate: EditionCandidate; readonly count: number }[] = [];
   for (const release of releases ?? []) {
     const releaseMbid = optionalMbid(release.id);
     if (releaseMbid === undefined) continue;
@@ -333,20 +335,26 @@ export function releaseGroupEditionCandidates(
           .filter((format): format is string => typeof format === 'string'),
       ),
     ];
-    candidates.push({
-      releaseMbid,
-      title: release.title ?? undefined,
-      date: release.date ?? undefined,
-      country: release.country ?? undefined,
-      format: formats.length > 0 ? formats.join(' + ') : undefined,
-      trackCount: totalTrackCount(release),
+    const count = totalTrackCount(release);
+    editions.push({
+      count,
+      candidate: {
+        releaseMbid,
+        title: release.title ?? undefined,
+        date: release.date ?? undefined,
+        country: release.country ?? undefined,
+        format: formats.length > 0 ? formats.join(' + ') : undefined,
+        ...(count > 0 ? { trackCount: count } : {}),
+      },
     });
   }
-  if (candidates.length === 0) return candidates;
-  const modal = modalTrackCount(candidates);
-  return candidates.sort((a, b) => {
-    const modalRank = Number(a.trackCount !== modal) - Number(b.trackCount !== modal);
-    if (modalRank !== 0) return modalRank;
-    return compareDates(a.date, b.date);
-  });
+  if (editions.length === 0) return [];
+  const modal = modalTrackCount(editions.map((edition) => edition.count));
+  return editions
+    .sort((a, b) => {
+      const modalRank = Number(a.count !== modal) - Number(b.count !== modal);
+      if (modalRank !== 0) return modalRank;
+      return compareDates(a.candidate.date, b.candidate.date);
+    })
+    .map((edition) => edition.candidate);
 }

--- a/packages/downloader/src/adapters/sqlite/event-store.test.ts
+++ b/packages/downloader/src/adapters/sqlite/event-store.test.ts
@@ -8,7 +8,7 @@ import type { EventMetadata, StoredEvent } from '../../application/ports/event-s
 import { InProcessEventBus } from './event-bus.js';
 import { SqliteCheckpointStore, SqliteEventStore } from './event-store.js';
 import { openEventDatabase, type EventDatabase } from './schema.js';
-import { UpcasterRegistry } from './upcaster.js';
+import { CURRENT_SCHEMA_VERSION, UpcasterRegistry } from './upcaster.js';
 
 const META: EventMetadata = { acquisitionId: 'acq-1', occurredAt: '2026-07-03T12:00:00.000Z' };
 
@@ -107,10 +107,13 @@ describe('SqliteEventStore', () => {
   });
 
   it('upcasts stored events on read', async () => {
-    const registry = new UpcasterRegistry().register('AcquisitionFulfilled', 1, (data) => ({
-      ...data,
-      location: '/library/renamed',
-    }));
+    // Registered at the version freshly-appended events are stamped with, so the read path applies
+    // it (real upcasters bridge old→current; this unit only exercises the toStored → upcast wiring).
+    const registry = new UpcasterRegistry().register(
+      'AcquisitionFulfilled',
+      CURRENT_SCHEMA_VERSION,
+      (data) => ({ ...data, location: '/library/renamed' }),
+    );
     const store = new SqliteEventStore(freshDb(), registry);
     await store.append('acq-1', 0, [FULFILLED], META);
 

--- a/packages/downloader/src/adapters/sqlite/index.ts
+++ b/packages/downloader/src/adapters/sqlite/index.ts
@@ -7,5 +7,5 @@ export { SqliteDeadLetterStore } from './dead-letters.js';
 export { SqliteParkedEffectStore } from './parked-effects.js';
 export { SqliteResourceLedger } from './resource-ledger.js';
 export { InProcessEventBus, pollCatchUp } from './event-bus.js';
-export { UpcasterRegistry, CURRENT_SCHEMA_VERSION } from './upcaster.js';
+export { UpcasterRegistry, CURRENT_SCHEMA_VERSION, buildUpcasterRegistry } from './upcaster.js';
 export type { Upcaster } from './upcaster.js';

--- a/packages/downloader/src/adapters/sqlite/upcaster.test.ts
+++ b/packages/downloader/src/adapters/sqlite/upcaster.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { CURRENT_SCHEMA_VERSION, UpcasterRegistry } from './upcaster.js';
+import { CURRENT_SCHEMA_VERSION, UpcasterRegistry, buildUpcasterRegistry } from './upcaster.js';
 
 describe('UpcasterRegistry', () => {
   it('is pass-through when nothing is registered (the MVP)', () => {
@@ -40,6 +40,44 @@ describe('UpcasterRegistry', () => {
   });
 
   it('stamps new events at the current schema version', () => {
-    expect(CURRENT_SCHEMA_VERSION).toBe(1);
+    expect(CURRENT_SCHEMA_VERSION).toBe(2);
+  });
+});
+
+describe('buildUpcasterRegistry — ManualSelectionRequested v1 → v2', () => {
+  const registry = buildUpcasterRegistry();
+
+  function upcast(data: Record<string, unknown>): Record<string, unknown> {
+    return registry.upcast('ManualSelectionRequested', 1, data);
+  }
+
+  it('drops a v1 trackCount: 0 sentinel to absent and passes a real count through', () => {
+    const result = upcast({
+      type: 'ManualSelectionRequested',
+      candidates: [
+        { releaseMbid: 'a', title: 'Known', trackCount: 12 },
+        { releaseMbid: 'b', title: 'Unknown', trackCount: 0 },
+      ],
+    });
+
+    expect(result.candidates).toEqual([
+      { releaseMbid: 'a', title: 'Known', trackCount: 12 },
+      { releaseMbid: 'b', title: 'Unknown' },
+    ]);
+  });
+
+  it('tolerates an event with no candidates array', () => {
+    expect(upcast({ type: 'ManualSelectionRequested' })).toEqual({
+      type: 'ManualSelectionRequested',
+      candidates: [],
+    });
+  });
+
+  it('leaves a v2 event (stored at the current version) untouched', () => {
+    const v2 = {
+      type: 'ManualSelectionRequested',
+      candidates: [{ releaseMbid: 'b', title: 'Unknown' }],
+    };
+    expect(registry.upcast('ManualSelectionRequested', 2, v2)).toEqual(v2);
   });
 });

--- a/packages/downloader/src/adapters/sqlite/upcaster.ts
+++ b/packages/downloader/src/adapters/sqlite/upcaster.ts
@@ -8,8 +8,14 @@ import type { AcquisitionEvent } from '../../domain/acquisition/events.js';
  * migration, exactly the ES form of the no-breaking-change policy.
  */
 
-/** The schema version stamped on every event written today. */
-export const CURRENT_SCHEMA_VERSION = 1;
+/**
+ * The schema version stamped on every event written today.
+ *
+ * v2 (schema-evolution `EditionCandidate.trackCount`): the `ManualSelectionRequested` edition menu
+ * stored an unknown track count as the sentinel `0`; v2 makes the count optional (absent = unknown)
+ * and the read-side upcaster folds the legacy `0` to absent. See {@link buildUpcasterRegistry}.
+ */
+export const CURRENT_SCHEMA_VERSION = 2;
 
 /** Transforms one on-disk event payload from version N to version N+1. */
 export type Upcaster = (data: Record<string, unknown>) => Record<string, unknown>;
@@ -43,4 +49,36 @@ export class UpcasterRegistry {
     }
     return current as unknown as AcquisitionEvent;
   }
+}
+
+/**
+ * Lifts a v1 `ManualSelectionRequested` to v2: an `EditionCandidate` whose `trackCount` was the v1
+ * `0` sentinel (the only way a count of 0 could arise — the MusicBrainz mapping summed per-medium
+ * `track-count`s and a music release always has ≥1 track, so 0 meant "no usable media", i.e.
+ * unknown) drops the field entirely, matching the v2 "absent = unknown" shape. A real count (`> 0`)
+ * passes through unchanged.
+ */
+const manualSelectionRequestedV1ToV2: Upcaster = (data) => {
+  const candidates = Array.isArray(data.candidates) ? data.candidates : [];
+  return {
+    ...data,
+    candidates: candidates.map((candidate: Record<string, unknown>) => {
+      if (candidate.trackCount !== 0) return candidate;
+      const { trackCount: _unknown, ...rest } = candidate;
+      return rest;
+    }),
+  };
+};
+
+/**
+ * The downloader's read-side upcaster registry: the single place every known schema-evolution
+ * transform is registered, wired into the {@link SqliteEventStore} in composition. An empty
+ * registry would silently skip every upcast, so production and tests must build it here.
+ */
+export function buildUpcasterRegistry(): UpcasterRegistry {
+  return new UpcasterRegistry().register(
+    'ManualSelectionRequested',
+    1,
+    manualSelectionRequestedV1ToV2,
+  );
 }

--- a/packages/downloader/src/composition/runtime.ts
+++ b/packages/downloader/src/composition/runtime.ts
@@ -14,7 +14,7 @@ import {
   SqliteEventStore,
   SqliteParkedEffectStore,
   SqliteResourceLedger,
-  UpcasterRegistry,
+  buildUpcasterRegistry,
   fetchHttpClient,
   openEventDatabase,
   realTimer,
@@ -115,7 +115,7 @@ export async function createDownloaderRuntime(
   mkdirSync(dirname(config.databaseFile), { recursive: true });
   const db = openEventDatabase(config.databaseFile);
   const bus = new InProcessEventBus();
-  const store = new SqliteEventStore(db, new UpcasterRegistry(), bus);
+  const store = new SqliteEventStore(db, buildUpcasterRegistry(), bus);
   const checkpoints = new SqliteCheckpointStore(db);
   const deadLetters = overrides.deadLetters ?? new SqliteDeadLetterStore(db);
   const parkedEffects = new SqliteParkedEffectStore(db);

--- a/packages/downloader/src/domain/acquisition/events.ts
+++ b/packages/downloader/src/domain/acquisition/events.ts
@@ -45,9 +45,10 @@ export interface DownloadedFile {
  * One edition of a release group offered for manual selection — a lightweight presentation value,
  * not a {@link Target}, since presenting an edition needs no track manifest. Carried on the
  * `ManualSelectionRequested` event so the retained candidates are part of the acquisition's
- * history. Fields beyond the id and track count are optional: MusicBrainz data is sparse, and a
- * missing field degrades presentation, never the pause itself. An unknown track count arrives as
- * 0 (the mapping sums per-medium counts, unknown contributing nothing).
+ * history. Every field is optional: MusicBrainz data is sparse, and a missing field degrades
+ * presentation, never the pause itself. An unknown track count is absent (the mapping sums
+ * per-medium counts; a release with no usable media has no count to report). Legacy v1 history
+ * stored an unknown count as the sentinel `0` — the read-side upcaster folds that `0` to absent.
  */
 export interface EditionCandidate {
   readonly releaseMbid: Mbid;
@@ -55,7 +56,7 @@ export interface EditionCandidate {
   readonly date?: string;
   readonly country?: string;
   readonly format?: string;
-  readonly trackCount: number;
+  readonly trackCount?: number;
 }
 
 export type AcquisitionEvent =

--- a/packages/downloader/src/facade/schemas.ts
+++ b/packages/downloader/src/facade/schemas.ts
@@ -160,7 +160,8 @@ export const editionCandidateSchema = z.object({
   date: z.string().optional(),
   country: z.string().optional(),
   format: z.string().optional(),
-  trackCount: z.number(),
+  // Absent when the edition's track count is unknown (v2 EditionCandidate; legacy v1 stored 0).
+  trackCount: z.number().optional(),
 });
 
 export const acquisitionStatusResponseSchema = z.object({

--- a/packages/downloader/test/contract/events-upcast.contract.test.ts
+++ b/packages/downloader/test/contract/events-upcast.contract.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { AcquisitionEvent } from '../../src/domain/acquisition/events.js';
+import {
+  defaultPolicies,
+  sampleGroupRequest,
+} from '../../src/domain/acquisition/__fixtures__/acquisition-fixtures.js';
+import { foldEvents } from '../../src/domain/acquisition/state.js';
+import { buildUpcasterRegistry } from '../../src/adapters/sqlite/upcaster.js';
+
+/**
+ * Schema-evolution contract: a legacy stored event, folded through the read-side upcaster under the
+ * current code, must still replay to the correct state. `EditionCandidate.trackCount` changed from
+ * `0-means-unknown` (v1) to optional/absent (v2); the frozen v1 fixture below is exactly the
+ * on-disk shape the upcaster promises to fold forever. If this test ever fails, legacy history has
+ * become unfoldable — the worst failure an event-sourced store can suffer.
+ */
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+const FIXTURE_DIR = new URL('./fixtures/events/', import.meta.url).pathname;
+
+describe('ManualSelectionRequested v1 → v2 upcast (EditionCandidate.trackCount)', () => {
+  const fixture = readJson(join(FIXTURE_DIR, 'manual-selection.requested/v1.json')) as {
+    event: Record<string, unknown>;
+  };
+
+  function upcastFixture(): AcquisitionEvent {
+    return buildUpcasterRegistry().upcast('ManualSelectionRequested', 1, {
+      ...fixture.event,
+    });
+  }
+
+  it('drops the legacy trackCount: 0 sentinel to absent, and passes a real count through', () => {
+    const event = upcastFixture();
+    if (event.type !== 'ManualSelectionRequested') throw new Error('wrong event type');
+
+    const [known, unknown] = event.candidates;
+    expect(known.trackCount).toBe(12);
+    expect(unknown.trackCount).toBeUndefined();
+    expect(Object.prototype.hasOwnProperty.call(unknown, 'trackCount')).toBe(false);
+  });
+
+  it('folds the upcast legacy event to AwaitingManualSelection with the unknown count absent', () => {
+    const history: readonly AcquisitionEvent[] = [
+      { type: 'AcquisitionRequested', request: sampleGroupRequest, policies: defaultPolicies() },
+      upcastFixture(),
+    ];
+
+    const state = foldEvents(history);
+
+    expect(state.phase).toBe('AwaitingManualSelection');
+    if (state.phase !== 'AwaitingManualSelection') throw new Error('unreachable');
+    expect(state.candidates).toEqual([
+      {
+        releaseMbid: 'boot-1',
+        title: 'Live at Budokan',
+        date: '1995-05-01',
+        country: 'JP',
+        format: 'CD',
+        trackCount: 12,
+      },
+      { releaseMbid: 'boot-2', title: 'Promo Sampler' },
+    ]);
+  });
+
+  it('leaves a current v2 event (already absent for unknown) untouched', () => {
+    const v2Event: AcquisitionEvent = {
+      type: 'ManualSelectionRequested',
+      candidates: [
+        { releaseMbid: 'boot-1', title: 'Live at Budokan', trackCount: 12 },
+        { releaseMbid: 'boot-2', title: 'Promo Sampler' },
+      ],
+    };
+
+    const folded = foldEvents([
+      { type: 'AcquisitionRequested', request: sampleGroupRequest, policies: defaultPolicies() },
+      buildUpcasterRegistry().upcast('ManualSelectionRequested', 2, {
+        ...v2Event,
+      } as unknown as Record<string, unknown>),
+    ]);
+
+    expect(folded.phase).toBe('AwaitingManualSelection');
+    if (folded.phase !== 'AwaitingManualSelection') throw new Error('unreachable');
+    expect(folded.candidates[1]).toEqual({ releaseMbid: 'boot-2', title: 'Promo Sampler' });
+  });
+});

--- a/packages/downloader/test/contract/fixtures/events/manual-selection.requested/v1.json
+++ b/packages/downloader/test/contract/fixtures/events/manual-selection.requested/v1.json
@@ -1,0 +1,25 @@
+{
+  "provenance": {
+    "recordedAt": "2026-07-23T00:00:00.000Z",
+    "schemaVersion": 1,
+    "note": "The v1 on-disk shape of an internal ManualSelectionRequested event. Under v1 an unknown EditionCandidate track count was stored as the sentinel 0 (the MusicBrainz mapping summed per-medium track-counts, an unknown medium contributing 0, so a release with no usable media summed to 0). FROZEN — never regenerate; the upcaster must fold this shape forever."
+  },
+  "event": {
+    "type": "ManualSelectionRequested",
+    "candidates": [
+      {
+        "releaseMbid": "boot-1",
+        "title": "Live at Budokan",
+        "date": "1995-05-01",
+        "country": "JP",
+        "format": "CD",
+        "trackCount": 12
+      },
+      {
+        "releaseMbid": "boot-2",
+        "title": "Promo Sampler",
+        "trackCount": 0
+      }
+    ]
+  }
+}

--- a/packages/importer/src/domain/import/events.ts
+++ b/packages/importer/src/domain/import/events.ts
@@ -157,7 +157,14 @@ export type ReviewCause =
        * pre-change events, which have no id, still read as hinted.
        */
       readonly hintedReleaseId?: string;
-      readonly best?: CandidateRef;
+      /**
+       * The best (lowest-distance) candidate that fell to review. Required: the decider reaches
+       * `match-review` only for a non-empty candidate list (the empty case routes to `no-match`
+       * first), so it has always populated `best` — every stored `match-review` event carries it,
+       * and no legacy history lacks it. (The wire DTO keeps `best` optional; that is a separate,
+       * additive serialization altitude.)
+       */
+      readonly best: CandidateRef;
     }
   | { readonly kind: 'no-match' }
   | {

--- a/packages/importer/src/facade/mapping.test.ts
+++ b/packages/importer/src/facade/mapping.test.ts
@@ -130,10 +130,11 @@ describe('reviewToDto', () => {
     });
   });
 
-  it('maps a best-less match review, no-match, and remediation', () => {
-    expect(reviewToDto({ cause: { kind: 'match-review', hinted: false }, candidates: [] })).toEqual(
-      { kind: 'match-review', hinted: false, best: undefined, candidates: [] },
-    );
+  it('maps an unhinted match review, no-match, and remediation', () => {
+    const best = { dataSource: 'MusicBrainz', albumId: 'album-9' };
+    expect(
+      reviewToDto({ cause: { kind: 'match-review', hinted: false, best }, candidates: [] }),
+    ).toEqual({ kind: 'match-review', hinted: false, best, candidates: [] });
     expect(reviewToDto({ cause: { kind: 'no-match' }, candidates: [] })).toEqual({
       kind: 'no-match',
     });

--- a/packages/importer/src/facade/mapping.ts
+++ b/packages/importer/src/facade/mapping.ts
@@ -103,7 +103,9 @@ export function reviewToDto(review: OpenReview): ReviewDto {
         kind: 'match-review',
         hinted: cause.hinted,
         hintedReleaseId: cause.hintedReleaseId,
-        best: cause.best === undefined ? undefined : { ...cause.best },
+        // `best` is required in the domain; the wire DTO keeps it optional (a tolerant, additive
+        // serialization altitude), but the mapping now always carries the present candidate.
+        best: { ...cause.best },
         candidates: review.candidates.map(candidateToDto),
       };
     case 'no-match':

--- a/packages/importer/test/contract/events-fold.contract.test.ts
+++ b/packages/importer/test/contract/events-fold.contract.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { ImportEvent } from '../../src/domain/import/events.js';
+import { foldEvents } from '../../src/domain/import/state.js';
+import {
+  candidate,
+  proposed,
+  requested,
+} from '../../src/domain/import/__fixtures__/import-fixtures.js';
+import { UpcasterRegistry } from '../../src/adapters/sqlite/upcaster.js';
+
+/**
+ * Schema-evolution contract: `ReviewCause` `match-review.best` was tightened from optional to
+ * required. That is only safe because every stored `match-review` event has always carried `best`
+ * (the decider reaches match-review solely for a non-empty candidate list; the empty case routes to
+ * `no-match`). No upcaster/version bump is needed — the on-disk bytes are already valid under the
+ * required type. This test proves the frozen v1 shape still folds through the (pass-through) read
+ * path to the correct review state; if it fails, the tightening broke legacy history.
+ */
+
+function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+const FIXTURE_DIR = new URL('./fixtures/events/', import.meta.url).pathname;
+
+describe('ReviewRequired match-review legacy fold (best now required)', () => {
+  const fixture = readJson(join(FIXTURE_DIR, 'review.required/v1.json')) as {
+    event: Record<string, unknown>;
+  };
+
+  it('folds a legacy stored match-review event to awaiting-review with best present', () => {
+    // The importer read path stamps no upcaster (MVP pass-through); the stored bytes are cast as-is.
+    const reviewEvent = new UpcasterRegistry().upcast(
+      'ReviewRequired',
+      1,
+      fixture.event,
+    ) as ImportEvent;
+
+    const history: readonly ImportEvent[] = [
+      requested({ hints: { mbReleaseId: 'mb-release-1' } }),
+      proposed([candidate()]),
+      reviewEvent,
+    ];
+
+    const state = foldEvents(history);
+
+    expect(state.phase).toBe('awaiting-review');
+    if (state.phase !== 'awaiting-review') throw new Error('unreachable');
+    expect(state.cause.kind).toBe('match-review');
+    if (state.cause.kind !== 'match-review') throw new Error('unreachable');
+    expect(state.cause.best).toEqual({ dataSource: 'MusicBrainz', albumId: 'album-1' });
+  });
+});

--- a/packages/importer/test/contract/fixtures/events/review.required/v1.json
+++ b/packages/importer/test/contract/fixtures/events/review.required/v1.json
@@ -1,0 +1,16 @@
+{
+  "provenance": {
+    "recordedAt": "2026-07-23T00:00:00.000Z",
+    "schemaVersion": 1,
+    "note": "The v1 on-disk shape of an internal ReviewRequired event with a match-review cause. The decider reaches match-review only for a non-empty candidate list (the empty case routes to no-match first), so it has ALWAYS populated `best` — no legacy history lacks it. FROZEN: this is the shape the (now-required) `best` type must keep folding forever."
+  },
+  "event": {
+    "type": "ReviewRequired",
+    "cause": {
+      "kind": "match-review",
+      "hinted": true,
+      "hintedReleaseId": "mb-release-1",
+      "best": { "dataSource": "MusicBrainz", "albumId": "album-1" }
+    }
+  }
+}

--- a/packages/web/src/lib/components/AcquisitionDetail.ssr.test.ts
+++ b/packages/web/src/lib/components/AcquisitionDetail.ssr.test.ts
@@ -165,7 +165,7 @@ describe('AcquisitionDetail (SSR)', () => {
               format: 'CD',
               trackCount: 12,
             },
-            { releaseMbid: 'boot-2', trackCount: 10 },
+            { releaseMbid: 'boot-2' },
           ],
         },
         timeline: [],
@@ -177,6 +177,10 @@ describe('AcquisitionDetail (SSR)', () => {
     expect(body).toContain('JP');
     expect(body).toContain('CD');
     expect(body).toContain('<td>12</td>');
+    // The second edition is sparse: an unknown title renders as (untitled) and an unknown (absent)
+    // track count renders as a dash, not 0.
+    expect(body).toContain('(untitled)');
+    expect(body).toContain('<td>—</td>');
     expect(body).toContain('action="?/select"');
     expect(body).toContain('value="boot-1"');
     expect(body).toContain('value="boot-2"');

--- a/packages/web/src/lib/components/AcquisitionDetail.svelte
+++ b/packages/web/src/lib/components/AcquisitionDetail.svelte
@@ -93,7 +93,7 @@
           <td>{candidate.date ?? '—'}</td>
           <td>{candidate.country ?? '—'}</td>
           <td>{candidate.format ?? '—'}</td>
-          <td>{candidate.trackCount}</td>
+          <td>{candidate.trackCount ?? '—'}</td>
           <td>
             <form method="POST" action="?/select">
               <input type="hidden" name="releaseMbid" value={candidate.releaseMbid} />


### PR DESCRIPTION
The two deferred **schema-evolution** representability fixes from the review backlog. Both alter serialized event shapes, so each carries a legacy-fold contract fixture proving old stored events still parse/fold. Written test-first; full gate green.

## `EditionCandidate.trackCount`: `0-means-unknown` → optional
The count was produced by summing MusicBrainz `media[].track-count`; a music release always has ≥1 track, so a sum of `0` could only mean "no usable media" — i.e. genuinely unknown. So `0` was always the unknown sentinel, and the "0 = zero tracks vs unknown" overload is resolved by making the field optional (absent = unknown).
- **Schema bump + upcaster:** `CURRENT_SCHEMA_VERSION` 1→2 (downloader); `manualSelectionRequestedV1ToV2` drops each candidate's `trackCount === 0` to absent, passes `> 0` through. **Also fixed a latent bug:** the production `UpcasterRegistry` was instantiated empty (no transform would ever have run) — added a `buildUpcasterRegistry()` factory and wired it into the composition root.
- **Legacy-fold test:** a frozen v1 fixture (unknown edition stored as `trackCount: 0`) upcasts + folds to `AwaitingManualSelection` with the unknown count absent and a real count (12) intact.
- **Downstream:** domain type + producer (MB mapping omits 0; picker's modal ranking still uses raw counts internally so ordering is unchanged), facade DTO (`trackCount` optional), web edition menu renders `?? '—'` instead of `0`.

## importer `match-review.best`: optional → required
History-verified: since the first commit, `decideProposal` has emitted `best` unconditionally (the empty-candidate case routes to `no-match` first). **No legacy stored `match-review` event can lack it**, so this is a safe tightening — no upcaster, no version bump on its own.
- **Legacy-fold test:** a frozen v1 `ReviewRequired` fixture folds to `awaiting-review` with `cause.best` present under the now-required type.
- **Downstream:** domain type required; `reviewToDto` simplified. The **wire DTO `best` stays optional** (separate serialization altitude — additive/tolerant), so no wire contract breaks and the web guard remains valid.

## Gate
`pnpm check` green: 100% coverage (1613 tests), downloader contract 72, importer contract 58 (both incl. the new legacy-fold tests), release 46. Neither event is a cross-context *published* event, so the read-side upcaster/fold path is the correct backward-compat surface — which the fixtures exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
