### PR TITLE
test: slskd recorder PII scrub + native Python bridge test tier (review follow-ups)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -74,6 +74,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - run: pnpm install --frozen-lockfile
       - name: Install Chromium (browser-mode client tests)
         run: pnpm --dir packages/web exec playwright install --with-deps chromium
@@ -83,6 +86,8 @@ jobs:
         run: pnpm run test:contract
       - name: Release-tooling tests
         run: pnpm run test:release
+      - name: Beets-bridge unit tests @ 100% coverage (Python)
+        run: pnpm run test:bridge
 
   # main only, after the gate is green: build the image once, gate it through the out-of-process E2E
   # tier — browser parity phase included, so Playwright drives the same image that publishes — then,

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ packages/web/build/
 packages/web/test-results/
 packages/web/playwright-report/
 /packages/web/.e2e-scratch/
+
+# Python (beets bridge tests)
+__pycache__/
+*.pyc
+.coverage
+packages/importer/test/bridge/.venv/

--- a/.prettierignore
+++ b/.prettierignore
@@ -24,3 +24,6 @@ packages/web/.svelte-kit/
 packages/web/build/
 packages/web/test-results/
 packages/web/playwright-report/
+
+# Python hermetic venvs
+**/.venv/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -128,6 +128,8 @@ export default tseslint.config(
       'test/e2e/**',
       'test/boundaries/**',
       'packages/*/test/contract/**',
+      'packages/*/test/bridge/**',
+      '**/.venv/**',
       'scripts/**',
       'packages/*/scripts/**',
       '**/*.config.ts',

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "test:cov": "vitest run --coverage",
     "test:contract": "vitest run --config packages/downloader/test/contract/vitest.config.ts && vitest run --config packages/importer/test/contract/vitest.config.ts",
     "test:release": "vitest run --config scripts/release/vitest.config.ts",
+    "test:bridge": "bash packages/importer/test/bridge/run.sh",
     "test:e2e": "bash test/e2e/run.sh",
     "contracts:events": "tsx packages/downloader/scripts/contracts/generate-event-schemas.ts && tsx packages/importer/scripts/contracts/generate-event-schemas.ts",
     "version:prep": "tsx scripts/release/version-prep.ts",
-    "check": "pnpm run format && pnpm run lint && pnpm run typecheck && pnpm run build && pnpm run test:cov && pnpm run test:contract && pnpm run test:release",
+    "check": "pnpm run format && pnpm run lint && pnpm run typecheck && pnpm run build && pnpm run test:cov && pnpm run test:contract && pnpm run test:release && pnpm run test:bridge",
     "test:e2e:web": "pnpm --dir packages/web exec playwright test",
     "dev": "pnpm --dir packages/web dev"
   },

