### PR TITLE
chore(openspec): draft auth-roles proposal

### DIFF
--- a/openspec/changes/auth-roles/.openspec.yaml
+++ b/openspec/changes/auth-roles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/auth-roles/design.md
+++ b/openspec/changes/auth-roles/design.md
@@ -1,0 +1,93 @@
+# Design — auth-roles
+
+## Context
+
+See proposal.md — Why. Current state: `plexResourcesSchema` parses only `clientIdentifier`
+(schemas.ts), the membership predicate is `resources.some((r) => r.clientIdentifier ===
+machineId)` (adapter.ts), and the session codec (session.ts) is a pure HMAC-signed claims module
+— `{plexAccountId, username, expiresAt}`, zod-parsed on verify, deliberately not a port, with
+the e2e harness importing `signSession` as the single implementation. The stall-surfacing change
+(grilled 2026-08-05) will consume the seam this change introduces; its research doc
+(`docs/research/dead-letter-redrive-semantics.md`) does not constrain this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Close the review sweep's predicate finding by requiring the matched resource to be a server.
+- Establish the permission-question seam (PEP/PDP split) so authorization models are swappable
+  behind one signature.
+- Keep the entire change inside `packages/web`; zero facade or bounded-context impact.
+
+**Non-Goals:**
+
+- No admin surface, no role-gated route, and no HTTP rendering convention for refusals — the
+  first consumer (stall-surfacing) fixes how a refusal renders; shipping a convention with zero
+  consumers would be speculative.
+- No session-schema versioning machinery beyond the additive optional claim.
+- No policy engine, no user store, no per-resource ownership (promotion trigger recorded in the
+  proposal).
+
+## Decisions
+
+**D1 — The predicate: identifier match AND provides-server.** Membership requires one
+`/resources` entry with `clientIdentifier === PLEX_SERVER_MACHINE_ID` whose `provides`
+(comma-separated list per plex.tv) contains `server`. Alternatives: *owned-only* (locks out
+every legitimate share-guest); *account allowlist* (rebuilds the user database that
+share-is-approval exists to avoid). Device/player entries — the client-forgeable class — never
+carry `provides: "server"`, which is the finding's attack shape.
+
+**D2 — Role is the matched entry's `owned` flag, read once.** `owned === true` ⇒ `owner`, else
+(false or absent) ⇒ `guest`. Single derivation point is the adapter's membership check, which
+now returns `{identity, role}`; the callback threads it into the minted session. Schema reads
+both new fields tolerantly (`owned: z.boolean().optional()`, `provides: z.string().optional()`)
+— absent fields degrade toward denial/least-privilege, never toward grant.
+
+**D3 — Additive session claim, tolerant decode, no forced re-login.** `role` joins the signed
+claims as an optional field defaulting to `guest` on decode. Alternative considered: rotate the
+codec (or secret) to force universal re-login. Rejected: the predicate fix does not invalidate
+any legitimately issued session, and the conservative default means no privilege appears by
+omission; the owner logs in again once to pick up `owner`. `SessionIdentity` grows the role so
+the e2e harness's minted cookies stay honest.
+
+**D4 — The seam: `authorize(claims, action)` in a pure `lib/server/authz.ts`.** Call sites name
+an action from the closed union `PrivilegedAction`; the decision point consults a
+`Record<PrivilegedAction, Role>` table and returns a value — `{kind: 'permitted'} | {kind:
+'refused'}` — never throws. Like `session.ts`, this is deliberately NOT a port: there is no
+external actor behind a pure decision, so tests exercise the real path with minted claims. The
+union ships with its first member, `'system:redrive'`, declared now and mapped to `owner` —
+reserved by the stall-surfacing grill, referenced by no route until that change — because a
+closed union with zero members is untestable and the name is already decided. Swapping RBAC for
+ABAC/PBAC later changes only this module's internals; the signature (and an additive optional
+`resource` parameter, if ever needed) absorbs the rest.
+
+**D5 — Contract truth.** `provides` and `owned` become consumed fields: the plextv recorder's
+projection widens to capture them, the owner-account fixture is re-recorded to witness both, and
+the replay test drives the real predicate to a grant with `role: owner`. The guest-side variant
+(`owned` false/absent) has no recordable source — a guest token is not ours to record — so it is
+covered at the unit tier against the tolerant schema, with the fixture-absence documented in the
+contract test (the same honesty rule the recorder already follows for the events/transfers
+coupling).
+
+## Risks / Trade-offs
+
+- **[plex.tv could permit a hostile PMS to register an arbitrary machine identifier]** → The
+  predicate fix strictly narrows admission regardless (the known client-forgeable device hole
+  closes). Implementation carries a timeboxed verification task against plex.tv docs/community
+  sources; if server-side forgery proves possible, the recorded fallback is pinning the owner by
+  account identity via configuration — a small follow-up change, and the reason `authorize`'s
+  internals are swappable.
+- **[`provides` formatting drift (casing, spacing, multi-value)]** → Parse as a trimmed,
+  case-insensitive comma-list; the re-recorded fixture pins the real spelling.
+- **[Owner lockout if plex.tv reports `owned` unexpectedly]** → Tolerant default is `guest`, so
+  the failure mode is missing privilege, not lost access; live verification after deploy is the
+  owner's login (same procedure as the v3.13.0 gate ship).
+- **[Guest regression if share-guests' entries don't carry `provides: "server"`]** → Same
+  degrade direction (denied login, fail-closed); verified live with a share-guest account before
+  the change is declared done — noted in tasks as the one manual step.
+
+## Migration Plan
+
+Deploy normally. Existing sessions continue as `guest` for their remaining lifetime; the owner
+re-logs-in once. Rollback is the previous image — the old codec ignores the unknown `role`
+claim, so cookies minted by this version stay valid on rollback.

