### PR TITLE
docs(openspec): draft redrivable-stalled-imports proposal

### DIFF
--- a/openspec/changes/redrivable-stalled-imports/.openspec.yaml
+++ b/openspec/changes/redrivable-stalled-imports/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/redrivable-stalled-imports/design.md
+++ b/openspec/changes/redrivable-stalled-imports/design.md
@@ -1,0 +1,122 @@
+# Design — redrivable-stalled-imports
+
+## Context
+
+See `proposal.md` for motivation (the 2026-08-02 chromaprint incident; recovery required manual
+store surgery — the procedure is recorded in session memory `import-reactor-redrive-procedure`).
+
+What already exists and is NOT changed here:
+
+- The reactor's durable retry budget, dead-lettering, and stalled exposure
+  (`import-management` spec "A failing import effect's retry budget is durable…"): budgets live
+  in `parked_effects` keyed by the event's `global_seq`; dead letters carry the owning
+  `stream_id`; the stalled read model seeds from the dead-letter store at boot; `clearStalled`
+  clears dead letters + exposure when any non-failing event of the stream is processed
+  (`packages/importer/src/application/import/reactor.ts`).
+- `ApplyingState` retains `directory` and `mode` (`state.ts`), and `react()` already derives the
+  Apply effect purely from that state for existing arms (`react.ts`).
+- The import status DTO already exposes `stalled?: true` (additive, decided).
+
+## Goals / Non-Goals
+
+**Goals:** the redrive is one domain event riding the existing durability machinery; the UI
+renders the decided stalled fact and offers one honest affordance; recovery never touches the
+store by hand again.
+
+**Non-Goals:** no automatic redrive policy (a stall means something environmental needs a human
+first — the incident's fix was a config change); no reactor/durability changes; no import detail
+page; no downloader involvement; no liveness/pacing changes (a stalled page keeps its poll — the
+retry resolves on the very page being watched).
+
+## Decisions
+
+### D1 — The redrive is a domain event; the durability machinery does the rest
+
+New command `RetryApply` → event `ApplyRetryRequested` (no payload beyond the standard
+metadata):
+
+- `decide`: terminal states absorb (`ok([])`, the established terminal-absorption pattern);
+  phase `applying` emits `ApplyRetryRequested`; every other phase is the modeled `illegal`
+  refusal.
+- `evolve`: identity on the applying state — the event is a re-drive fact, not a state change.
+- `react`: `case 'ApplyRetryRequested'` mirrors the existing arms —
+  `state.phase === 'applying' ? [{ type: 'Apply', directory: state.directory, mode: state.mode }] : []`.
+
+Everything else is emergent from the shipped durability design, deliberately: the new event has
+a new `global_seq`, so `parked_effects` starts a fresh attempt tally (fresh budget by
+construction); processing the event is a non-failing stream event, so `clearStalled` clears the
+old dead letters and the stalled exposure; if the re-driven apply fails through its budget, it
+dead-letters and stalls again through the normal path. Alternative considered — an infra-level
+"redrive dead letter" facade operation replaying the original event (rejected: it would need
+checkpoint surgery semantics in production code, bypass the event log's account of what
+happened, and leave the timeline unable to narrate the retry).
+
+### D2 — The stalled gate lives in the application layer
+
+`retryImport` (use-case) consults the stalled exposure before dispatching `RetryApply`: not
+stalled → modeled `NotStalled` refusal. Rationale: "stalled" is an infrastructure fact (dead
+letters), not a domain fact — the domain guard stays phase-only, and the application layer is
+the altitude that composes domain + infra. This keeps the affordance honest (a live, still-
+retrying apply can't be double-dispatched into two concurrent bridge runs) while the domain
+stays pure. The double-click race (two retries before the first processes) is bounded: the
+second `RetryApply` finds the exposure already cleared → refused; and the bridge adapter
+serializes invocations regardless (its own design: one bridge process at a time).
+
+### D3 — Additive facade surface
+
+- Command `retryImport({ id })` → modeled errors: `NotFound`, `NotStalled`, and the decide-level
+  refusal for wrong phases. Response `{ importId }` (matches `resolveReview`'s shape).
+- History: additive entry kind `apply-retried` (carrying `at`), so consumers narrate instead of
+  hitting the tolerant unknown arm. Existing consumers are tolerant readers — additive-only rule
+  holds.
+- No new list/read endpoints: the queue composes from `listImports()` (already carries
+  `stalled?` and `acquisitionId?` per entry).
+
+### D4 — The copy (reviewed as content; extends the shipped register + verb inventory pattern)
+
+| Surface | Copy |
+| --- | --- |
+| Overall status (stalled) | tone `attention`, phrase `Adding to the library stopped — needs a retry` |
+| Now-row (stalled) | attention state (no spinner): `Adding to the library stopped — retry it below` |
+| Retry affordance | `Retry adding to the library` — consequence-free label (the consequence IS the label's verb); dispatches `retryImport` |
+| Timeline `apply-retried` | Layer 1 `Retried adding to the library`, state routine, no disclosure payload |
+| Attention queue chip (ask) | `Retry the import` |
+| Modeled `NotStalled` error | `This import isn’t waiting on a retry — it may have resumed or settled. Reload to see its current state.` |
+
+Register rules as shipped: no internal vocabulary (dead letter, reactor, effect stay out of
+layer 1), verb-led imperative affordance, no hedges on deterministic outcomes. The stalled
+now-row and status phrase gate on the DECIDED `stalled` flag (v3.12.0 doctrine), never on
+re-deriving from history shapes.
+
+### D5 — Queue membership and titling
+
+`attentionItems` gains a third arm: imports from `listImports()` with `stalled === true` become
+items (kind `stalled-import`, module importer, ask per D4), titled through the existing
+composed-title fallback chain (the queue load already composes titles by import id). Items with
+an acquisition correlation link to `/acquisitions/{id}` (where the affordance lives); an
+uncorrelated stalled import is still listed — `AttentionItem.href` becomes optional and an
+unlinked row renders its title plainly (listed-not-dropped per the web-ui sparse-fields rule).
+The nav badge count follows automatically (it reuses `attentionItems`).
+
+## Risks / Trade-offs
+
+- [Retry offered while the cause persists → stall loops] → accepted and honest: each loop is an
+  explicit human act; the fresh dead letter re-exposes the stall; the incident-class fixes are
+  environmental (config/image) and the affordance note tells the user nothing it can't promise.
+- [Two rapid retries] → bounded by the D2 gate + serialized bridge; worst case one modeled
+  refusal after the fact.
+- [`apply-retried` shown to older acquisitions' merged timelines] → additive kind; the web's
+  tolerant arm covers a version skew window (single deployable, so none in practice).
+- [Stalled page keeps polling at ~5s] → unchanged from today; the page in question is exactly
+  where the human acts, and the poll picks up the outcome.
+
+## Migration Plan
+
+Additive events/commands only; history folds at read time; no upcasters, no storage changes.
+Standard release pipeline; rollback is a prior-image redeploy.
+
+## Open Questions
+
+None blocking. Deferred by intent: exposing the dead-lettered error text through the facade for
+the detail page's disclosure (today it lives only in logs/store; the visible line doesn't need
+it and the incident memory records the operator path).

--- a/openspec/changes/redrivable-stalled-imports/proposal.md
+++ b/openspec/changes/redrivable-stalled-imports/proposal.md
@@ -1,0 +1,56 @@
+# Proposal: redrivable-stalled-imports
+
+## Why
+
+The 2026-08-02 incident (chromaprint abort → dead-lettered apply) proved that when an import
+stalls, the system knows — the reactor dead-letters the effect and the status read model exposes
+`stalled` — but the user can't see it and can't act on it. The acquisition page showed
+"Adding to the library…" forever, the attention queue showed nothing, and recovery took manual
+SQLite surgery on the production store plus a container restart. A stalled import is a
+human-decision pause; the web-ui spec already demands every such pause surface in the attention
+queue, and an operator affordance must exist so recovery is a click, not database surgery.
+
+## What Changes
+
+- **A redrive is a domain fact.** New importer command `RetryApply` → event `ApplyRetryRequested`,
+  legal only while the import is in its `applying` phase. The reactor reacts to it by re-deriving
+  the same Apply effect it derives today from the applying state — which, by the existing
+  durability design, automatically grants a fresh retry budget (budgets key on the new event's
+  position) and clears the old dead letters (`clearStalled` fires on any non-failing event of the
+  stream). Zero changes to the reactor's durability machinery.
+- **The facade gains an additive `retryImport` command**, permitted only while the import is
+  actually stalled (the application layer consults the stalled exposure; a non-stalled applying
+  import gets a modeled refusal, so the affordance can't double-dispatch a live apply).
+- **The import history additively gains an `apply-retried` kind** so the timeline narrates the
+  retry in the register instead of falling to the tolerant unknown-kind line.
+- **The web renders the decided `stalled` flag** (v3.12.0 doctrine — rendered, never re-derived):
+  the acquisition detail presents the stall as an attention state with a retry affordance in the
+  affordance register, and stalled imports join the attention queue with an ask-oriented chip.
+- **Non-goals:** no downloader changes; no reactor/durability changes; no automatic re-drive
+  policy (retry stays a human decision); no import detail page (the acquisition detail remains
+  the surface); no change to liveness pacing.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `import-management`: new requirement — a stalled import is redrivable through a domain command
+  that grants a fresh budget and clears its dead letters; the facade exposes it as an additive
+  command and narrates it as an additive history kind.
+- `web-ui`: the acquisition detail SHALL present a stalled import as an attention state with a
+  register-compliant retry affordance; the attention queue SHALL list stalled imports.
+
+## Impact
+
+- **Code:** `packages/importer` domain (`commands/events/decide/evolve/react`), application
+  (retry use-case + stalled gate), facade (additive command + history kind);
+  `packages/web` (copy additions, acquisition-detail affordance + route action, attention
+  queue membership). No `packages/downloader` changes.
+- **Contracts:** additive only — one facade command, one history entry kind. No cross-module
+  contract touch; no upcasters (new event type, existing events unchanged).
+- **Tests:** full unit ladder in both packages; e2e blast radius expected nil (new testids only)
+  but local `pnpm test:e2e` mandatory (user-visible strings in the diff).

--- a/openspec/changes/redrivable-stalled-imports/specs/import-management/spec.md
+++ b/openspec/changes/redrivable-stalled-imports/specs/import-management/spec.md
@@ -1,0 +1,51 @@
+# import-management — delta for redrivable-stalled-imports
+
+## ADDED Requirements
+
+### Requirement: A stalled import is redrivable as a domain fact with a fresh budget
+
+The system SHALL let an operator retry a stalled import's failed effect through a domain command
+that records the retry as an event on the import's own stream, legal only while the import is in
+its applying phase (terminal states absorb the command as a no-op; other phases refuse it as a
+modeled error). Reacting to the recorded retry SHALL re-derive the same apply effect from the
+import's state that the original resolution derived, and — by the durable-budget design — the
+retried effect SHALL carry a fresh retry budget and its successful processing SHALL clear the
+import's dead letters and stalled exposure. The facade SHALL expose the retry as an additive
+command that is permitted only while the import is actually exposed as stalled; requesting a
+retry for a non-stalled import SHALL be a modeled refusal, never a duplicate concurrent apply.
+The import history SHALL narrate the retry through an additive entry kind carrying its
+occurrence time. No redrive SHALL require direct store manipulation.
+
+#### Scenario: Retrying a stalled apply re-drives the effect with a fresh budget
+
+- **GIVEN** an import whose apply effect dead-lettered and is exposed as stalled
+- **WHEN** the operator dispatches the retry command through the facade
+- **THEN** a retry event is recorded on the import's stream, the reactor re-dispatches the apply
+  effect with a fresh retry budget, and the import's dead letters and stalled exposure are
+  cleared
+
+#### Scenario: A successful redrive completes the import
+
+- **GIVEN** a stalled import whose underlying failure cause has been remedied
+- **WHEN** the operator retries and the re-driven apply succeeds
+- **THEN** the import reaches its applied phase exactly as an undisturbed apply would, and the
+  history narrates the retry between the resolution and the application
+
+#### Scenario: A retry for a non-stalled import is refused, not double-dispatched
+
+- **GIVEN** an import in its applying phase whose effect is still being processed (not stalled)
+- **WHEN** a retry command is dispatched
+- **THEN** the facade returns a modeled refusal and no additional apply effect is dispatched
+
+#### Scenario: A retry against a settled import is absorbed
+
+- **GIVEN** an import already applied or rejected
+- **WHEN** a retry command is dispatched
+- **THEN** the command is absorbed without effect and the import's state is unchanged
+
+#### Scenario: A re-driven effect that fails again stalls again, honestly
+
+- **GIVEN** a stalled import whose failure cause persists
+- **WHEN** the operator retries and the re-driven apply exhausts its fresh budget
+- **THEN** the retry event dead-letters like any other effect and the import is exposed as
+  stalled again

--- a/openspec/changes/redrivable-stalled-imports/specs/web-ui/spec.md
+++ b/openspec/changes/redrivable-stalled-imports/specs/web-ui/spec.md
@@ -1,0 +1,57 @@
+# web-ui — delta for redrivable-stalled-imports
+
+## ADDED Requirements
+
+### Requirement: A stalled import is visible and redrivable from the acquisition detail
+
+The web UI SHALL render the import's decided stalled flag — rendered, never re-derived from
+retry internals — as an attention state on the acquisition detail page: the overall status and
+the in-progress row SHALL say, in the register, that adding to the library stopped and needs a
+retry, never an indefinite progress phrase. The page SHALL offer a retry affordance in the
+affordance register (imperative verb-led label, consequence stating the composed contract, no
+parenthesized asides) that dispatches the facade's retry command; a modeled refusal (the import
+settled or resumed meanwhile) SHALL render as the modeled action error. The stalled state SHALL
+NOT present a spinner or progress animation. Diagnostic detail (the dead-lettered effect's error
+text, where exposed) belongs in disclosure, not the visible line.
+
+#### Scenario: A stalled import stops claiming progress
+
+- **GIVEN** an acquisition whose import is exposed as stalled
+- **WHEN** the user views the acquisition detail
+- **THEN** the status and the now-row present an attention state saying the add stopped and
+  needs a retry, with no progress animation and no indefinite "Adding to the library…" claim
+
+#### Scenario: One click retries the stalled import
+
+- **GIVEN** the acquisition detail of a stalled import
+- **WHEN** the user activates the retry affordance
+- **THEN** the facade's retry command is dispatched and the page reflects the resumed apply
+
+#### Scenario: A stale retry renders the modeled error
+
+- **GIVEN** a stalled import that resumed or settled after the page loaded
+- **WHEN** the user activates the retry affordance
+- **THEN** the facade's modeled refusal renders as the action error and the page's next load
+  shows the import's true state
+
+### Requirement: Stalled imports join the attention queue
+
+The attention queue SHALL list every stalled import as an item whose ask names the decision
+(retrying the import), titled by its musical intent where the acquisition correlation composes
+and degrading through the established title fallbacks otherwise, linking to the acquisition
+detail where the retry affordance lives. An item whose import carries no acquisition correlation
+SHALL still be listed rather than dropped. The navigation's attention count SHALL include
+stalled imports.
+
+#### Scenario: A stalled import appears in the queue with an ask
+
+- **GIVEN** an import exposed as stalled whose acquisition correlation composes
+- **WHEN** the user opens the attention queue
+- **THEN** the queue lists the item titled by the musical intent with an ask-oriented chip,
+  linking to the acquisition detail
+
+#### Scenario: Retrying clears the queue entry
+
+- **GIVEN** a stalled import listed in the attention queue
+- **WHEN** the user follows the link and retries, and the re-driven apply succeeds
+- **THEN** the import no longer appears in the attention queue

--- a/openspec/changes/redrivable-stalled-imports/tasks.md
+++ b/openspec/changes/redrivable-stalled-imports/tasks.md
@@ -1,0 +1,39 @@
+# Tasks — redrivable-stalled-imports
+
+Test-first throughout: every production line lands behind a failing test, run red first (repo
+non-negotiable; see memory `tdd-authorship-order-enforced`). References: design.md D1–D5.
+
+## 1. Importer domain (D1)
+
+- [ ] 1.1 `RetryApply` command + `ApplyRetryRequested` event types (red: decide/evolve/react
+      tests first)
+- [ ] 1.2 `decide`: applying → emit; terminal → absorb; other phases → modeled illegal
+- [ ] 1.3 `evolve`: identity on applying (and a degradation arm consistent with the fold's
+      tolerant regime)
+- [ ] 1.4 `react`: re-derive the Apply effect from state, mirroring the existing arms
+
+## 2. Application + facade (D2, D3)
+
+- [ ] 2.1 `retryImport` use-case: stalled-exposure gate (`NotStalled` modeled refusal),
+      dispatch through the normal command path
+- [ ] 2.2 Facade command `retryImport({id})` with modeled error mapping; response `{importId}`
+- [ ] 2.3 Additive `apply-retried` history kind in the projection + facade schema (with `at`)
+- [ ] 2.4 Reactor integration test: dead-lettered apply → retry event → fresh budget, dead
+      letters cleared, effect re-dispatched; failure path stalls again
+
+## 3. Web (D4, D5)
+
+- [ ] 3.1 Copy additions (status phrase, now-row, affordance label, timeline entry, NotStalled
+      error) in the copy modules' `satisfies`-checked regime
+- [ ] 3.2 Acquisition detail: stalled attention state (decided-flag gated), retry affordance +
+      route action dispatching `retryImport`, modeled-error rendering
+- [ ] 3.3 Attention queue: `stalled-import` arm from `listImports()`, optional-href rendering,
+      composed titles; nav badge follows
+- [ ] 3.4 SSR/page-server tests for all of the above; timeline renders `apply-retried`
+
+## 4. Gate and verification
+
+- [ ] 4.1 `pnpm check` green (100% coverage both packages)
+- [ ] 4.2 Local `pnpm test:e2e` (user-visible strings in the diff; ship.md Phase 5 step 1)
+- [ ] 4.3 Verify the full loop against the dev app or e2e stack: stall → queue entry → retry →
+      applied


### PR DESCRIPTION
Pending plan only — no implementation. Drafts the OpenSpec change making stalled imports visible and redrivable, from the 2026-08-02 incident (chromaprint abort → dead-lettered apply → invisible freeze, recovery via manual store surgery).

Core design: `RetryApply` → `ApplyRetryRequested` as one domain event; fresh retry budget and dead-letter clearing are emergent from the shipped durability machinery (budgets key on the new event's position; `clearStalled` fires on any non-failing stream event). Zero reactor changes. The web renders the decided `stalled` flag as an attention state with a register-compliant retry affordance, and stalled imports join the attention queue.

Artifacts: proposal, delta specs (`import-management`, `web-ui`), design D1–D5, tasks. Validated `--strict`. Implementation lands as a future `/ship` of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)