--- a/packages/downloader/test/contract/fixtures/slskd/events.json
+++ b/packages/downloader/test/contract/fixtures/slskd/events.json
@@ -7,7 +7,11 @@
   },
   "request": {
     "method": "GET",
-    "path": "/api/v0/events"
+    "path": "/api/v0/events",
+    "query": {
+      "offset": "0",
+      "limit": "100"
+    }
   },
   "response": {
     "status": 200,

--- a/packages/downloader/test/contract/record/slskd.ts
+++ b/packages/downloader/test/contract/record/slskd.ts
@@ -12,7 +12,11 @@ import { CONTRACT_FIXTURE_ROOT, type ContractFixture } from '../support/fixture.
  *
  * Everything captured is passed through {@link sanitize} before writing: real Soulseek usernames
  * become peerN and the per-peer share-alias prefix (`@@xxxx\`) becomes `@@share\`, leaving only the
- * public music metadata (artist / album / filename). Review the printed summary before committing.
+ * public music metadata (artist / album / filename). The two metadata endpoints are additionally
+ * projected to just their consumed fields — {@link projectOptions} drops the Soulseek credentials and
+ * the rest of slskd's config; {@link projectEvents} trims each event's JSON-encoded `data` (which
+ * sanitize cannot reach into) to `localFilename` + `transfer.id`. Review the printed summary before
+ * committing.
  */
 
 const BASE_URL = process.env.SLSKD_BASE_URL;
@@ -24,6 +28,9 @@ const SEARCH_TEXT = 'Pink Floyd Dark Side of the Moon';
 const PEER_CAP = 5;
 // One page of the newest-first events log — enough to capture a recent DownloadFileComplete.
 const EVENTS_LIMIT = 100;
+// How many DownloadFileComplete events to keep in the fixture — a handful pins the decode/re-root
+// contract without bloating the committed file.
+const EVENTS_KEPT = 3;
 
 if (BASE_URL === undefined || API_KEY === undefined) {
   throw new Error('SLSKD_BASE_URL and SLSKD_API_KEY must be set');
@@ -58,6 +65,49 @@ function sanitize(value: unknown): unknown {
   }
   if (typeof value === 'string') return value.replace(/^@@[^\\]+\\/, '@@share\\');
   return value;
+}
+
+/**
+ * Keep only the one consumed subtree — `directories` — so the Soulseek account credentials, listen
+ * ports, blacklist, integrations, and the rest of slskd's effective config never reach the committed
+ * (public-repo) fixture. Only `directories.downloads` is actually read by the adapter.
+ */
+function projectOptions(body: unknown): unknown {
+  const dirs = (body as { directories?: { incomplete?: string; downloads?: string } }).directories;
+  return { directories: { incomplete: dirs?.incomplete, downloads: dirs?.downloads } };
+}
+
+/**
+ * Keep only `DownloadFileComplete` events, each trimmed to the fields the staged-path resolver
+ * consumes — `localFilename` + `transfer.id` — dropping the peer `username`, the `remoteFilename`
+ * share token, and the rest of the transfer object. The event `data` is a JSON-encoded string, so
+ * {@link sanitize} cannot reach inside it; this projection is what keeps third-party PII out of the
+ * committed fixture. The event id is normalized to a non-identifying `evt-<prefix>`.
+ *
+ * Note the coupling: events.json is not independently re-recordable. The staged-path resolver matches
+ * a `DownloadFileComplete` to the polled transfer by `transfer.id`, so a re-record must capture the
+ * events log AFTER the enqueued transfer from this same session has completed (its completion event
+ * present), or the transfers contract test can't resolve a staged path. Refresh the whole coupled set
+ * (search → transfer → events) together, not events alone.
+ */
+function projectEvents(body: unknown): unknown {
+  const events = Array.isArray(body) ? body : [];
+  const kept: unknown[] = [];
+  for (const raw of events) {
+    const event = raw as { timestamp?: string; type?: string; data?: string };
+    if (event.type !== 'DownloadFileComplete' || typeof event.data !== 'string') continue;
+    const data = JSON.parse(event.data) as { localFilename?: string; transfer?: { id?: string } };
+    const id = data.transfer?.id;
+    if (data.localFilename === undefined || id === undefined) continue;
+    kept.push({
+      timestamp: event.timestamp,
+      type: event.type,
+      id: `evt-${id.slice(0, 8)}`,
+      data: JSON.stringify({ localFilename: data.localFilename, transfer: { id } }),
+    });
+    if (kept.length >= EVENTS_KEPT) break;
+  }
+  return kept;
 }
 
 async function call(
@@ -176,13 +226,14 @@ async function main(): Promise<void> {
   );
 
   // The effective configuration: only directories.downloads (the downloads root) is consumed, used
-  // to re-root slskd's container-side localFilename onto our shared staging volume.
+  // to re-root slskd's container-side localFilename onto our shared staging volume. Projected to just
+  // `directories` so the Soulseek credentials and the rest of the config never reach the fixture.
   const options = await call('GET', '/api/v0/options');
   write(
     'options.json',
     fixture(
       { method: 'GET', path: '/api/v0/options' },
-      options,
+      { status: options.status, body: projectOptions(options.body) },
       'GET /api/v0/options — only directories.downloads is consumed (the downloads root)',
     ),
   );
@@ -190,12 +241,9 @@ async function main(): Promise<void> {
   // The newest-first, paged activity log with its real offset/limit query. Each record's `data` is a
   // JSON-encoded string; a `DownloadFileComplete` carries the authoritative localFilename + transfer
   // id the staged-path resolver decodes. A completion only appears once a download has finished, so
-  // run this recorder against an instance that has completed at least one download for full coverage.
-  // NOTE: the committed events.json/options.json fixtures predate this recorder capture (they were
-  // hand-maintained), so their `request` blocks lack the `query` recorded here. Re-record both against
-  // a live slskd instance on the next slskd pin bump to make the recorder byte-faithful to them; the
-  // decode/request-shape tests are unaffected in the meantime (the fixture server captures the real
-  // outbound request, not the fixture file).
+  // run against an instance that has completed the enqueued transfer above. `projectEvents` trims each
+  // event to the consumed fields (a JSON string sanitize cannot reach into), keeping peer PII out —
+  // and see its note on the events↔transfers-poll coupling before re-recording.
   const events = await call('GET', `/api/v0/events?offset=0&limit=${EVENTS_LIMIT}`);
   write(
     'events.json',
@@ -205,7 +253,7 @@ async function main(): Promise<void> {
         path: '/api/v0/events',
         query: { offset: '0', limit: String(EVENTS_LIMIT) },
       },
-      events,
+      { status: events.status, body: projectEvents(events.body) },
       'GET /api/v0/events — newest-first paged log; DownloadFileComplete.data is a JSON-encoded string',
     ),
   );

--- a/packages/importer/src/adapters/beets/bridge/bridge.py
+++ b/packages/importer/src/adapters/beets/bridge/bridge.py
@@ -234,7 +234,7 @@ def serialize_match(match):
 def serialize_album(album):
     try:
         path = os.fsdecode(album.path) if album.path else ""
-    except Exception:
+    except Exception:  # pragma: no cover — os.fsdecode never raises on the bytes/str/None beets produces; defensive crash-barrier only
         path = ""
     return {
         "artist": album.albumartist or "",

--- a/packages/importer/test/bridge/.coveragerc
+++ b/packages/importer/test/bridge/.coveragerc
@@ -1,0 +1,15 @@
+# Coverage gate for the beets bridge's Python unit tests — the Python peer of the TS `test:cov`
+# 100% gate. Branch coverage, measuring only bridge.py (the tests fake beets, so nothing else runs).
+[run]
+branch = True
+source =
+    ../../src/adapters/beets/bridge
+
+[report]
+fail_under = 100
+show_missing = True
+precision = 1
+# The CLI entrypoint guard never runs under unittest (the module is imported, not executed as
+# __main__). Any other exclusion must be justified in-line like a TS `v8 ignore` waiver.
+exclude_also =
+    if __name__ == .__main__.:

--- a/packages/importer/test/bridge/fakes.py
+++ b/packages/importer/test/bridge/fakes.py
@@ -1,0 +1,409 @@
+"""Faithful fakes for the beets contracts the bridge depends on.
+
+Named ``fakes.py`` (not ``test_*.py``) so unittest's ``test_*.py`` discovery never runs it as a
+test module. The bridge imports beets only lazily inside its functions, so these fakes are injected
+into ``sys.modules`` and the bridge is driven directly — no real beets install, ffmpeg, network, or
+audio files.
+
+The goal is faithfulness, not blind mocking: each fake models the real beets contract the bridge
+relies on (confuse's nested config views, ``autotag.tag_album``'s proposal/recommendation shapes,
+the ``Distance`` object, ``ImportSession``'s question hooks, the ``album_imported`` plugin-listener
+flow, ``search_ids`` ID lookup). A test that fails therefore means the *bridge* is wrong, not that a
+mock drifted from beets.
+"""
+
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+_BRIDGE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "src",
+    "adapters",
+    "beets",
+    "bridge",
+)
+if _BRIDGE_DIR not in sys.path:
+    sys.path.insert(0, _BRIDGE_DIR)
+
+import bridge  # noqa: E402,F401 — re-exported for tests after the sys.path insert above
+
+# The pinned fixture release (The Beatles — "Love Me Do", 1988), so IDs read like the real ones.
+MBID = "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
+BEETS_VERSION = "2.12.0"
+
+
+class FakeView:
+    """A minimal confuse ConfigView: nested ``view[key]`` access, ``set``, ``get`` (a plain scalar
+    read), ``as_str_seq``, and ``as_filename`` (confuse's PATH resolution). Auto-vivifies children so
+    ``config["import"]["quiet"].set(...)`` works exactly as the bridge's ``deep_set`` walks the
+    overlay."""
+
+    def __init__(self, value=None, filename_error=None):
+        if isinstance(value, dict):
+            self._scalar = None
+            self._data = dict(value)
+        else:
+            self._scalar = value
+            self._data = {}
+        self._children = {}
+        self._filename_error = filename_error
+
+    def __getitem__(self, key):
+        if key not in self._children:
+            self._children[key] = FakeView(self._data.get(key), self._filename_error)
+        return self._children[key]
+
+    def set(self, value):
+        self._scalar = value
+        self._data = dict(value) if isinstance(value, dict) else {}
+
+    def get(self):
+        """The scalar value at this leaf (confuse's plain read), distinct from ``as_filename``'s
+        PATH resolution."""
+        return self._scalar
+
+    def as_str_seq(self):
+        return [str(item) for item in (self._scalar or [])]
+
+    def as_filename(self):
+        if self._filename_error is not None:
+            raise self._filename_error
+        return self._scalar
+
+
+class FakeConfig(FakeView):
+    """The confuse ``Configuration`` singleton beets exposes as ``beets.config``; adds ``set_file``
+    (the bridge makes the user's exact file authoritative before applying the session overlay)."""
+
+    def __init__(self, value=None, filename_error=None):
+        super().__init__(value, filename_error)
+        self.set_file_calls = []
+
+    def set_file(self, path):
+        self.set_file_calls.append(path)
+
+
+class Distance:
+    """beets' autotag ``Distance``: coerces to a float overall score, iterates ``(name, amount)``
+    penalty pairs via ``items()``, and carries a per-track ``tracks`` mapping."""
+
+    def __init__(self, value, penalties=(), tracks=None):
+        self._value = value
+        self._penalties = list(penalties)
+        self.tracks = tracks or {}
+
+    def __float__(self):
+        return float(self._value)
+
+    def items(self):
+        return list(self._penalties)
+
+
+class FakeAlbumInfo:
+    """An ``autotag.AlbumInfo``: a source-tagged ``identifier`` plus the album-level fields the
+    bridge serializes for the diff."""
+
+    def __init__(
+        self,
+        identifier,
+        artist="",
+        album="",
+        year=0,
+        media="",
+        label="",
+        catalognum="",
+        country="",
+        albumdisambig="",
+    ):
+        self.identifier = identifier
+        self.artist = artist
+        self.album = album
+        self.year = year
+        self.media = media
+        self.label = label
+        self.catalognum = catalognum
+        self.country = country
+        self.albumdisambig = albumdisambig
+
+
+class FakeTrackInfo:
+    """An ``autotag.TrackInfo``: the candidate's proposed per-track tags."""
+
+    def __init__(self, title="", index=0):
+        self.title = title
+        self.index = index
+
+
+class FakeMatch:
+    """An ``autotag.AlbumMatch``: candidate info, overall/per-track distance, the file→track
+    ``mapping``, and the leftover ``extra_items`` / ``extra_tracks``."""
+
+    def __init__(self, info, distance, mapping=None, extra_items=(), extra_tracks=()):
+        self.info = info
+        self.distance = distance
+        self.mapping = mapping or {}
+        self.extra_items = list(extra_items)
+        self.extra_tracks = list(extra_tracks)
+
+
+class FakeItem:
+    """A ``library.Item``: the file's current tags. ``path`` is bytes, as beets stores it."""
+
+    def __init__(self, path=b"", title="", artist="", track=0, length=0.0):
+        self.path = path
+        self.title = title
+        self.artist = artist
+        self.track = track
+        self.length = length
+        # Written by apply_manual_tags:
+        self.albumartist = ""
+        self.album = ""
+        self.year = 0
+        self.disc = 0
+
+
+class FakeAlbum:
+    """A ``library.Album``: an imported/incumbent album row."""
+
+    def __init__(self, albumartist="", album="", path=b""):
+        self.albumartist = albumartist
+        self.album = album
+        self.path = path
+
+
+class FakeLib:
+    """A beets ``Library``: answers ``albums(query)`` with the configured incumbents and records the
+    query it was asked (so a test can assert the duplicate lookup was built)."""
+
+    def __init__(self, albums=()):
+        self._albums = list(albums)
+        self.album_queries = []
+
+    def albums(self, query):
+        self.album_queries.append(query)
+        return list(self._albums)
+
+
+class Proposal:
+    """The third element of ``autotag.tag_album``'s return: the candidate matches."""
+
+    def __init__(self, candidates=()):
+        self.candidates = list(candidates)
+
+
+DEFAULT_CONFIG_DATA = {
+    "plugins": ["musicbrainz"],
+    "library": "/work/beets/library.db",
+    "directory": "/work/library",
+}
+
+
+def install(config_data=None, filename_error=None):
+    """Inject a fresh, fully-wired fake ``beets`` package into ``sys.modules`` and return a handle.
+
+    Fresh classes/modules every call means no state leaks between tests (the ``BeetsPlugin``
+    listener registry, the ``ImportTask.lookup_candidates`` class stub, the session ``plan``).
+    """
+    handle = SimpleNamespace()
+    handle.config = FakeConfig(
+        DEFAULT_CONFIG_DATA if config_data is None else config_data, filename_error
+    )
+    handle.lib = FakeLib()
+    handle.proposal = Proposal()
+    handle.tag_calls = []
+    handle.from_path = lambda path: FakeItem(path=path)
+
+    # ---- beets.library ----
+    library_mod = types.ModuleType("beets.library")
+
+    class Item:
+        @staticmethod
+        def from_path(path):
+            return handle.from_path(path)
+
+    library_mod.Item = Item
+    library_mod.Album = FakeAlbum
+
+    # ---- beets.plugins ----
+    plugins_mod = types.ModuleType("beets.plugins")
+    plugins_mod.load_plugins_calls = []
+    # Snapshots of an overlay-forced config leaf (`import.resume`, which SESSION_OVERLAY forces to
+    # False) taken AT each load_plugins() call, so a test can pin that the overlay was already
+    # applied when plugins loaded — the ordering the bridge documents (a reorder that loaded plugins
+    # first would snapshot the pre-overlay value instead).
+    plugins_mod.overlay_at_load = []
+    plugins_mod.sent = []
+
+    class BeetsPlugin:
+        listeners = {"album_imported": []}
+
+    def load_plugins():
+        plugins_mod.load_plugins_calls.append(True)
+        plugins_mod.overlay_at_load.append(handle.config["import"]["resume"].get())
+
+    def send(event, **kwargs):
+        plugins_mod.sent.append((event, kwargs))
+        return []
+
+    plugins_mod.BeetsPlugin = BeetsPlugin
+    plugins_mod.load_plugins = load_plugins
+    plugins_mod.send = send
+    handle.BeetsPlugin = BeetsPlugin
+    handle.plugins = plugins_mod
+
+    # ---- beets.ui ----
+    ui_mod = types.ModuleType("beets.ui")
+    ui_mod.opened = []
+
+    def _open_library(config):
+        ui_mod.opened.append(config)
+        return handle.lib
+
+    ui_mod._open_library = _open_library
+
+    # ---- beets.autotag ----
+    autotag_mod = types.ModuleType("beets.autotag")
+
+    class Recommendation:
+        none = "none"
+
+    def tag_album(items, search_artist=None, search_name=None, search_ids=None):
+        handle.tag_calls.append(
+            {
+                "items": items,
+                "search_artist": search_artist,
+                "search_name": search_name,
+                "search_ids": search_ids,
+            }
+        )
+        return (None, None, handle.proposal)
+
+    autotag_mod.Recommendation = Recommendation
+    autotag_mod.tag_album = tag_album
+    handle.autotag = autotag_mod
+
+    # ---- beets.dbcore.query ----
+    dbcore_mod = types.ModuleType("beets.dbcore")
+    query_mod = types.ModuleType("beets.dbcore.query")
+
+    class MatchQuery:
+        def __init__(self, field, value):
+            self.field = field
+            self.value = value
+
+    class AndQuery:
+        def __init__(self, subqueries):
+            self.subqueries = subqueries
+
+    query_mod.MatchQuery = MatchQuery
+    query_mod.AndQuery = AndQuery
+    dbcore_mod.query = query_mod
+    handle.MatchQuery = MatchQuery
+    handle.AndQuery = AndQuery
+
+    # ---- beets.importer ----
+    importer_mod = types.ModuleType("beets.importer")
+
+    class Action:
+        ASIS = SimpleNamespace(name="Action.ASIS")
+        SKIP = SimpleNamespace(name="Action.SKIP")
+
+    class DuplicateAction:
+        REMOVE = SimpleNamespace(name="DuplicateAction.REMOVE")
+        KEEP = SimpleNamespace(name="DuplicateAction.KEEP")
+        SKIP = SimpleNamespace(name="DuplicateAction.SKIP")
+
+    class ImportTask:
+        """A beets ``ImportTask`` for one album. ``lookup_candidates`` is the seam the bridge stubs
+        for as-is/manual imports; by default the test pre-populates ``candidates`` directly (as a
+        real matcher lookup would)."""
+
+        def __init__(self, items=(), candidates=(), album=None, duplicates=()):
+            self.items = list(items)
+            self.candidates = list(candidates)
+            self.album = album
+            self.duplicates = list(duplicates)
+            self.cur_artist = "unset"
+            self.cur_album = "unset"
+            self.rec = "unset"
+
+        def lookup_candidates(self, search_ids):
+            return None
+
+    class ImportSession:
+        """beets' ``ImportSession``. Its ``run()`` plays the configured tasks through the very
+        question hooks the bridge overrides — ``lookup_candidates``, ``choose_match``,
+        ``get_duplicate_action`` — and fires the ``album_imported`` event to every registered
+        plugin listener, exactly as beets' pipeline does. So the bridge's own answers (not a
+        fabricated flag) drive the post-run branch state."""
+
+        plan = []
+
+        def __init__(self, lib, loghandler, paths, query):
+            self.lib = lib
+            self.loghandler = loghandler
+            self.paths = paths
+            self.query = query
+
+        def run(self):
+            for task in list(type(self).plan):
+                task.lookup_candidates([])
+                choice = self.choose_match(task)
+                if choice is Action.SKIP:
+                    continue
+                if task.duplicates:
+                    if self.get_duplicate_action(task, task.duplicates) is DuplicateAction.SKIP:
+                        continue
+                for listener in list(BeetsPlugin.listeners.get("album_imported", [])):
+                    listener(self.lib, task.album)
+
+    importer_mod.Action = Action
+    importer_mod.DuplicateAction = DuplicateAction
+    importer_mod.ImportTask = ImportTask
+    importer_mod.ImportSession = ImportSession
+    handle.importer = importer_mod
+    handle.Action = Action
+    handle.DuplicateAction = DuplicateAction
+    handle.ImportTask = ImportTask
+    handle.ImportSession = ImportSession
+
+    # ---- beets (package root) ----
+    beets_mod = types.ModuleType("beets")
+    beets_mod.__version__ = BEETS_VERSION
+    beets_mod.config = handle.config
+    beets_mod.plugins = plugins_mod
+    beets_mod.library = library_mod
+    beets_mod.ui = ui_mod
+    beets_mod.autotag = autotag_mod
+    beets_mod.dbcore = dbcore_mod
+    beets_mod.importer = importer_mod
+    handle.beets = beets_mod
+
+    for name, module in {
+        "beets": beets_mod,
+        "beets.library": library_mod,
+        "beets.plugins": plugins_mod,
+        "beets.ui": ui_mod,
+        "beets.autotag": autotag_mod,
+        "beets.dbcore": dbcore_mod,
+        "beets.dbcore.query": query_mod,
+        "beets.importer": importer_mod,
+    }.items():
+        sys.modules[name] = module
+
+    return handle
+
+
+def make_task(items=(), candidates=(), album=None, duplicates=()):
+    """Convenience task builder that resolves the currently-installed fake ``ImportTask`` (so the
+    bridge's class-level ``lookup_candidates`` stub takes effect on it)."""
+    return sys.modules["beets.importer"].ImportTask(
+        items=items, candidates=candidates, album=album, duplicates=duplicates
+    )
+
+
+def set_plan(*tasks):
+    """Set the tasks the installed session's ``run()`` will play."""
+    sys.modules["beets.importer"].ImportSession.plan = list(tasks)

--- a/packages/importer/test/bridge/run.sh
+++ b/packages/importer/test/bridge/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# The Python peer of `pnpm test:cov`: runs the beets-bridge unit tests under coverage.py at a 100%
+# branch-coverage gate (.coveragerc). Hermetic — creates a local .venv (gitignored) holding only
+# coverage; the tests fake `beets`, so no beets/ffmpeg/network is needed, just a `python3` on PATH
+# (which the bridge itself already requires). Wired into `pnpm check` and the CI `test` job.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+VENV=.venv
+if [[ ! -x "$VENV/bin/coverage" ]]; then
+  python3 -m venv "$VENV"
+  "$VENV/bin/pip" install --quiet 'coverage==7.6.10'
+fi
+
+"$VENV/bin/coverage" run -m unittest discover -s . -p 'test_*.py'
+"$VENV/bin/coverage" report

--- a/packages/importer/test/bridge/test_apply.py
+++ b/packages/importer/test/bridge/test_apply.py
@@ -1,0 +1,249 @@
+"""The `apply` verb: run a real ImportSession for a chosen outcome (a re-resolved candidate,
+as-is, or manual tags), honoring the duplicate action, and reporting applied / skipped-duplicate /
+the modeled refusals. Also the BridgeSession that answers every question beets would ask a human."""
+
+import json
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+import fakes
+from fakes import bridge
+
+
+def _apply_args(directory, candidate=None, tags=None, duplicate_action="skip"):
+    return SimpleNamespace(
+        directory=directory, candidate=candidate, tags=tags, duplicate_action=duplicate_action
+    )
+
+
+def _incumbent(path=b"/library/The Beatles/Love Me Do"):
+    return fakes.FakeAlbum(albumartist="The Beatles", album="Love Me Do", path=path)
+
+
+def _matching_candidate(album_id=fakes.MBID):
+    return fakes.FakeMatch(
+        info=fakes.FakeAlbumInfo(identifier=("MusicBrainz", album_id)),
+        distance=fakes.Distance(0.0),
+    )
+
+
+class RunApplyTest(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.intake = os.path.join(self._dir.name, "intake")
+        os.makedirs(self.intake)
+        with open(os.path.join(self.intake, "01 Love Me Do.mp3"), "wb") as handle:
+            handle.write(b"\0")
+        self.album = fakes.FakeAlbum(
+            albumartist="The Beatles", album="Love Me Do", path=b"/library/The Beatles/Love Me Do"
+        )
+
+    def test_an_as_is_import_moves_the_album_and_reports_applied(self):
+        handle = fakes.install()
+        fakes.set_plan(fakes.make_task(album=self.album))
+        result = bridge.run_apply(handle.config, _apply_args(self.intake))
+        self.assertEqual(
+            result,
+            {"status": "applied", "location": "/library/The Beatles/Love Me Do", "failures": []},
+        )
+
+    def test_as_is_stubs_the_candidate_lookup_so_no_network_is_touched(self):
+        """For as-is the bridge replaces the task's candidate lookup with a no-op that clears any
+        candidates and sets the recommendation to none — the pipeline flows straight to ASIS."""
+        handle = fakes.install()
+        task = fakes.make_task(candidates=[_matching_candidate()], album=self.album)
+        fakes.set_plan(task)
+        bridge.run_apply(handle.config, _apply_args(self.intake))
+        self.assertEqual(task.candidates, [])
+        self.assertEqual(task.rec, handle.autotag.Recommendation.none)
+        self.assertIsNone(task.cur_artist)
+        self.assertIsNone(task.cur_album)
+
+    def test_an_applied_album_with_no_path_reports_an_empty_location(self):
+        handle = fakes.install()
+        fakes.set_plan(fakes.make_task(album=fakes.FakeAlbum(path=b"")))
+        result = bridge.run_apply(handle.config, _apply_args(self.intake))
+        self.assertEqual(result["location"], "")
+
+    def test_a_chosen_candidate_is_re_resolved_by_id_and_imported(self):
+        handle = fakes.install()
+        task = fakes.make_task(candidates=[_matching_candidate()], album=self.album)
+        fakes.set_plan(task)
+        args = _apply_args(self.intake, candidate=f"MusicBrainz:{fakes.MBID}")
+        result = bridge.run_apply(handle.config, args)
+        self.assertEqual(result["status"], "applied")
+        # The candidate's album id is pinned as the deterministic ID lookup for the session.
+        self.assertEqual(handle.config["import"]["search_ids"].as_str_seq(), [fakes.MBID])
+
+    def test_a_malformed_candidate_reference_is_refused(self):
+        handle = fakes.install()
+        with self.assertRaises(bridge.BridgeRefusal) as caught:
+            bridge.run_apply(handle.config, _apply_args(self.intake, candidate="not-a-ref"))
+        self.assertEqual(caught.exception.kind, "bad-candidate-ref")
+
+    def test_a_candidate_that_no_longer_resolves_by_id_is_refused(self):
+        handle = fakes.install()
+        # The task offers a different release than the one requested, so no ID match is found.
+        fakes.set_plan(fakes.make_task(candidates=[_matching_candidate("some-other-id")], album=self.album))
+        args = _apply_args(self.intake, candidate="MusicBrainz:00000000-0000-0000-0000-000000000000")
+        with self.assertRaises(bridge.BridgeRefusal) as caught:
+            bridge.run_apply(handle.config, args)
+        self.assertEqual(caught.exception.kind, "candidate-not-found")
+        self.assertIn("00000000-0000-0000-0000-000000000000", str(caught.exception))
+
+    def test_a_skipped_duplicate_returns_the_incumbents_and_imports_nothing(self):
+        handle = fakes.install()
+        fakes.set_plan(fakes.make_task(album=self.album, duplicates=[_incumbent()]))
+        result = bridge.run_apply(handle.config, _apply_args(self.intake, duplicate_action="skip"))
+        self.assertEqual(
+            result,
+            {
+                "status": "skipped-duplicate",
+                "incumbents": [
+                    {"artist": "The Beatles", "album": "Love Me Do", "path": "/library/The Beatles/Love Me Do"}
+                ],
+            },
+        )
+
+    def test_a_replace_duplicate_action_still_imports_the_album(self):
+        handle = fakes.install()
+        fakes.set_plan(fakes.make_task(album=self.album, duplicates=[_incumbent()]))
+        result = bridge.run_apply(handle.config, _apply_args(self.intake, duplicate_action="replace"))
+        self.assertEqual(result["status"], "applied")
+
+    def test_a_keep_both_duplicate_action_still_imports_the_album(self):
+        handle = fakes.install()
+        fakes.set_plan(fakes.make_task(album=self.album, duplicates=[_incumbent()]))
+        result = bridge.run_apply(handle.config, _apply_args(self.intake, duplicate_action="keep-both"))
+        self.assertEqual(result["status"], "applied")
+
+    def test_manual_tags_apply_writes_the_tags_and_imports_as_is(self):
+        handle = fakes.install()
+        item = fakes.FakeItem(path=os.path.join(self.intake, "01 Love Me Do.mp3").encode())
+        fakes.set_plan(fakes.make_task(items=[item], album=self.album))
+        tags = {
+            "albumArtist": "The Beatles",
+            "album": "Love Me Do",
+            "tracks": [{"path": "01 Love Me Do.mp3", "title": "Love Me Do", "trackNumber": 1}],
+        }
+        result = bridge.run_apply(handle.config, _apply_args(self.intake, tags=json.dumps(tags)))
+        self.assertEqual(result["status"], "applied")
+        self.assertEqual(item.albumartist, "The Beatles")
+        self.assertEqual(item.title, "Love Me Do")
+
+    def test_an_import_that_moves_no_album_is_refused_as_nothing_imported(self):
+        handle = fakes.install()
+        fakes.set_plan()  # beets produced no importable album for the directory
+        with self.assertRaises(bridge.BridgeRefusal) as caught:
+            bridge.run_apply(handle.config, _apply_args(self.intake))
+        self.assertEqual(caught.exception.kind, "nothing-imported")
+
+    def test_a_post_import_pipeline_failure_after_a_move_is_recorded_not_retried(self):
+        """When session.run() raises AFTER an album already moved, the outcome is still `applied`
+        with the error captured in failures[] — not a plain retryable crash (design D7)."""
+        handle = fakes.install()
+        alpha = fakes.FakeAlbum(album="Alpha", path=b"/library/Alpha")
+        beta = fakes.FakeAlbum(album="Beta", path=b"/library/Beta")
+
+        seen = {"count": 0}
+
+        def fail_on_second(lib, album):  # a plugin listener that raises on the 2nd album
+            seen["count"] += 1
+            if seen["count"] >= 2:
+                raise RuntimeError("synthetic post-import failure recorded as an apply failure")
+
+        # Registered BEFORE the bridge appends its own listener, so album 1 is recorded then album 2
+        # raises before the bridge sees it.
+        handle.BeetsPlugin.listeners["album_imported"] = [fail_on_second]
+        fakes.set_plan(fakes.make_task(album=alpha), fakes.make_task(album=beta))
+        result = bridge.run_apply(handle.config, _apply_args(self.intake))
+        self.assertEqual(result["status"], "applied")
+        self.assertEqual(result["location"], "/library/Alpha")
+        self.assertEqual(
+            result["failures"],
+            [{"stage": "import-pipeline", "message": "synthetic post-import failure recorded as an apply failure"}],
+        )
+
+    def test_a_pipeline_failure_before_anything_moved_propagates_as_a_retryable_crash(self):
+        handle = fakes.install()
+
+        def fail_immediately(lib, album):
+            raise RuntimeError("network fault")
+
+        handle.BeetsPlugin.listeners["album_imported"] = [fail_immediately]
+        fakes.set_plan(fakes.make_task(album=self.album))
+        with self.assertRaises(RuntimeError):
+            bridge.run_apply(handle.config, _apply_args(self.intake))
+
+
+class ApplyManualTagsTest(unittest.TestCase):
+    def test_manual_tags_overwrite_album_and_matched_track_fields(self):
+        matched = fakes.FakeItem(path=b"/intake/01 A.mp3", title="old", track=0)
+        unmatched = fakes.FakeItem(path=b"/intake/02 B.mp3", title="keep-me", track=9)
+        task = SimpleNamespace(items=[matched, unmatched])
+        tags = {
+            "albumArtist": "New Artist",
+            "album": "New Album",
+            "year": 1999,
+            "tracks": [
+                {
+                    "path": "/somewhere/01 A.mp3",
+                    "title": "Track One",
+                    "trackNumber": 1,
+                    "artist": "Featured",
+                    "discNumber": 2,
+                }
+            ],
+        }
+        bridge.apply_manual_tags(task, tags)
+        self.assertEqual(matched.albumartist, "New Artist")
+        self.assertEqual(matched.album, "New Album")
+        self.assertEqual(matched.year, 1999)
+        self.assertEqual(matched.title, "Track One")
+        self.assertEqual(matched.track, 1)
+        self.assertEqual(matched.artist, "Featured")
+        self.assertEqual(matched.disc, 2)
+        # A file with no corresponding track keeps its existing title/track.
+        self.assertEqual(unmatched.title, "keep-me")
+        self.assertEqual(unmatched.track, 9)
+
+    def test_manual_tags_omit_optional_fields_when_absent(self):
+        item = fakes.FakeItem(path=b"/intake/01 A.mp3", artist="original", track=0)
+        item.year = 0
+        item.disc = 0
+        task = SimpleNamespace(items=[item])
+        tags = {
+            "albumArtist": "New Artist",
+            "album": "New Album",
+            "tracks": [{"path": "01 A.mp3", "title": "Track One", "trackNumber": 1}],
+        }
+        bridge.apply_manual_tags(task, tags)
+        self.assertEqual(item.title, "Track One")
+        self.assertEqual(item.year, 0)  # no year in tags -> untouched
+        self.assertEqual(item.artist, "original")  # no track artist -> untouched
+        self.assertEqual(item.disc, 0)  # no discNumber -> untouched
+
+
+class BridgeSessionAnswersTest(unittest.TestCase):
+    """The session must never pause or defer to a human: it declines resume and answers as-is to any
+    per-item question."""
+
+    def _session(self):
+        handle = fakes.install()
+        choice = {"mode": "as-is", "duplicate_action": "skip"}
+        return handle, bridge.make_session(handle.importer, handle.lib, "/intake", choice)
+
+    def test_the_session_never_resumes_a_previous_run(self):
+        _handle, session = self._session()
+        self.assertFalse(session.should_resume("/intake"))
+
+    def test_the_session_answers_as_is_to_an_individual_item_question(self):
+        handle, session = self._session()
+        self.assertIs(session.choose_item(object()), handle.Action.ASIS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/importer/test/bridge/test_bootstrap.py
+++ b/packages/importer/test/bridge/test_bootstrap.py
@@ -1,0 +1,134 @@
+"""The bridge's startup plumbing: the private contract channel, config bootstrap, and the
+session-overlay merge that guarantees non-interactivity and a MusicBrainz candidate source."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+import fakes
+from fakes import bridge
+
+
+class ContractChannelTest(unittest.TestCase):
+    """``claim_stdout`` must reserve a private duplicate of real stdout for the one JSON document and
+    divert fd 1 (everything beets and its subprocesses print) to stderr, so nothing corrupts the
+    contract channel."""
+
+    def test_claim_stdout_reserves_the_original_stdout_and_diverts_fd_1_to_stderr(self):
+        original_channel = bridge._contract_channel
+        saved_stdout = sys.stdout
+        saved_fd1 = os.dup(1)
+        tmp_path = tempfile.mkstemp()[1]
+        try:
+            capture_fd = os.open(tmp_path, os.O_WRONLY)
+            os.dup2(capture_fd, 1)  # fd 1 now points at the capture file
+            os.close(capture_fd)
+
+            bridge.claim_stdout()
+            # The private channel is a dup of fd 1 taken before it was repointed, so it still
+            # reaches the capture file; fd 1 itself now aliases stderr.
+            bridge.emit({"status": "ping"})
+
+            self.assertIs(sys.stdout, sys.stderr)
+        finally:
+            os.dup2(saved_fd1, 1)
+            os.close(saved_fd1)
+            sys.stdout = saved_stdout
+            if bridge._contract_channel is not None and bridge._contract_channel is not original_channel:
+                bridge._contract_channel.close()
+            bridge._contract_channel = original_channel
+
+        with open(tmp_path) as handle:
+            written = handle.read()
+        os.unlink(tmp_path)
+        self.assertEqual(json.loads(written), {"status": "ping"})
+
+    def test_emit_writes_one_newline_terminated_json_document(self):
+        import io
+
+        original_channel = bridge._contract_channel
+        channel = io.StringIO()
+        bridge._contract_channel = channel
+        try:
+            bridge.emit({"status": "valid", "kind": "x"})
+        finally:
+            bridge._contract_channel = original_channel
+        self.assertEqual(channel.getvalue(), '{"status": "valid", "kind": "x"}\n')
+
+
+class BootstrapTest(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.config_path = os.path.join(self._dir.name, "config.yaml")
+        with open(self.config_path, "w") as handle:
+            handle.write("directory: /x\n")
+
+    def test_a_missing_config_file_is_refused_before_any_beets_work(self):
+        fakes.install()
+        missing = os.path.join(self._dir.name, "does-not-exist.yaml")
+        with self.assertRaises(bridge.BridgeRefusal) as caught:
+            bridge.bootstrap(missing)
+        self.assertEqual(caught.exception.kind, "config-not-found")
+
+    def test_bootstrap_points_beetsdir_at_the_config_directory(self):
+        fakes.install()
+        saved = os.environ.get("BEETSDIR")
+
+        def restore():
+            if saved is None:
+                os.environ.pop("BEETSDIR", None)
+            else:
+                os.environ["BEETSDIR"] = saved
+
+        self.addCleanup(restore)
+        bridge.bootstrap(self.config_path)
+        self.assertEqual(os.environ["BEETSDIR"], self._dir.name)
+
+    def test_bootstrap_makes_the_users_exact_file_authoritative(self):
+        handle = fakes.install()
+        bridge.bootstrap(self.config_path)
+        self.assertEqual(handle.config.set_file_calls, [os.path.abspath(self.config_path)])
+
+    def test_the_musicbrainz_candidate_source_is_injected_when_the_plugin_list_omits_it(self):
+        """A plugin list written for an older beets carried no `musicbrainz` plugin; the bridge
+        injects it into the effective list so a candidate source always loads."""
+        handle = fakes.install(config_data={"plugins": ["chroma"]})
+        config = bridge.bootstrap(self.config_path)
+        self.assertEqual(config["plugins"].as_str_seq(), ["chroma", "musicbrainz"])
+
+    def test_the_musicbrainz_source_is_not_duplicated_when_already_present(self):
+        handle = fakes.install(config_data={"plugins": ["musicbrainz", "chroma"]})
+        config = bridge.bootstrap(self.config_path)
+        self.assertEqual(config["plugins"].as_str_seq(), ["musicbrainz", "chroma"])
+
+    def test_bootstrap_applies_the_session_overlay_before_loading_plugins(self):
+        """The overlay must win over the user's file, which requires it to be applied BEFORE
+        load_plugins() so plugins see the merged view. The load_plugins fake snapshots an
+        overlay-forced leaf (`import.resume`, forced to False) at call time; that the snapshot shows
+        the forced value proves the overlay was already visible when plugins loaded — a reorder or a
+        dropped `deep_set(config, …)` would leave the pre-overlay value here instead."""
+        handle = fakes.install()
+        bridge.bootstrap(self.config_path)
+        self.assertEqual(handle.plugins.load_plugins_calls, [True])
+        self.assertEqual(handle.plugins.overlay_at_load, [False])
+        self.assertIn("pluginload", [event for event, _ in handle.plugins.sent])
+
+
+class DeepSetTest(unittest.TestCase):
+    """The overlay merge recurses into nested sections and force-sets each leaf, so the forced
+    session keys (never interactive/resuming/incremental) win over the user's file."""
+
+    def test_deep_set_recurses_into_sections_and_sets_scalar_leaves(self):
+        view = fakes.FakeView(
+            {"import": {"resume": True}, "threaded": True}
+        )
+        bridge.deep_set(view, {"import": {"resume": False}, "threaded": False})
+        self.assertEqual(view["import"]["resume"].get(), False)
+        self.assertEqual(view["threaded"].get(), False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/importer/test/bridge/test_bridge.py
+++ b/packages/importer/test/bridge/test_bridge.py
@@ -1,0 +1,97 @@
+"""Unit tests for the beets bridge's pure control flow.
+
+The bridge imports beets only lazily inside its functions, so these tests inject a fake `beets`
+module into `sys.modules` and drive the bridge directly — no real beets install, ffmpeg, or audio
+files required. That keeps this tier fast and dependency-free (stdlib `unittest` under coverage.py),
+while pinning the behavior the contract tier (which replays recorded JSON) can never reach: the
+bridge's own Python control flow.
+
+The load-bearing case is the `except OSError: raise` / `except Exception: continue` split in
+`collect_items`. A real I/O fault (EACCES/EIO/a vanished file) must propagate so the crash surfaces
+as a retryable infrastructure error; only an unreadable/unsupported *format* may be silently skipped.
+A regression that reordered those handlers or widened the bare `except` would silently drop a file
+beets could have read once the fault cleared — the exact class of bug this bridge change fixed.
+"""
+
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+BRIDGE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "src",
+    "adapters",
+    "beets",
+    "bridge",
+)
+if BRIDGE_DIR not in sys.path:
+    sys.path.insert(0, BRIDGE_DIR)
+
+import bridge  # noqa: E402 — imported after the sys.path insert above
+
+
+def _install_fake_beets(from_path):
+    """Make `from beets import library` inside the bridge resolve to a stub whose
+    `library.Item.from_path` delegates to `from_path` (which may return a value or raise)."""
+    beets = types.ModuleType("beets")
+    library = types.ModuleType("beets.library")
+
+    class Item:
+        @staticmethod
+        def from_path(path):
+            return from_path(path)
+
+    library.Item = Item
+    beets.library = library
+    sys.modules["beets"] = beets
+    sys.modules["beets.library"] = library
+
+
+class CollectItemsTest(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        # os.walk needs a real entry to iterate; the byte content is irrelevant (from_path is faked).
+        with open(os.path.join(self._dir.name, "track.flac"), "wb") as handle:
+            handle.write(b"\0")
+        self.addCleanup(self._dir.cleanup)
+
+    def test_an_io_fault_reading_a_file_propagates(self):
+        """An OSError from reading a file is a retryable infrastructure fault, never a skip."""
+
+        def raise_io(_path):
+            raise OSError(5, "I/O error")
+
+        _install_fake_beets(raise_io)
+        with self.assertRaises(OSError):
+            bridge.collect_items(self._dir.name)
+
+    def test_an_unreadable_format_is_skipped_not_raised(self):
+        """A non-OSError (an unreadable/unsupported format) is skipped; an all-skipped directory
+        surfaces the modeled `no-audio-files` refusal, not the raw exception."""
+
+        def raise_format(_path):
+            raise ValueError("not an audio file beets can read")
+
+        _install_fake_beets(raise_format)
+        with self.assertRaises(bridge.BridgeRefusal) as caught:
+            bridge.collect_items(self._dir.name)
+        self.assertEqual(caught.exception.kind, "no-audio-files")
+
+    def test_readable_files_are_collected(self):
+        """A file beets can read is returned as an item."""
+        sentinel = object()
+        _install_fake_beets(lambda _path: sentinel)
+        self.assertEqual(bridge.collect_items(self._dir.name), [sentinel])
+
+    def test_a_missing_directory_is_refused(self):
+        """A path that is not a directory is a modeled refusal, before any file is read."""
+        _install_fake_beets(lambda _path: object())
+        with self.assertRaises(bridge.BridgeRefusal) as caught:
+            bridge.collect_items(os.path.join(self._dir.name, "does-not-exist"))
+        self.assertEqual(caught.exception.kind, "directory-not-found")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/importer/test/bridge/test_main.py
+++ b/packages/importer/test/bridge/test_main.py
@@ -1,0 +1,103 @@
+"""End-to-end drive of `main`: argument dispatch, the emitted contract document per verb, and the
+refusal-to-status mapping (doomed for propose/apply, invalid for validate). Exit code is always 0
+for a well-formed outcome; only unexpected crashes travel as non-zero."""
+
+import io
+import json
+import os
+import tempfile
+import unittest
+
+import fakes
+from fakes import bridge
+
+
+class MainTest(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.config_path = os.path.join(self._dir.name, "config.yaml")
+        with open(self.config_path, "w") as handle:
+            handle.write("plugins: [musicbrainz]\n")
+        self.intake = os.path.join(self._dir.name, "intake")
+        os.makedirs(self.intake)
+        with open(os.path.join(self.intake, "01 Love Me Do.mp3"), "wb") as handle:
+            handle.write(b"\0")
+        self.library = os.path.join(self._dir.name, "library")
+        os.makedirs(self.library)
+        self._saved_claim = bridge.claim_stdout
+        self._saved_channel = bridge._contract_channel
+        self.channel = io.StringIO()
+
+        def fake_claim():
+            bridge._contract_channel = self.channel
+
+        bridge.claim_stdout = fake_claim
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        bridge.claim_stdout = self._saved_claim
+        bridge._contract_channel = self._saved_channel
+
+    def _emitted(self):
+        return json.loads(self.channel.getvalue())
+
+    def _standard_config(self, handle):
+        handle.config = fakes.FakeConfig(
+            {
+                "plugins": ["musicbrainz"],
+                "library": os.path.join(self.library, "library.db"),
+                "directory": self.library,
+            }
+        )
+        handle.beets.config = handle.config
+
+    def test_propose_emits_a_proposal_document_and_returns_zero(self):
+        handle = fakes.install()
+        info = fakes.FakeAlbumInfo(identifier=("MusicBrainz", fakes.MBID), artist="The Beatles", album="Love Me Do")
+        handle.proposal = fakes.Proposal([fakes.FakeMatch(info=info, distance=fakes.Distance(0.0))])
+        code = bridge.main(["--config", self.config_path, "propose", self.intake, "--search-id", fakes.MBID])
+        self.assertEqual(code, 0)
+        emitted = self._emitted()
+        self.assertEqual(emitted["status"], "proposal")
+        self.assertEqual(emitted["candidates"][0]["album_id"], fakes.MBID)
+
+    def test_apply_emits_an_applied_document(self):
+        handle = fakes.install()
+        fakes.set_plan(fakes.make_task(album=fakes.FakeAlbum(path=b"/library/x")))
+        code = bridge.main(["--config", self.config_path, "apply", self.intake, "--as-is"])
+        self.assertEqual(code, 0)
+        self.assertEqual(self._emitted()["status"], "applied")
+
+    def test_validate_emits_a_valid_document(self):
+        handle = fakes.install()
+        self._standard_config(handle)
+        code = bridge.main(["--config", self.config_path, "validate"])
+        self.assertEqual(code, 0)
+        self.assertEqual(self._emitted()["status"], "valid")
+
+    def test_a_business_refusal_on_propose_is_emitted_as_doomed(self):
+        fakes.install()
+        missing = os.path.join(self._dir.name, "never-existed")
+        code = bridge.main(["--config", self.config_path, "propose", missing])
+        self.assertEqual(code, 0)
+        emitted = self._emitted()
+        self.assertEqual(emitted["status"], "doomed")
+        self.assertEqual(emitted["kind"], "directory-not-found")
+        self.assertIn("never-existed", emitted["reason"])
+
+    def test_a_business_refusal_on_validate_is_emitted_as_invalid(self):
+        handle = fakes.install()
+        handle.config = fakes.FakeConfig(
+            {"library": os.path.join(self.library, "library.db"), "directory": os.path.join(self._dir.name, "gone")}
+        )
+        handle.beets.config = handle.config
+        code = bridge.main(["--config", self.config_path, "validate"])
+        self.assertEqual(code, 0)
+        emitted = self._emitted()
+        self.assertEqual(emitted["status"], "invalid")
+        self.assertEqual(emitted["kind"], "library-directory-missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/importer/test/bridge/test_propose.py
+++ b/packages/importer/test/bridge/test_propose.py
@@ -1,0 +1,94 @@
+"""The `propose` verb: run the matcher over a staged directory, emit candidates sorted best-first,
+and surface any library incumbents the best candidate would duplicate."""
+
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+import fakes
+from fakes import bridge
+
+
+def _propose_args(directory, search_id=None, search_artist=None, search_album=None):
+    return SimpleNamespace(
+        directory=directory,
+        search_id=search_id,
+        search_artist=search_artist,
+        search_album=search_album,
+    )
+
+
+class RunProposeTest(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.intake = os.path.join(self._dir.name, "intake")
+        os.makedirs(self.intake)
+        with open(os.path.join(self.intake, "01 Love Me Do.mp3"), "wb") as handle:
+            handle.write(b"\0")
+
+    def _candidate(self, album_id, distance, artist="The Beatles", album="Love Me Do"):
+        info = fakes.FakeAlbumInfo(
+            identifier=("MusicBrainz", album_id), artist=artist, album=album
+        )
+        item = fakes.FakeItem(path=b"/intake/01.mp3", title="Love Me Do", track=1, length=143.0)
+        track = fakes.FakeTrackInfo(title="Love Me Do", index=1)
+        return fakes.FakeMatch(
+            info=info,
+            distance=fakes.Distance(distance, penalties=[], tracks={track: 0.0}),
+            mapping={item: track},
+        )
+
+    def test_a_directory_with_no_incumbent_emits_the_candidates_and_no_duplicates(self):
+        handle = fakes.install()
+        handle.proposal = fakes.Proposal([self._candidate(fakes.MBID, 0.0)])
+        result = bridge.run_propose(handle.config, _propose_args(self.intake, search_id=fakes.MBID))
+        self.assertEqual(result["status"], "proposal")
+        self.assertEqual(len(result["candidates"]), 1)
+        self.assertEqual(result["candidates"][0]["album_id"], fakes.MBID)
+        self.assertEqual(result["duplicates"], [])
+        # A --search-id pins the ID lookup passed to the matcher.
+        self.assertEqual(handle.tag_calls[0]["search_ids"], [fakes.MBID])
+
+    def test_free_search_passes_no_id_to_the_matcher(self):
+        handle = fakes.install()
+        handle.proposal = fakes.Proposal([self._candidate(fakes.MBID, 0.0)])
+        bridge.run_propose(handle.config, _propose_args(self.intake))
+        self.assertEqual(handle.tag_calls[0]["search_ids"], [])
+
+    def test_candidates_are_ordered_best_first_by_distance(self):
+        handle = fakes.install()
+        far = self._candidate("far-id", 0.6, album="Basement Tape")
+        near = self._candidate("near-id", 0.1)
+        handle.proposal = fakes.Proposal([far, near])
+        result = bridge.run_propose(handle.config, _propose_args(self.intake))
+        self.assertEqual(
+            [candidate["album_id"] for candidate in result["candidates"]],
+            ["near-id", "far-id"],
+        )
+
+    def test_the_best_candidates_incumbents_are_reported_as_duplicates(self):
+        handle = fakes.install()
+        handle.lib = fakes.FakeLib(
+            albums=[fakes.FakeAlbum(albumartist="The Beatles", album="Love Me Do", path=b"/library/x")]
+        )
+        handle.proposal = fakes.Proposal([self._candidate(fakes.MBID, 0.0)])
+        result = bridge.run_propose(handle.config, _propose_args(self.intake, search_id=fakes.MBID))
+        self.assertEqual(
+            result["duplicates"],
+            [{"artist": "The Beatles", "album": "Love Me Do", "path": "/library/x"}],
+        )
+
+    def test_no_candidates_yields_an_empty_proposal_and_no_incumbent_lookup(self):
+        handle = fakes.install()
+        handle.lib = fakes.FakeLib(albums=[fakes.FakeAlbum(album="anything")])
+        handle.proposal = fakes.Proposal([])
+        result = bridge.run_propose(handle.config, _propose_args(self.intake))
+        self.assertEqual(result, {"status": "proposal", "candidates": [], "duplicates": []})
+        # With no best candidate there is nothing to check the library against.
+        self.assertEqual(handle.lib.album_queries, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/importer/test/bridge/test_serialize.py
+++ b/packages/importer/test/bridge/test_serialize.py
@@ -1,0 +1,166 @@
+"""The pure serializers that shape the JSON a review reads: per-track diffs, penalties, album
+fields, and incumbent lookup. These freeze the headline contract the change added."""
+
+import os
+import unittest
+
+import fakes
+from fakes import bridge
+
+
+class IdentifierOfTest(unittest.TestCase):
+    def test_a_populated_identifier_is_returned_as_source_and_string_id(self):
+        info = fakes.FakeAlbumInfo(identifier=("MusicBrainz", fakes.MBID))
+        self.assertEqual(bridge.identifier_of(info), ("MusicBrainz", fakes.MBID))
+
+    def test_a_missing_source_or_id_becomes_empty_strings_never_none(self):
+        info = fakes.FakeAlbumInfo(identifier=(None, None))
+        self.assertEqual(bridge.identifier_of(info), ("", ""))
+
+
+class SerializeTrackTest(unittest.TestCase):
+    def test_a_mapped_track_carries_proposed_tags_current_tags_and_distance(self):
+        item = fakes.FakeItem(
+            path=b"/intake/01 Love Me Do.mp3",
+            title="Love Me Do",
+            artist="The Beatles",
+            track=1,
+            length=143.07265306122449,
+        )
+        track = fakes.FakeTrackInfo(title="Love Me Do", index=1)
+        result = bridge.serialize_track(item, track, 0.0)
+        self.assertEqual(
+            result,
+            {
+                "path": "/intake/01 Love Me Do.mp3",
+                "title": "Love Me Do",
+                "index": 1,
+                "current": {
+                    "title": "Love Me Do",
+                    "artist": "The Beatles",
+                    "track": 1,
+                    "length": 143.07265306122449,
+                },
+                "distance": 0.0,
+            },
+        )
+
+    def test_an_unreadable_duration_is_omitted_never_recorded_as_a_false_zero(self):
+        item = fakes.FakeItem(path=b"/intake/02.mp3", title="", artist="", track=0, length=0)
+        result = bridge.serialize_track(item, fakes.FakeTrackInfo(), 0.5)
+        self.assertNotIn("length", result["current"])
+
+
+class SerializeMatchTest(unittest.TestCase):
+    def test_a_match_serializes_tracks_penalties_extras_and_album_fields(self):
+        item = fakes.FakeItem(
+            path=b"/intake/01 Luv Me Do.mp3",
+            title="Luv Me Do",
+            artist="The Beatles",
+            track=1,
+            length=143.0,
+        )
+        track = fakes.FakeTrackInfo(title="Love Me Do", index=1)
+        extra_item = fakes.FakeItem(path=b"/intake/99 Bonus.mp3", title="Bonus Beatz", track=9)
+        extra_track = fakes.FakeTrackInfo(title="P.S. I Love You", index=2)
+        info = fakes.FakeAlbumInfo(
+            identifier=("MusicBrainz", fakes.MBID),
+            artist="The Beatles",
+            album="Love Me Do",
+            year=1988,
+            media="8cm CD",
+            label="Parlophone",
+            catalognum="CD3R 4949",
+            country="XE",
+            albumdisambig="mini CD",
+        )
+        distance = fakes.Distance(
+            0.073,
+            penalties=[("unmatched_tracks", 0.051), ("tracks", 0.021)],
+            tracks={track: 0.125},
+        )
+        match = fakes.FakeMatch(
+            info=info,
+            distance=distance,
+            mapping={item: track},
+            extra_items=[extra_item],
+            extra_tracks=[extra_track],
+        )
+        result = bridge.serialize_match(match)
+        self.assertEqual(result["data_source"], "MusicBrainz")
+        self.assertEqual(result["album_id"], fakes.MBID)
+        self.assertEqual(result["distance"], 0.073)
+        self.assertEqual(
+            result["penalties"],
+            [
+                {"name": "unmatched_tracks", "amount": 0.051},
+                {"name": "tracks", "amount": 0.021},
+            ],
+        )
+        self.assertEqual(result["tracks"][0]["title"], "Love Me Do")
+        self.assertEqual(result["tracks"][0]["distance"], 0.125)
+        self.assertEqual(
+            result["extra_items"],
+            [{"path": "/intake/99 Bonus.mp3", "title": "Bonus Beatz", "track": 9}],
+        )
+        self.assertEqual(result["extra_tracks"], [{"title": "P.S. I Love You", "index": 2}])
+        self.assertEqual(
+            result["album_fields"],
+            {
+                "year": 1988,
+                "media": "8cm CD",
+                "label": "Parlophone",
+                "catalognum": "CD3R 4949",
+                "country": "XE",
+                "albumdisambig": "mini CD",
+            },
+        )
+
+    def test_a_perfect_match_has_empty_penalties_and_extras(self):
+        item = fakes.FakeItem(path=b"/intake/01.mp3", title="Love Me Do", track=1, length=143.0)
+        track = fakes.FakeTrackInfo(title="Love Me Do", index=1)
+        info = fakes.FakeAlbumInfo(identifier=("MusicBrainz", fakes.MBID), artist="The Beatles", album="Love Me Do")
+        match = fakes.FakeMatch(
+            info=info,
+            distance=fakes.Distance(0.0, penalties=[], tracks={track: 0.0}),
+            mapping={item: track},
+        )
+        result = bridge.serialize_match(match)
+        self.assertEqual(result["penalties"], [])
+        self.assertEqual(result["extra_items"], [])
+        self.assertEqual(result["extra_tracks"], [])
+
+
+class SerializeAlbumTest(unittest.TestCase):
+    def test_an_album_with_a_path_is_decoded(self):
+        album = fakes.FakeAlbum(albumartist="The Beatles", album="Love Me Do", path=b"/library/The Beatles/Love Me Do")
+        self.assertEqual(
+            bridge.serialize_album(album),
+            {"artist": "The Beatles", "album": "Love Me Do", "path": "/library/The Beatles/Love Me Do"},
+        )
+
+    def test_an_album_without_a_path_serializes_an_empty_path(self):
+        album = fakes.FakeAlbum(albumartist="The Beatles", album="Love Me Do", path=b"")
+        self.assertEqual(bridge.serialize_album(album)["path"], "")
+
+
+class FindIncumbentsTest(unittest.TestCase):
+    def test_incumbents_are_the_library_albums_matching_the_candidate_artist_and_album(self):
+        fakes.install()
+        lib = fakes.FakeLib(
+            albums=[fakes.FakeAlbum(albumartist="The Beatles", album="Love Me Do", path=b"/library/x")]
+        )
+        result = bridge.find_incumbents(lib, "The Beatles", "Love Me Do")
+        self.assertEqual(result, [{"artist": "The Beatles", "album": "Love Me Do", "path": "/library/x"}])
+        # The lookup is an AND of exact artist+album matches.
+        query = lib.album_queries[0]
+        self.assertEqual(len(query.subqueries), 2)
+        self.assertEqual({q.field for q in query.subqueries}, {"albumartist", "album"})
+
+    def test_no_matching_library_album_yields_no_incumbents(self):
+        fakes.install()
+        self.assertEqual(bridge.find_incumbents(fakes.FakeLib(albums=[]), "X", "Y"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/importer/test/bridge/test_validate.py
+++ b/packages/importer/test/bridge/test_validate.py
@@ -1,0 +1,85 @@
+"""The `validate` verb: parse the user's config, check the library database and directory, and
+report the effective merged session view — the startup gate."""
+
+import os
+import tempfile
+import unittest
+
+import fakes
+from fakes import bridge
+
+
+class RunValidateTest(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._dir.cleanup)
+        self.library = os.path.join(self._dir.name, "library")
+        self.beets_dir = os.path.join(self._dir.name, "beets")
+        os.makedirs(self.library)
+        os.makedirs(self.beets_dir)
+        self.db_path = os.path.join(self.beets_dir, "library.db")
+
+    def test_a_well_formed_config_reports_the_effective_session_view(self):
+        handle = fakes.install(
+            config_data={
+                "plugins": ["musicbrainz"],
+                "library": self.db_path,
+                "directory": self.library,
+            }
+        )
+        result = bridge.run_validate(handle.config)
+        self.assertEqual(
+            result,
+            {
+                "status": "valid",
+                "beets_version": fakes.BEETS_VERSION,
+                "library_database": self.db_path,
+                "library_directory": self.library,
+                "plugins": ["musicbrainz"],
+                "overlay": bridge.SESSION_OVERLAY,
+            },
+        )
+
+    def test_a_database_named_without_a_directory_resolves_against_the_current_directory(self):
+        """A bare `library.db` (no parent in the path) is checked against '.', which exists — so a
+        directory-less database name still validates."""
+        handle = fakes.install(
+            config_data={"plugins": [], "library": "library.db", "directory": self.library}
+        )
+        result = bridge.run_validate(handle.config)
+        self.assertEqual(result["status"], "valid")
+
+    def test_an_unusable_config_is_reported_as_invalid(self):
+        handle = fakes.install(
+            config_data={"library": self.db_path, "directory": self.library},
+            filename_error=RuntimeError("bad template"),
+        )
+        with self.assertRaises(bridge.BridgeRefusal) as caught:
+            bridge.run_validate(handle.config)
+        self.assertEqual(caught.exception.kind, "config-invalid")
+
+    def test_a_missing_library_directory_is_reported_as_invalid(self):
+        handle = fakes.install(
+            config_data={
+                "library": self.db_path,
+                "directory": os.path.join(self._dir.name, "nonexistent"),
+            }
+        )
+        with self.assertRaises(bridge.BridgeRefusal) as caught:
+            bridge.run_validate(handle.config)
+        self.assertEqual(caught.exception.kind, "library-directory-missing")
+
+    def test_a_missing_database_directory_is_reported_as_invalid(self):
+        handle = fakes.install(
+            config_data={
+                "library": os.path.join(self._dir.name, "gone", "library.db"),
+                "directory": self.library,
+            }
+        )
+        with self.assertRaises(bridge.BridgeRefusal) as caught:
+            bridge.run_validate(handle.config)
+        self.assertEqual(caught.exception.kind, "library-db-missing")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Two follow-ups from the whole-codebase review sweep

Both are **test-only** (no product code changed beyond one justified coverage waiver; no version bump, no release). They close the two deferrals noted in the v3.10.1 review-hardening PR.

### 1. slskd contract recorder — scrub secrets/PII + close the events.json query drift
The review flagged that the recorder now emits an `offset/limit` query block the committed `events.json` lacked. Investigating a live re-record surfaced two bigger problems and one coupling:
- **Latent secret/PII leak (the real fix):** `record/slskd.ts` wrote *whole* `/api/v0/options` (Soulseek **username + password**, listen ports, blacklist, integrations) and *whole* event payloads (peer usernames, `remoteFilename` share tokens) to committed, **public-repo** fixtures — `sanitize()` aliases `username` *keys* and strips share prefixes but can't reach inside the JSON-encoded event `data` string. Added `projectOptions` (keep only `directories`) and `projectEvents` (keep only `DownloadFileComplete`, trimmed to `localFilename` + `transfer.id`, id normalized) so a full re-record can never leak secrets or third-party PII.
- **Coupling documented:** `events.json` is *not* independently re-recordable — the staged-path resolver matches a `DownloadFileComplete` to the polled transfer by id, so it stays coupled to `transfers-poll.json`. Only the missing `query` block was the actual drift; it's now added, with the coupling documented on `projectEvents`.

### 2. Native Python test tier for the beets bridge, at 100% coverage
`bridge.py`'s pure Python control flow — the load-bearing `collect_items` `except OSError: raise` vs `except Exception: continue` split (the exact silent-file-drop class the v3.10.1 change fixed), plus every verb (propose/apply/validate), the private contract channel, refusals, duplicate handling, and argparse dispatch — was reachable by **no CI test**: the contract tier replays recorded JSON and never executes the Python.

Approach was **research-backed** (polyglot-testing prior art + expert consensus): a *native* Python runner with its *own* native coverage gate — **not** a vitest-shell-out (a smell that yields zero real coverage), and **not** a single merged cross-language coverage number (dilution + incommensurable branch semantics). Per-language native gating mirrors the repo's existing model.
- Added `packages/importer/test/bridge/`: stdlib-`unittest` tests under `coverage.py` (branch, `fail_under=100`) driven by **faithful faked beets** modules — the fake `ImportSession.run()` replays the bridge's own hooks and fires `album_imported`, so post-run state comes from the bridge's logic, not fabricated flags (verified by a test-quality review).
- Hermetic `run.sh` bootstraps a coverage-only `.venv` (no beets/ffmpeg needed — only `python3`, which the bridge already requires). Wired into `pnpm check` and the CI `test` job via `setup-python`. `.venv` ignored by git/eslint/prettier.
- bridge.py reaches **100% line+branch** with a single justified `# pragma: no cover` on a genuinely-unreachable defensive arm (the only bridge.py change — a comment).

Both changes are gate-green (`pnpm check`), and the Python suite passed a test-quality review (findings applied: fiction-test removed, bootstrap ordering contract pinned, leaked global restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