--- a/openspec/changes/auth-roles/proposal.md
+++ b/openspec/changes/auth-roles/proposal.md
@@ -1,0 +1,74 @@
+# Proposal: auth-roles
+
+## Why
+
+The whole-project review sweep (2026-08-05) found the login gate's membership predicate
+under-constrained: it grants a session to any Plex account whose `/resources` listing contains
+an entry with the configured machine identifier — but that listing includes every device an
+account can see, and device entries carry client-chosen identifiers, while
+`PLEX_SERVER_MACHINE_ID` is not a secret (`.env.example` documents fetching it from
+`:32400/identity`). The one predicate protecting the entire UI must require that the matching
+resource actually *is* the server. At the same time, the upcoming stall-surfacing change (grilled
+2026-08-05) needs the system's first authorization distinction — an owner-gated admin surface
+with a redrive verb — and the fix and the distinction want the same new fact from the same
+plex.tv response: the resource's `owned` flag. This change ships both together: the tightened
+predicate, and the authorization *seam* — shaped so RBAC today can become ABAC/PBAC later with
+zero call-site churn — with no consumer beyond the fix itself.
+
+## What Changes
+
+- **The membership predicate requires a server resource.** Admission is decided only by a
+  `/resources` entry whose identifier matches `PLEX_SERVER_MACHINE_ID` **and** whose `provides`
+  names a server — device/player entries with coincidental or forged client identifiers no
+  longer satisfy the gate. plex.tv's `owned` flag on that entry is read at the same moment.
+- **Sessions carry a role.** The versioned session gains `role: 'owner' | 'guest'`, derived in
+  exactly one place — the login callback — from the matched server resource's `owned` flag.
+  Pre-existing cookies without the field degrade tolerantly to `guest` for their remaining
+  lifetime (conservative: no privilege appears by decoding absence). No route behaves
+  differently by role in this change.
+- **The `authorize` seam.** A single decision point answers the permission question
+  `authorize(session, action)` where actions are a closed union (compile-checked, same
+  discipline as the web verb inventory). Call sites name *actions, never roles*; the decision
+  internals are a table-driven role check today and swappable (ABAC/PBAC) behind the unchanged
+  signature later — the XACML PEP/PDP split. The action union ships empty-but-for-a-seam-test
+  member until stall-surfacing adds `system:redrive` as its first real consumer.
+- **Contract truth for the new fields.** `provides` and `owned` become consumed fields of the
+  plex.tv resources contract: schema, recorded fixture witness, and recorder projection all
+  extend together. The guest-side variant (`owned` absent/false) is documented as a tolerant
+  default where a genuine guest recording is unobtainable.
+- **Non-goals:** no admin surface, no role-gated route, no policy engine, no user store, no
+  per-resource ownership — the seam's first consumer is the separate stall-surfacing change.
+  RBAC→ABAC promotion trigger: a second privileged surface or a per-resource ownership
+  requirement.
+
+## Capabilities
+
+### New Capabilities
+
+- `web-authorization`: the permission-question seam — closed action union, single decision
+  point, role model (`owner`/`guest`) derived solely from Plex server ownership at login, and
+  the guarantee that privileged actions are decided only through the seam.
+
+### Modified Capabilities
+
+- `web-access-control`: the membership requirement tightens (matching resource must provide a
+  server); the session contract gains the role field with tolerant degradation for pre-existing
+  cookies; the "no further per-user distinctions" clause is withdrawn in favor of the role
+  model (base interface access is unchanged for every valid session).
+
+## Impact
+
+- **Code:** `packages/web` only — the plex.tv adapter + zod schemas (`provides`, `owned`), the
+  login callback (role derivation), the session codec (additive field + tolerant read), and a
+  new `lib/server/authz` module (action union, decision table, `authorize`). Neither bounded
+  context changes; no facade contracts change.
+- **Contract tier:** `packages/web/test/contract` plextv fixtures re-recorded to witness
+  `provides`/`owned` on the owner's account; recorder projection extended to the newly consumed
+  fields (secret-scrub discipline unchanged).
+- **Security posture:** closes the review sweep's Plex-predicate finding. One verification item
+  travels with implementation: whether plex.tv permits a hostile *server* registration to claim
+  an arbitrary machine identifier (if so, the documented fallback is pinning the owner by
+  account identity via configuration — a design.md decision point, not a blocker for the
+  predicate fix, which strictly narrows admission either way).
+- **Operations:** existing sessions keep working as `guest`; the owner re-logs-in once to pick
+  up the role. No new required configuration.

