### PR TITLE
test(e2e): observe the blocked-import restart window via the delivered narration

### DIFF
--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -134,6 +134,37 @@ export async function pollUntilTerminal(id: string, timeoutMs = 90_000): Promise
   }
 }
 
+/**
+ * Poll until the detail page's status marker reads one of the given phrases. For observing a
+ * mid-story state the terminal poll deliberately never settles on (e.g. delivered-and-importing
+ * while a test has the bridge gated shut).
+ */
+export async function pollForStatus(
+  id: string,
+  phrases: ReadonlySet<string>,
+  timeoutMs = 90_000,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const status = await readStatus(id);
+    if (status !== undefined && phrases.has(status)) return status;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `acquisition ${id} never showed ${[...phrases].join(' / ')} (last: ${status})`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+}
+
+/** The delivered-and-importing narration: the downloader has deposited; the import is working. */
+export const DELIVERED_NARRATION: ReadonlySet<string> = new Set([
+  'Delivered \u{2014} confirming the import',
+  'Matching against the library',
+  'Adding to the library',
+  'Waiting for your review',
+]);
+
 /** True when the review queue page shows its explicit empty marker. */
 export async function reviewQueueEmpty(): Promise<boolean> {
   const res = await fetch(`${BASE_URL}/reviews`, {

--- a/test/e2e/restart.e2e.test.ts
+++ b/test/e2e/restart.e2e.test.ts
@@ -5,10 +5,12 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import {
   BASE_URL,
   DATA_DIR,
+  DELIVERED_NARRATION,
   IMPORTER_DB,
   MBID,
   countEvents,
   pollForEvent,
+  pollForStatus,
   pollUntilTerminal,
   reviewQueueEmpty,
   seedStagedFixture,
@@ -44,10 +46,11 @@ describe('restart resilience (durable stores + subscription checkpoint)', () => 
   it('completes the import exactly once across a kill between fulfilment and import', async () => {
     const acquisitionId = await submitAcquisition(MBID);
 
-    // Fulfilment committed (observable over the interface) and the seam handoff durably recorded
-    // in the importer's own store — while the blocked bridge guarantees the import cannot finish.
-    const status = await pollUntilTerminal(acquisitionId);
-    expect(status).toBe('In your library');
+    // Fulfilment committed (observable over the interface as the delivered-and-importing
+    // narration — the honest UI never claims an ending here) and the seam handoff durably
+    // recorded in the importer's own store, while the blocked bridge guarantees the import
+    // cannot finish.
+    await pollForStatus(acquisitionId, DELIVERED_NARRATION);
     await pollForEvent(IMPORTER_DB, 'ImportRequested');
     expect(countEvents(IMPORTER_DB, 'ImportApplied')).toBe(0);
 


### PR DESCRIPTION
Second e2e-language fix after #114: the restart-resilience test's first wait polled for a terminal status during its deliberately-blocked import window — a state the post-#113 UI narrates honestly as delivered-and-importing (never an ending), so the poll could not settle. The wait now observes that narration (`pollForStatus` + `DELIVERED_NARRATION`); the post-restart assertion still settles at "In your library". full-loop passed on the previous run; restart-mid-download's flow is unaffected (its import is unblocked).

Test-only; merge re-runs the pipeline toward the v3.14.0 publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)