### PR TITLE
ci: point contract-drift workflow at relocated drift scripts

### DIFF
--- a/.github/workflows/contract-drift.yml
+++ b/.github/workflows/contract-drift.yml
@@ -40,7 +40,7 @@ jobs:
         # pipefail so `tee` doesn't mask a non-zero exit from the drift script.
         run: |
           set -o pipefail
-          pnpm tsx test/contract/drift/musicbrainz.ts 2>&1 | tee mb.log
+          pnpm tsx packages/downloader/test/contract/drift/musicbrainz.ts 2>&1 | tee mb.log
 
       - name: Wait for slskd swagger
         run: |
@@ -60,7 +60,7 @@ jobs:
         # pipefail so `tee` doesn't mask a non-zero exit from the drift script.
         run: |
           set -o pipefail
-          pnpm tsx test/contract/drift/slskd.ts 2>&1 | tee slskd.log
+          pnpm tsx packages/downloader/test/contract/drift/slskd.ts 2>&1 | tee slskd.log
 
       - name: Open or refresh drift issue
         if: steps.mb.outcome == 'failure' || steps.slskd.outcome == 'failure'


### PR DESCRIPTION
## Summary
- The v3.0.0 workspace restructure moved the drift scripts to `packages/downloader/test/contract/drift/`, but the scheduled contract-drift workflow still invoked them at the old repo-root path.
- Every scheduled run since has failed with `ERR_MODULE_NOT_FOUND` and filed a false drift issue.
- Updates the two `pnpm tsx` invocations to the new paths.

## Verification
- `pnpm tsx packages/downloader/test/contract/drift/musicbrainz.ts` run locally from the repo root: all fixtures replay green against live MusicBrainz — no actual drift.
- The slskd script resolves and runs from the root as well (its pinned-spec paths are `import.meta.url`-relative, so cwd doesn't matter).

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)