--- a/openspec/changes/auth-roles/specs/web-access-control/spec.md
+++ b/openspec/changes/auth-roles/specs/web-access-control/spec.md
@@ -1,0 +1,102 @@
+# web-access-control — delta for auth-roles
+
+## MODIFIED Requirements
+
+### Requirement: The web interface requires an authorized session
+
+The web interface SHALL require a valid session on every server route except the login flow
+(`/login`, its callback) and the health endpoint. An unauthenticated GET or HEAD request SHALL
+be redirected to the login page; any other unauthenticated request (form actions and other
+writes) SHALL be refused without side effects. A valid session SHALL grant the base interface —
+submission, cancellation, selection, and review resolution — regardless of role; per-user
+distinctions SHALL exist only as owner-gated privileged actions decided through the
+authorization seam (see `web-authorization`). This change gates no route or action by role.
+
+#### Scenario: Unauthenticated page request lands on login
+
+- **WHEN** a request without a valid session cookie targets any gated page
+- **THEN** the response redirects to the login page and no gated content is served
+
+#### Scenario: Unauthenticated action is refused
+
+- **WHEN** a request without a valid session cookie targets a form action or other state-changing route
+- **THEN** the request is refused and no facade command is invoked
+
+#### Scenario: Health endpoint stays open
+
+- **WHEN** a request without any session targets the health endpoint
+- **THEN** it is served normally, so deploy verification and monitoring need no credentials
+
+#### Scenario: A guest session retains the base interface
+
+- **WHEN** a request with a valid guest-role session targets any base-interface page or action
+- **THEN** it is served exactly as before roles existed
+
+### Requirement: Access is granted solely by Plex server membership
+
+Authorization SHALL be decided by asking plex.tv, with the logging-in user's own token, whether
+the account can see a **server** whose machine identifier equals the configured
+`PLEX_SERVER_MACHINE_ID`: the matching resource entry SHALL both carry the configured machine
+identifier and declare that it provides a server. A resource entry that matches the identifier
+but does not provide a server — a player or other device, whose identifiers are client-chosen —
+SHALL NOT satisfy the check. There SHALL be no user database, allowlist, or per-user
+permissions. The matched entry's ownership flag SHALL be read at this moment as the session's
+role source (see `web-authorization`). A plex.tv failure or unreachability SHALL surface as a
+modeled infrastructure error on the login page and SHALL never result in a grant.
+
+#### Scenario: Shared account is admitted
+
+- **WHEN** the authenticated Plex account's accessible resources include a server providing
+  the configured machine identifier
+- **THEN** the login completes and a session is issued
+
+#### Scenario: Unshared account is denied
+
+- **WHEN** the authenticated Plex account's accessible resources do not include the configured machine identifier
+- **THEN** the login page renders a denial message, no session is issued, and nothing about the account is stored
+
+#### Scenario: A non-server resource with a matching identifier is denied
+
+- **WHEN** the authenticated account's resources contain an entry carrying the configured
+  machine identifier that does not declare it provides a server
+- **THEN** the login is denied exactly as an unshared account is, and no session is issued
+
+#### Scenario: plex.tv unavailable fails closed
+
+- **WHEN** plex.tv is unreachable or returns a malformed or error response during the membership check
+- **THEN** the login fails with a modeled infrastructure error and no session is issued
+
+### Requirement: Sessions are stateless signed cookies with fixed expiry
+
+A session SHALL be a signed, HttpOnly cookie carrying the Plex account identity, the session's
+role, and a fixed expiry 7 days from login, verified per-request by pure computation against the
+configured `SESSION_SECRET` — no server-side session state and no per-request plex.tv call.
+Activity SHALL NOT extend a session; re-login re-runs the membership check, making cookie
+lifetime the re-verification cadence. A validly signed cookie without a role field SHALL decode
+as a guest session (see `web-authorization`); role SHALL change only by logging in again.
+
+#### Scenario: Valid session is admitted without upstream calls
+
+- **WHEN** a request carries an untampered session cookie within its validity window
+- **THEN** it is admitted by signature and expiry verification alone, with no external call
+
+#### Scenario: Expired session must log in again
+
+- **WHEN** a request carries a session cookie past its fixed expiry, regardless of how recently the user was active
+- **THEN** the request is treated as unauthenticated and the user must complete the Plex login again
+
+#### Scenario: Tampered cookie is unauthenticated
+
+- **WHEN** a request carries a cookie whose signature does not verify
+- **THEN** the request is treated as unauthenticated
+
+#### Scenario: Rotating the secret revokes every session
+
+- **WHEN** `SESSION_SECRET` is changed and the process restarted
+- **THEN** all previously issued cookies fail verification and every user must log in again
+
+#### Scenario: The role rides the cookie, not a lookup
+
+- **WHEN** a request carries a valid session cookie bearing a role
+- **THEN** the role is available to the authorization seam from the cookie alone, with no
+  store read or upstream call

