### PR TITLE
test(e2e): read the detail page's status in its own new language

### DIFF
--- a/test/e2e/full-loop.e2e.test.ts
+++ b/test/e2e/full-loop.e2e.test.ts
@@ -67,10 +67,11 @@ describe('out-of-process full loop (web interface, real socket)', () => {
   it('drives intent → download → deposit → seam → beets import to a terminal outcome', async () => {
     const acquisitionId = await submitAcquisition(MBID);
 
-    // Downloader side: resolve (MB stub) → search/rank/download (slskd stub, stateful poll) →
-    // real ffmpeg probe of the seeded FLAC → real filesystem deposit → Fulfilled over the UI.
+    // The whole loop over the UI's own language: resolve (MB stub) → search/rank/download (slskd
+    // stub, stateful poll) → real ffmpeg probe of the seeded FLAC → real filesystem deposit →
+    // seam → beets auto-apply — settled only when the page says "In your library".
     const status = await pollUntilTerminal(acquisitionId);
-    expect(status).toBe('Fulfilled');
+    expect(status).toBe('In your library');
     expect(existsSync(join(DEPOSIT_DIR, 'Test_Artist', 'Test_Album_(2020)'))).toBe(true);
 
     // Seam handoff: the importer's catch-up subscription consumed acquisition.fulfilled and

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -109,7 +109,18 @@ export async function readStatus(id: string): Promise<string | undefined> {
   return /data-testid="status"[^>]*>([^<]+)</.exec(html)?.[1]?.trim();
 }
 
-const TERMINAL = new Set(['Fulfilled', 'Exhausted', 'Conflicted', 'Cancelled']);
+// The detail page's status marker speaks the human status phrases (legible-acquisition-history),
+// and a delivery only reads as settled once its import applied — so "terminal" here means the
+// story's true endings, not the downloader enum: the loop now proves the WHOLE pipeline through
+// beets before it returns.
+const TERMINAL = new Set([
+  'In your library',
+  'No usable download found',
+  'Stopped \u{2014} destination occupied',
+  'Cancelled',
+  'Couldn\u{2019}t identify the release',
+  'Import rejected',
+]);
 
 export async function pollUntilTerminal(id: string, timeoutMs = 90_000): Promise<string> {
   const deadline = Date.now() + timeoutMs;

--- a/test/e2e/restart-mid-download.e2e.test.ts
+++ b/test/e2e/restart-mid-download.e2e.test.ts
@@ -119,7 +119,7 @@ describe('restart resumption mid-download (reactor-durability)', () => {
 
     // The startup re-drive re-derives the Download effect and the adapter re-attaches to the
     // source's transfer: the acquisition reaches its terminal outcome instead of orphaning.
-    expect(await pollUntilTerminal(acquisitionId, 180_000)).toBe('Fulfilled');
+    expect(await pollUntilTerminal(acquisitionId, 180_000)).toBe('In your library');
 
     // The candidate was never downloaded a second time: one enqueue across both process lives.
     expect(await enqueueCount()).toBe(1);

--- a/test/e2e/restart.e2e.test.ts
+++ b/test/e2e/restart.e2e.test.ts
@@ -47,7 +47,7 @@ describe('restart resilience (durable stores + subscription checkpoint)', () => 
     // Fulfilment committed (observable over the interface) and the seam handoff durably recorded
     // in the importer's own store — while the blocked bridge guarantees the import cannot finish.
     const status = await pollUntilTerminal(acquisitionId);
-    expect(status).toBe('Fulfilled');
+    expect(status).toBe('In your library');
     await pollForEvent(IMPORTER_DB, 'ImportRequested');
     expect(countEvents(IMPORTER_DB, 'ImportApplied')).toBe(0);
 
@@ -64,7 +64,7 @@ describe('restart resilience (durable stores + subscription checkpoint)', () => 
     expect(countEvents(IMPORTER_DB, 'ImportApplied')).toBe(1);
 
     // And the interface still tells the same story after the restart.
-    expect(await pollUntilTerminal(acquisitionId)).toBe('Fulfilled');
+    expect(await pollUntilTerminal(acquisitionId)).toBe('In your library');
     expect(await reviewQueueEmpty()).toBe(true);
   });
 });


### PR DESCRIPTION
The v3.14.0 merge's out-of-process E2E gate failed (nothing was published — the gate ordering worked as designed): the e2e helpers poll the detail page's `data-testid="status"` marker for raw enum identifiers (`Fulfilled` et al.), and after #113 that marker speaks the human status phrases.

Fix: the `TERMINAL` set becomes the story's true ending phrases, and the loop settles only at **"In your library"** — which upgrades the assertion: the poll now proves the whole pipeline through the beets apply, not just the downloader's deposit. `'Downloading'` (restart-mid-download) is phrase-identical and unchanged.

Test-only change (no version bump); the merge re-runs the pipeline and, on a green gate, publishes v3.14.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)