### PR TITLE
fix(importer): complete the beets image environment — flac binary + discogs extra (v3.15.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.15.1](https://github.com/jgchk/music-downloader/compare/v3.15.0...v3.15.1) (2026-08-02)
+
+### Bug Fixes
+
+* **importer:** complete the beets image environment — flac binary + discogs extra ([f89d559](https://github.com/jgchk/music-downloader/commit/f89d559d36d265e6a40df349687757450d587ffe))
 ## [3.15.0](https://github.com/jgchk/music-downloader/compare/v3.14.0...v3.15.0) (2026-08-02)
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,12 +36,12 @@ RUN rm -rf node_modules packages/downloader/node_modules packages/importer/node_
 # --- Runtime: Node + both modules' OS-level dependencies ------------------------------------------
 # ffmpeg serves the downloader's audio probe; python3 runs the stateless beets bridge; the venv
 # pins beets at the contract-tested version (packages/importer/src/adapters/beets/bridge/
-# requirements.txt); fpcalc (libchromaprint-tools), oggz-tools and opus-tools let the user's beets
-# plugin chain run unmodified.
+# requirements.txt); fpcalc (libchromaprint-tools), flac (badfiles' FLAC validator), oggz-tools
+# and opus-tools let the user's beets plugin chain run unmodified.
 FROM node:24.18.0-slim AS runtime
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-    python3 python3-venv ffmpeg libchromaprint-tools oggz-tools opus-tools \
+    python3 python3-venv ffmpeg libchromaprint-tools flac oggz-tools opus-tools \
   && rm -rf /var/lib/apt/lists/*
 
 COPY packages/importer/src/adapters/beets/bridge/requirements.txt /opt/beets-bridge/requirements.txt

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "private": true,
   "description": "An extensible, event-sourced music downloader and importer — a modular monolith.",
   "type": "module",

--- a/packages/importer/src/adapters/beets/bridge/requirements.txt
+++ b/packages/importer/src/adapters/beets/bridge/requirements.txt
@@ -2,5 +2,5 @@
 # deliberate event: re-record the contract fixtures (test/contract/README.md) and re-run the gate.
 # The extras cover the production plugin chain's Python dependencies (binaries — ffmpeg, fpcalc,
 # oggz-tools, opus-tools — are baked into the runtime image by the Dockerfile).
-beets[fetchart,embedart,chroma,lastgenre,lyrics,scrub]==2.12.0
+beets[fetchart,embedart,chroma,discogs,lastgenre,lyrics,scrub]==2.12.0
 requests>=2.32.5


### PR DESCRIPTION
Two Docker-image gaps surfaced by the 2026-08-02 stalled-apply incident (the chroma abort on The Isley Brothers — 3+3):

- **`flac` binary missing from the runtime image** — the `badfiles` plugin warned `command not found: flac` on every FLAC file, silently skipping FLAC validation. Added `flac` to the runtime stage's apt packages.
- **`discogs` plugin failed to import** — the beets pin omitted the `discogs` extra, so `python3-discogs-client` was never installed and beets dropped the plugin with a traceback on every run. Added `discogs` to the extras.

No production code changes; the beets version pin (2.12.0) is unchanged, so the bridge contract fixtures stay valid.

**Verification:** built the runtime environment layers with an assertion layer appended — `which flac` and `python3 -c "from beetsplug import discogs"` both pass inside the image. Full gate green including the bridge's Python tier with a freshly resolved venv (new requirements install cleanly).

Not addressed here (tracked in session notes): `chroma` remains disabled in flight's beets config after its chromaprint abort; the stalled-import visibility/redrive product gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)