--- a/openspec/changes/auth-roles/specs/web-authorization/spec.md
+++ b/openspec/changes/auth-roles/specs/web-authorization/spec.md
@@ -1,0 +1,71 @@
+# web-authorization — delta for auth-roles
+
+## Purpose
+
+Decide whether a signed-in principal may perform a privileged action. One decision point answers
+the permission question for actions named from a closed set; the role model behind it (owner vs
+guest, derived solely from Plex server ownership at login) is an implementation the seam hides,
+so richer models can replace it without any call site changing.
+
+## ADDED Requirements
+
+### Requirement: Privileged actions are decided by a single decision point
+
+Every privileged action the web layer offers SHALL be authorized by asking a single decision
+point whether the presenting session may perform a named action, drawn from a closed,
+compile-checked set of action names. Call sites SHALL name only the action — never a role or any
+other decision input — and SHALL NOT decide privilege by any other means. A refusal SHALL be a
+modeled outcome that produces no side effects. Routes and actions outside the privileged set are
+unaffected: every valid session retains the base interface.
+
+#### Scenario: A guest session is refused an owner-gated action
+
+- **WHEN** a session carrying the guest role asks to perform an action the decision point gates
+  to owners
+- **THEN** the decision is a modeled refusal, and nothing about the request is executed
+
+#### Scenario: An owner session is permitted
+
+- **WHEN** a session carrying the owner role asks to perform an owner-gated action
+- **THEN** the decision permits it
+
+#### Scenario: The decision input is the session and the action name alone
+
+- **WHEN** the same action is asked of the same session twice
+- **THEN** the decision is identical — no ambient state, upstream call, or per-request context
+  participates
+
+### Requirement: Roles derive solely from Plex server ownership at login
+
+A session's role SHALL be determined exactly once, at login, from the plex.tv resource entry
+that satisfied the membership check: `owner` when plex.tv reports the account owns that server,
+`guest` otherwise. There SHALL be no other source of role — no configuration allowlist, no user
+database, no mutation after issuance. When plex.tv omits the ownership flag, the role SHALL be
+`guest`.
+
+#### Scenario: The owning account signs in as owner
+
+- **WHEN** the login membership check matches a server resource plex.tv marks as owned by the
+  authenticating account
+- **THEN** the issued session carries the owner role
+
+#### Scenario: A share-guest signs in as guest
+
+- **WHEN** the login membership check matches a server resource plex.tv does not mark as owned
+- **THEN** the issued session carries the guest role
+
+#### Scenario: An absent ownership flag is a guest
+
+- **WHEN** the matched server resource carries no ownership flag at all
+- **THEN** the issued session carries the guest role
+
+### Requirement: Missing role information degrades to least privilege
+
+A session that carries no role — a validly signed cookie issued before roles existed — SHALL be
+treated as a guest for its remaining lifetime. Privilege SHALL never appear by omission.
+
+#### Scenario: A pre-role session is a guest
+
+- **WHEN** a request presents a validly signed, unexpired session cookie from before the role
+  field existed
+- **THEN** the session is admitted with the guest role, and owner-gated actions refuse it

--- a/openspec/changes/auth-roles/tasks.md
+++ b/openspec/changes/auth-roles/tasks.md
@@ -1,0 +1,54 @@
+# Tasks — auth-roles
+
+Every production edit follows red-first TDD: the failing test lands before the code, visible in
+commit order. All work is in `packages/web` unless a task says otherwise.
+
+## 1. The tightened membership predicate
+
+- [ ] 1.1 Extend `plexResourcesSchema` (red first): tolerant optional `provides` and `owned`
+      fields; unit tests pin absent-field decoding and the real comma-list shapes.
+- [ ] 1.2 Replace the `some(clientIdentifier === machineId)` predicate (red first): membership
+      requires the identifier match AND a trimmed, case-insensitive `provides` list containing
+      `server`; tests cover the matching server, the matching non-server device (denied — the
+      finding's attack shape), the multi-value list, and the absent `provides`.
+- [ ] 1.3 Timeboxed verification of the server-side forgery question (design Risks): consult
+      plex.tv docs/community sources on whether a hostile PMS can register an arbitrary machine
+      identifier; record the answer (and the account-id-pin fallback trigger, if live) in the
+      design doc.
+
+## 2. Role derivation and the session claim
+
+- [ ] 2.1 Widen the membership result (red first): the adapter returns the matched entry's role
+      (`owned === true` ⇒ `owner`, else `guest`); tests pin owned-true, owned-false, and
+      owned-absent derivations.
+- [ ] 2.2 Add the optional `role` claim to the session codec (red first): `SessionIdentity`
+      carries it, `signSession` embeds it, decode defaults an absent claim to `guest`; tests pin
+      the pre-role cookie decoding as guest and the round-trip of both roles.
+- [ ] 2.3 Thread the role through the login callback (red first): the minted session carries the
+      derived role; callback tests assert the owner and guest paths end-to-end through the flow.
+
+## 3. The authorize seam
+
+- [ ] 3.1 Create `lib/server/authz.ts` (red first): the closed `PrivilegedAction` union with
+      `'system:redrive'` as its reserved first member, the `Record<PrivilegedAction, Role>`
+      decision table, and `authorize(claims, action)` returning the permitted/refused value;
+      tests pin guest-refused, owner-permitted, absent-role-refused, and decision determinism.
+- [ ] 3.2 Boundary check: confirm no route or component imports the decision table or branches
+      on `role` directly — `authorize` is the only reader (grep-backed test or lint note per
+      house convention).
+
+## 4. Contract tier
+
+- [ ] 4.1 Widen the plextv recorder's projection to `provides` and `owned` (consumed-fields
+      discipline; secret-scrub unchanged).
+- [ ] 4.2 Re-record the owner-account fixture against live plex.tv so both new fields are
+      witnessed; update the replay test to drive the real predicate to a grant carrying
+      `role: owner`, and document in the contract test why the guest variant has no recorded
+      fixture (unit-tier tolerant-default coverage instead).
+
+## 5. Gate and done
+
+- [ ] 5.1 Full gate (`pnpm check`) green; e2e harness cookie-minting updated for the new
+      identity shape; local out-of-process e2e run passes.
+- [ ] 5.2 Post-deploy manual verification (with Jake): owner login carries `owner`, a
+      share-guest login still succeeds as `guest`, and pre-existing sessions behave as guests.


### PR DESCRIPTION
## Summary

Drafted OpenSpec change artifacts only — **no runtime change in this PR**. Implementation follows as its own `/ship` lifecycle.

The `auth-roles` change (grilled + drafted 2026-08-05) bundles two things that want the same new fact from the same plex.tv response:

- **Security fix (from the 2026-08-05 whole-project review sweep):** the login gate's membership predicate currently grants on `clientIdentifier` equality alone against `/resources`, which lists every device an account can see — and device identifiers are client-chosen while `PLEX_SERVER_MACHINE_ID` is not a secret. The tightened predicate requires the matching resource to actually provide a **server**.
- **The authorize seam:** `authorize(session, action)` with a closed action union — call sites name actions, never roles (the XACML PEP/PDP split), a table-driven RBAC decision point behind it, and `role: 'owner' | 'guest'` derived once at the login callback from the Plex resource's `owned` flag, carried additively in the signed session (pre-role cookies degrade to guest). RBAC→ABAC/PBAC later is an internals swap with zero call-site churn. First consumer: the upcoming stall-surfacing change (`system:redrive`).

## Contents

- `openspec/changes/auth-roles/proposal.md` — why / what / capabilities / impact
- `openspec/changes/auth-roles/specs/web-authorization/spec.md` — new capability
- `openspec/changes/auth-roles/specs/web-access-control/spec.md` — delta (predicate, session role, withdrawn no-per-user-distinctions clause)
- `openspec/changes/auth-roles/design.md` — decisions, risks (incl. the PMS machine-id forgery verification item), migration
- `openspec/changes/auth-roles/tasks.md` — red-first task breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)