### PR TITLE
chore(openspec): draft stalled-work-recovery proposal

### DIFF
--- a/docs/research/dead-letter-redrive-semantics.md
+++ b/docs/research/dead-letter-redrive-semantics.md
@@ -1,0 +1,548 @@
+# How do mature systems redrive dead-lettered work?
+
+**Research date:** 2026-08-05.
+
+**Question.** The reactor dead-letters a budget-exhausted effect into a SQLite ledger row
+`(subscription, globalSeq, error, occurredAt, streamId)` and marks the stream stalled; recovery
+today is manual DB surgery + restart. We are adding an operator-facing **redrive verb** on an
+owner-gated admin surface. The house leaning (open to challenge): redrive is an infra-level
+operation — no domain event — per-stream, implemented as *clear the stream's letters + stalled
+mark, then re-dispatch the pending effect derived from current state through the normal dispatch
+path*. What do mature messaging/event systems actually do on the five open sub-questions:
+failure-again semantics, ledger disposition, operator feedback, granularity, and the paired
+give-up verb?
+
+**Method.** Primary sources only, fetched 2026-08-05: AWS SQS developer guide and API reference;
+Particular Software's own ServicePulse/NServiceBus docs; MassTransit's docs; Confluent's Kafka
+Connect DLQ deep-dive (Robin Moffatt); Sidekiq's wiki plus the actual `api.rb` and Web UI route
+source on GitHub; Oban's hexdocs; Temporal's docs and CLI reference; Hohpe & Woolf's
+enterpriseintegrationpatterns.com; erlang.org; the `systemctl(1)` man page. House constraints
+from `docs/development/event-sourcing.md`, `docs/development/error-handling.md`, and the reactor
+source. Citations gathered in §6. Unreachable/secondary sources are flagged where used:
+freedesktop.org returned 403 for the systemctl page (the man7.org mirror of the same man page is
+cited instead); `docs.particular.net/servicecontrol/errors` returned 404 (superseded by the
+ServicePulse pages, which were fetched directly); one NServiceBus inference is marked
+[secondary].
+
+The supervisor/delivery-loop side of this territory — why effects settle off the mutex, how
+outcomes re-enter as commands — was already researched in
+[`nonblocking-external-work-observation.md`](nonblocking-external-work-observation.md) and is
+cross-referenced, not re-argued.
+
+---
+
+## 1. The house shape being decided (facts from this repo)
+
+- A dead letter is recorded per failed effect with `streamId` "so the owning acquisition can be
+  exposed as stalled"; the port already has `clearStream` ("Drop a resolved stream's letters
+  (idempotent) — the acquisition is no longer stalled") and `prune` (retention horizon)
+  (`packages/downloader/src/application/ports/dead-letter-port.ts:4-29`).
+- A stalled stream that is later driven successfully by any event already self-heals: "A stalled
+  acquisition's stream was driven successfully again (a cancellation, an operator resubmission):
+  its dead letters are resolved — clear them and the stalled exposure"
+  (`packages/downloader/src/application/acquisition/reactor.ts:296-300`).
+- The startup re-drive is level-triggered — "fold every stream and re-dispatch the effect its
+  current state is waiting on through the normal idempotent path" — and **deliberately skips
+  stalled streams**: "landed; awaiting an operator" (`reactor.ts:188-196`, `:221`). So the
+  proposed verb is precisely "un-land this stream and give it back to the machinery that already
+  knows how to drive it."
+- Constitution constraints: events are business facts, "not incidental telemetry"
+  (`docs/development/event-sourcing.md` §"Events are facts"); errors are values handled "at the
+  boundary that can actually make a decision, once" (`docs/development/error-handling.md`);
+  at-least-once delivery with idempotency via re-entry through `decide`
+  (`event-sourcing.md` §"Decisions in `decide`, effects in `react`"); no breaking changes to
+  public contracts (CLAUDE.md non-negotiables).
+
+---
+
+## 2. Prior art, system by system
+
+### 2.1 AWS SQS — DLQ redrive as an asynchronous *move* task
+
+- Redrive "move[s] unconsumed messages from a dead-letter queue to another destination for
+  processing. By default, dead-letter queue redrive moves messages from a dead-letter queue to a
+  source queue" [Q3]. It is a **move, not a copy**: the minimum IAM permissions for a redrive are
+  `ReceiveMessage` + `DeleteMessage` on the DLQ and `SendMessage` on the destination [Q3] — the
+  message leaves the DLQ as it goes.
+- **Failure-again = fresh full budget, and a severed history.** "The redrive task resets the
+  retention period. All redriven messages are considered new messages with a new `messageID` and
+  `enqueueTime`" [Q3]. A new message starts a new receive count against the source queue's
+  `maxReceiveCount` (the redrive policy that dead-letters "messages that are not processed
+  successfully" after that many receives [Q1][Q2]) — so a still-broken message will burn a full
+  retry budget and land in the DLQ *again*, as a fresh letter with no linkage to its previous
+  episode.
+- **Feedback = fire-and-forget with a status object.** `StartMessageMoveTask` "starts an
+  asynchronous task" and returns a `TaskHandle`; status is polled via `ListMessageMoveTasks`
+  ("the most recent message movement tasks (up to 10)") and a RUNNING task can be cancelled —
+  already-moved messages stay moved [Q3][Q4].
+- **Granularity = whole-queue only.** "Amazon SQS doesn't support filtering and modifying
+  messages while redriving them from the dead-letter queue" [Q3]; there is no per-message
+  redrive, only velocity control ("Custom max velocity … maximum allowed rate is 500 messages
+  per second"), a 36-hour task ceiling, 100 active tasks per account, and "only one active
+  message movement task … per queue at any given time" [Q3][Q4].
+- **Give-up verb:** none dedicated — disposal is retention expiry or a queue purge; AWS's own
+  best practice is to make the DLQ's retention *longer* than the source's because a moved
+  message keeps its original enqueue timestamp on standard queues [Q1].
+
+### 2.2 NServiceBus / ServiceControl / ServicePulse — the richest operator story surveyed
+
+- Endpoint-side, recoverability is immediate retries ("by default, up to five") then delayed
+  retries ("delays start with at 10 seconds, then 20 seconds, and lastly 30 seconds"), then
+  "messages which fail multiple times are moved to the configured error queue" with exception
+  details attached [P5]. ServiceControl ingests that error queue into its own database; the
+  broker queue is not the operator's working surface — the ingested record is [P1].
+- **Failure-again = a new failure, with an episode counter.** "A message that is sent for retry
+  is marked as such and is not displayed in the failed message list or included in failed
+  message groups **unless reprocessing the message fails again**"; "ServiceControl keeps track
+  of all retry attempts in the background. If a retry operation fails, ServicePulse will show
+  the number of failed retry attempts" [P2]. The redriven message re-enters the endpoint's input
+  queue as an ordinary message, so it passes through the endpoint's full recoverability policy
+  again before returning to the error queue [secondary — implied by the retry re-sending to the
+  endpoint's queue [P2] and recoverability applying to message processing generally [P5]; not
+  stated as one sentence in the fetched pages].
+- **Ledger disposition = retain everything, re-label.** Nothing is deleted on retry — the record
+  is hidden from the failed list while "sent for retry" and resurfaces on failure [P2]. Even the
+  delete verb is soft: deleting (archiving) marks messages `Deleted`; "Data from a deleted
+  message is still available … If any failed messages were deleted by mistake, they can be
+  restored from the Deleted Messages tab", and actual removal happens later under the
+  ServiceControl error-retention period [P3].
+- **Feedback = asynchronous with a first-class limbo state.** Group retries show operation
+  progress, and a "completed retry request … means those messages may not have been processed
+  yet" [P1]. The **Pending Retries** view exists precisely for the fire-and-forget gap: "failed
+  messages that have been requested to be retried but have not completed yet"; status updates
+  only "when the message is processed again as either an audited message (i.e. a successful
+  delivery) or as a failed message". Operators can retry again or "manually mark the failed
+  message as resolved", with the warning: "Retrying pending messages can cause the same message
+  to be processed multiple times. Do not retry a message if it has been processed by the
+  endpoint" [P4].
+- **Granularity = per-message first, then group.** Individual/custom selection retry is
+  positioned for "testing system fixes before deciding to retry several messages in a group";
+  groups (by exception type + stack trace, message type, endpoint) retry as a whole [P1].
+- **Give-up verb = archive**, restorable, retention-pruned, plus **mark-as-resolved** for
+  pending retries [P3][P4].
+
+### 2.3 MassTransit — an error queue with *no* first-party redrive
+
+Faulted messages move to a `_error` queue with "exception details … stored as headers with the
+message for analysis" [M1]. The documented operator story is broker tooling: "Once the reason for
+the fault has been resolved, you can use the tool to extract the original message and send it
+back to the original consumer" — and for anything richer MassTransit explicitly points at
+Particular's platform [M1]. The lesson is negative but real: a dead-letter surface without a
+built-in redrive verb outsources the verb to raw infrastructure tools — exactly the "manual DB
+surgery" stage this project is trying to graduate from.
+
+### 2.4 Kafka (Confluent / Robin Moffatt) — the log-native disposition
+
+Kafka Connect routes bad records to a dead-letter *topic* (with `errors.tolerance = all` and
+optional error-context headers carrying topic/partition/offset/exception) while "valid messages
+are processed as normal, and the pipeline keeps on running" [K1]. Reprocessing is *another
+consumer over the DLQ topic* — Moffatt's worked pattern is a chained second sink that re-reads
+the DLQ with different handling [K1]. Because the DLQ is a topic, records "remain … per
+configured topic retention policies, not automatic deletion upon reprocessing" [K1]: worklist
+position (consumer offset) and history (the log) are structurally separate, so redrive never
+destroys the record of the episode. There is no per-record verb at all — granularity is "run a
+consumer from an offset."
+
+### 2.5 Sidekiq — the smallest complete operator UI in the survey
+
+- Exhausted retries (default "25 retries over approximately 20 days") land the job in the Dead
+  set: "a holding pen for jobs which have failed all their retries", capped at "10,000 jobs or
+  6 months so it doesn't grow infinitely" [SK1].
+- **Failure-again = one fresh attempt, budget otherwise preserved.** The Web UI's retry calls
+  `SortedEntry#retry`, which is, in full:
+
+  ```ruby
+  def retry
+    remove_job do |message|
+      msg = Sidekiq.load_json(message)
+      msg["retry_count"] -= 1 if msg["retry_count"]
+      Sidekiq::Client.push(msg)
+    end
+  end
+  ```
+
+  — remove from the set, decrement the counter by exactly one, re-push [SK2]. The manual retry
+  therefore doesn't consume budget: a dead job gets one real attempt and, on failure, returns to
+  the morgue rather than restarting 25 retries. No fresh-budget reset, no immediate
+  re-dead-letter either.
+- **Ledger disposition = removal.** `remove_job` takes the entry out of the dead set as part of
+  retrying it [SK2]; the job payload itself carries its error metadata forward, but the morgue
+  row is gone.
+- **Feedback = fire-and-forget.** Retry is a re-push onto the queue; the operator learns the
+  outcome by the job's later reappearance in Retries/Dead tabs [SK1].
+- **Granularity & verbs:** the Web UI routes are the whole verb inventory — morgue: per-job and
+  selected-set `retry`/`delete`, plus `POST /morgue/all/retry` (`DeadSet.new.retry_all`) and
+  `POST /morgue/all/delete` (`DeadSet.new.clear`); retries tab additionally has
+  `POST /retries/all/kill` (send to morgue) [SK3]. **Kill and delete are distinct give-up
+  verbs**: `kill` moves to the dead set and fires configured `death_handlers`
+  (`DeadSet#kill` [SK2]); `delete` discards outright; `retry: false` jobs are "simply
+  discarded" without ever entering the morgue [SK1].
+
+### 2.6 Oban — the same one-more-attempt grant, stated in the API
+
+`Oban.retry_job` on a `retryable`/`discarded`/`completed` job "sets a job as `available`,
+**adding attempts if already maxed out**. Jobs currently `available` or `executing` are ignored"
+[O1] — i.e. `max_attempts` is bumped just enough to permit another attempt, and the guard
+refuses to retry work that isn't actually stuck. `retry_all_jobs` is the bulk twin; `cancel_job`
+is the paired give-up (state `cancelled`; `discarded` = "failed all retry attempts") [O1].
+
+### 2.7 Temporal — explicit, operator-chosen budget reset
+
+- **Workflow reset** is the heavyweight verb: "A Reset terminates a Workflow Execution and
+  creates a new Workflow Execution with the same Workflow Type and Workflow ID", copying event
+  history "up to and including the reset point"; later events are not carried forward, though
+  "Signals in the original history can be optionally copied to the new history" [T1][T2].
+- **Activity-level recovery** is the closer analogue and is explicit about budgets:
+  `temporal activity reset` "restarts the activity as if it were first being scheduled. That is,
+  it will reset both the number of attempts and the activity timeout", with separate
+  `--reset-heartbeats`; `pause`/`unpause` exist, and `unpause` takes `--reset-attempts` as an
+  *option* [T3]. `update-options` can change the retry policy of a live activity incrementally
+  [T3]. Fresh budget is a deliberate operator choice, expressed as flags — not an automatic
+  consequence of retrying.
+
+### 2.8 Enterprise Integration Patterns — two channels, two prognoses
+
+Hohpe & Woolf split the space the house taxonomy already splits: the **Dead Letter Channel**
+receives messages the system "cannot or should not deliver" [E1] (delivery/processing failure —
+plausibly transient, worth redriving once the cause is fixed), while the **Invalid Message
+Channel** receives "messages that could not be processed by their receivers" because they are
+semantically improper — the guidance there is isolation and diagnosis by an error handler, not
+retry [E2]. A redrive verb is a Dead-Letter-Channel verb; the give-up/archive verb is the act of
+reclassifying a letter as Invalid-Message-Channel material.
+
+### 2.9 Adjacent domains: OTP supervision and `systemctl reset-failed`
+
+- **Erlang/OTP** bounds automatic restarts by intensity/period: "If more than `MaxR` number of
+  restarts occur in the last `MaxT` seconds, the supervisor terminates all the child processes
+  and then itself", escalating to the next supervisor, "to prevent a situation where a process
+  repeatedly dies for the same reason, only to be restarted again" [ER1]. Exhaustion escalates
+  *up a hierarchy* (which restarts the whole subtree with fresh counters) rather than parking
+  for an operator; the doc's tuning guidance warns that multiplied intensities across levels
+  produce excessive total restarts [ER1]. The house has no supervisor-of-supervisors; its
+  escalation target *is* the operator — which is the systemd shape:
+- **systemd** is the nearest analogue to an infra-level "clear the failure mark" verb. A unit
+  that fails "will automatically enter the 'failed' state and its exit code and status is
+  recorded for introspection by the administrator until the service is stopped/re-started or
+  reset with this command" [SD1]. `systemctl reset-failed` does exactly and only the clearing:
+  "Reset the 'failed' state of the specified units … In addition … it also resets various other
+  per-unit properties: the start rate limit counter of all unit types is reset to zero, as is
+  the restart counter of service units. Thus, if a unit's start limit … is hit and the unit
+  refuses to be started again, use this command to make it startable again" [SD1]. Three
+  properties worth copying: it is **not a domain operation** (no unit file changes, no history
+  rewrite — the journal keeps the failure record); it **resets the whole rate-limit budget**
+  (fresh episode, not one grudging attempt); and it is **separate from `start`** — clearing the
+  mark and re-running the work are two verbs (the house proposal fuses them into one, which is a
+  defensible convenience, not a conflict).
+
+---
+
+## 3. Synthesis: the five sub-questions across the field
+
+### 3.1 Failure-again semantics
+
+Nobody re-dead-letters a redriven item without at least one genuine processing attempt. Beyond
+that the field splits cleanly on one axis — **how much budget a redrive grants**:
+
+- **Fresh full budget (episode restart):** SQS (redriven message "considered new" [Q3], full
+  `maxReceiveCount` again), systemd (`reset-failed` zeroes the rate-limit counters [SD1]),
+  Temporal's `activity reset` ("as if it were first being scheduled" [T3]), and NServiceBus in
+  effect (re-enters the endpoint queue and full recoverability [P2][P5, secondary]).
+- **One additional attempt (budget preserved):** Sidekiq (`retry_count -= 1` then re-push
+  [SK2]) and Oban ("adding attempts if already maxed out" [O1]) — the job-queue systems, where a
+  hot loop of operator-retry → 25 automatic retries would be the worse failure mode.
+
+What distinguishes the two camps is *where the automatic retry ladder lives*: systems whose
+redrive re-enters the normal ladder (SQS, NServiceBus) grant the ladder; systems whose dead
+items sit *past* the ladder (Sidekiq, Oban) grant a probe. Both camps keep an across-episode
+trail: ServiceControl counts and displays failed retry attempts [P2]; Sidekiq's job payload
+carries its retry state forward [SK2]; only SQS severs the linkage (new `messageID` [Q3]) — and
+that is a limitation of its move-semantics, not a design ideal anyone else copied. Temporal
+makes the budget question an explicit operator *option* (`--reset-attempts`) [T3].
+
+### 3.2 Ledger disposition
+
+The invariant everywhere: **the active worklist entry leaves the worklist on redrive** — SQS
+deletes the message from the DLQ [Q3], Sidekiq's `retry` runs inside `remove_job` [SK2],
+ServicePulse hides the record from the failed list [P2]. What differs is whether a *history*
+survives, and that tracks whether the system separates worklist from record: ServiceControl
+retains the full record and merely re-labels it (retry-in-flight, failed-again with attempt
+counts, soft-`Deleted` with restore) [P2][P3]; Kafka's DLQ-as-topic keeps every episode by
+construction, since reprocessing moves an offset rather than deleting records [K1]; SQS and
+Sidekiq destroy the ledger row and keep history only in whatever the payload/logs carry. The
+systems with the best operator reputation (ServiceControl, Kafka) are the ones that treat
+stall-episode history as operationally valuable; SQS's history-severing is a known cost of its
+design. So: yes, episode history is valued in the field — but by the systems whose dead-letter
+store *is* their database, not by those whose store is a transport queue.
+
+### 3.3 Operator feedback
+
+Uniformly **fire-and-forget at the dispatch level, with status legible afterwards** — no
+surveyed system blocks the operator's request on the reprocessing outcome. SQS returns a
+`TaskHandle` and exposes task status/cancellation [Q4][Q3]; ServicePulse shows group-retry
+progress, then relies on audit/error ingestion to settle each message's fate, with the explicit
+caveat that a completed retry request "means those messages may not have been processed yet"
+[P1][P2]; Sidekiq just re-pushes and lets the tabs tell the story [SK1][SK3]. The field's
+hard-won lesson is ServicePulse's **Pending Retries** view [P4]: pure fire-and-forget without an
+acknowledgment loop breeds a limbo state ("requested but not completed") that eventually needs
+its own surface, its own re-retry verb, its own mark-as-resolved verb, and a duplicate-
+processing warning. Systems whose outcome signal is intrinsic (the item either reappears in the
+dead list or doesn't) escape that machinery; systems that track requests as first-class
+operations inherit it.
+
+### 3.4 Granularity
+
+The operator-UI systems all lead with **per-item**, and offer bulk as a second verb: ServicePulse
+individual/selection retry "before deciding to retry several messages in a group", then group
+retry [P1]; Sidekiq per-job plus `all/retry`, `all/delete`, `all/kill` routes [SK3]; Oban
+`retry_job` plus `retry_all_jobs` [O1]. SQS is the inversion — bulk-only, no per-message
+selection, no filtering [Q3] — and it is the transport-level outlier, not the pattern. Bulk is
+considered essential at queue scale (thousands of letters from one bug); its cost is one loop
+over the per-item verb, which is why every system that has per-item also has all.
+
+### 3.5 The give-up verb
+
+**Universally paired with retry, never absent** in the operator-facing systems: ServicePulse
+archive (soft, restorable, retention-pruned [P3]) and mark-as-resolved for pending retries
+[P4]; Sidekiq `delete` (hard discard) *and* `kill` (demote from retry set to morgue, firing
+death handlers [SK2][SK3]); Oban `cancel_job` (`cancelled` as a distinct terminal state from
+`discarded` [O1]); EIP frames it as reclassification from dead-letter (retryable) to
+invalid-message (diagnose, don't retry) [E1][E2]. Guards observed in the field: soft-delete with
+a restore tab rather than hard delete (ServicePulse [P3]); duplicate-processing warnings before
+resolving/retrying pending work [P4]; Sidekiq's morgue auto-prunes on age/size so even
+un-actioned letters don't accumulate forever [SK1] (the house `prune` horizon is the same
+mechanism, `dead-letter-port.ts:27-28`).
+
+---
+
+## 4. Collisions with the house constitution
+
+- **Redrive as an infra verb, no domain event — attested, with one caveat.** systemd's
+  `reset-failed` [SD1], SQS's move task [Q3], and ServiceControl's whole operation model
+  [P1-P4] all live entirely outside business data; the failure mark and its clearing are
+  operational state, exactly matching the house's deliberate choice of a ledger-derived (not
+  event-derived) stalled flag. The one system that *does* touch history — Temporal reset
+  terminates the execution and truncates its event history into a new run [T1] — is mutating an
+  **orchestration journal**, not business truth (the same distinction
+  `nonblocking-external-work-observation.md` §2.3 drew for Temporal's timer events). Ported
+  naively to this codebase it would violate "events are never edited or deleted"
+  (`event-sourcing.md`); it must be reported as conflicting prior art, and the house's
+  no-domain-event leaning is the correct filter for it.
+- **Re-dispatch derived from current state through the normal path — attested.** ServiceControl
+  re-sends through the endpoint's ordinary processing [P2]; SQS re-enqueues to the source queue
+  [Q3]; the house's own startup re-drive already is this operation minus the stalled-skip
+  (`reactor.ts:188-196`). No surveyed system has a special "redrive execution mode" — the whole
+  point is re-entering the normal machinery, which for this codebase also means duplicate
+  settlement is absorbed by `decide` ("idempotency for free", `event-sourcing.md`).
+- **At-least-once + duplicates.** ServicePulse's "Do not retry a message if it has been
+  processed by the endpoint" [P4] is the field naming the hazard the house has already absorbed
+  structurally: a redriven effect whose previous execution actually succeeded settles as a stale
+  command through `decide`. The house is *stronger* here than ServicePulse, which must warn the
+  operator instead.
+- **Errors are values.** The dead-letter row is the reactor handling an exhausted infra fault "at
+  the boundary that can actually make a decision" (`error-handling.md`) — and the redrive verb
+  is that boundary deciding again, with human input. Nothing surveyed conflicts.
+- **A house-specific wrinkle no surveyed system has:** in queue systems, deleting the letter *is*
+  giving up, because the queue entry is the only carrier of the work's intent (Sidekiq `delete`
+  discards the job [SK3]; SQS purge/expiry drops the message [Q1]). Here the intent lives in the
+  event stream: clearing a stream's letters without redriving does not abandon anything — the
+  stream still folds to a state that derives a pending effect, and the *next boot's* re-drive
+  pass (which only skips streams while they are stalled, `reactor.ts:221`) would dispatch it
+  anyway. An infra-only "dismiss/mark-resolved" verb therefore cannot express give-up in this
+  architecture; it is merely a deferred redrive. Giving up on the work is a domain decision, and
+  the domain already owns the verb for it (cancellation). This is a genuine divergence from the
+  field's pairing, driven by event sourcing, not an omission.
+
+---
+
+## 5. Verdict — applied to the live decision
+
+**Sub-question 1 — failure-again.** The field splits on budget (fresh full ladder: SQS, systemd,
+Temporal-reset, NServiceBus [Q3][SD1][T3][P2]; single probe attempt: Sidekiq, Oban [SK2][O1]),
+but converges on: at least one real attempt, re-dead-letter through the *same* machinery on
+failure, and keep an across-episode trail. The house leaning — re-dispatch through the normal
+dispatch path — lands it in the fresh-full-budget camp (the redriven effect gets the ordinary
+park/backoff/exhaustion ladder and re-dead-letters at its end), which is the majority position
+and the systemd/Temporal position specifically. Attested. The one refinement the field suggests:
+ServiceControl counts and displays failed retry attempts across episodes [P2]; if runaway
+redrive ever matters (scripted redrive against a permanently broken stream), an episode count is
+the field's answer — surfaced, not enforced.
+
+**Sub-question 2 — ledger disposition.** Split, and the split is explainable: transport-store
+systems delete (SQS [Q3], Sidekiq [SK2]); database-store systems retain and re-label
+(ServiceControl [P2][P3], Kafka-by-construction [K1]) — and the database-store systems clearly
+treat episode history as operationally valuable. The house store is a database, but the house
+leaning (delete via the existing `clearStream`) is also the *existing* semantics of
+success-driven resolution (`reactor.ts:296-300`) and keeps one meaning for "letters exist ⇔
+stream is stalled". Attested either way; the honest middle from the field: delete from the
+worklist, but don't let the error text vanish into nothing at the moment of redrive — a
+structured log line (letters count + errors) at redrive time, or a retained-but-resolved row, is
+the ServiceControl lesson at SQLite scale. Do not adopt Temporal-style history mutation, and do
+not mint a domain event for it (§4).
+
+**Sub-question 3 — operator feedback.** Convergence: accept the request, return, and let an
+existing status surface tell the story; no system blocks on the reprocessing outcome (a
+redriven effect can legitimately take its whole retry ladder to settle). The house leaning is
+compatible and the house already owns the status surface: the stalled flag clears on redrive,
+the acquisition's history narration shows subsequent motion, and re-stalling re-appears in the
+ledger-seeded read model. The ServicePulse lesson to heed [P4]: the window between "redrive
+accepted" and "settled or re-stalled" should be legible (in-flight/parked already renders in the
+UI's own language) — but the house does *not* need a pending-retries subsystem, because its
+outcome signal is intrinsic (the stalled flag either stays cleared or returns), which is exactly
+the property that let Sidekiq skip that machinery too.
+
+**Sub-question 4 — granularity.** Convergence among operator-UI systems: per-item first, bulk as
+a trivially-added second verb [P1][SK3][O1]; only the transport-level SQS is bulk-only [Q3]. The
+house's per-stream leaning is attested and is the right first verb; a "redrive all stalled"
+button is one loop over it and worth having (whole-fleet recovery after an infra fix — the
+dominant real redrive scenario in ServiceControl's grouping model [P1]), but it is not essential
+at a scale of single-digit stalled acquisitions.
+
+**Sub-question 5 — give-up verb.** The field pairs retry with an explicit discard/archive
+everywhere it has an operator surface (archive/restore [P3], delete/kill [SK3], cancel [O1],
+mark-resolved [P4]), usually soft-deleted and retention-pruned. The house diverges *correctly*:
+an infra-level dismiss cannot express abandonment here, because intent lives in the event stream
+and the next boot re-derives the pending effect once the stalled skip is cleared (§4). The
+give-up half of the pair already exists as the domain's cancellation verb; the OpenSpec proposal
+should say so explicitly (the stalled UI offering both "redrive" and "cancel the acquisition" is
+the field's pairing, correctly altitude-split), rather than inventing a letters-dismissal verb
+that would silently behave as a deferred redrive.
+
+**Pitfall checklist for the OpenSpec proposal:**
+
+1. **Guard the verb's precondition.** Redrive only a stream that is actually stalled; reject or
+   no-op otherwise (Oban ignores `available`/`executing` jobs [O1]; SQS allows one active move
+   task per queue [Q4]). Concurrent/double redrive requests must be idempotent.
+2. **Run it on the dispatch mutex.** The startup re-drive already runs under the mutex to avoid
+   "a check-then-act re-attach hazard" (`reactor.ts:193-195`); the operator verb is the same
+   operation and needs the same seat.
+3. **No special execution mode.** Failure-again must flow through the ordinary
+   park → backoff → exhaust → dead-letter ladder and land as a fresh letter set — no one-shot
+   probe unless deliberately chosen against the majority pattern (§5.1).
+4. **Clear ledger + in-memory stalled mark through one seam** (the existing `clearStalled`
+   path), so the boot-seeded read model can never disagree with the table.
+5. **Don't destroy the trail silently.** At minimum, log the cleared letters (count, errors,
+   ages) at the moment of redrive; decide consciously whether an episode counter is wanted
+   (ServiceControl precedent [P2]).
+6. **Duplicate-settlement honesty.** The redriven effect may duplicate work whose earlier
+   execution partially succeeded; the proposal should name `decide`'s stale-command absorption
+   as the mechanism (not an operator warning à la ServicePulse [P4]) and test that path.
+7. **No payload/state editing in the verb.** SQS explicitly refuses "filtering and modifying
+   messages while redriving" [Q3]; the house verb re-derives the effect from folded state and
+   takes no arguments beyond the stream.
+8. **Fire-and-forget response shape.** Return accepted; feedback is the stalled flag + history
+   surface. Do not await settlement in the HTTP handler (the ladder can take minutes by
+   design).
+9. **Pair it on the UI, not in the ledger.** The stalled surface should offer redrive alongside
+   the existing domain cancellation; no infra "dismiss" verb (§4, §5.5).
+10. **Additive contract only.** The admin surface's new verb and any status fields must be
+    additive on the BFF contract, per the no-breaking-change rule (CLAUDE.md), and the verb
+    belongs in the web register's verb inventory like every other action telling.
+
+---
+
+## 6. Citations
+
+**This repository** (checkout `/home/jake/Projects/music-downloader-2`, branch state at research
+time):
+
+- `packages/downloader/src/application/ports/dead-letter-port.ts:4-29`
+- `packages/downloader/src/application/acquisition/reactor.ts:188-196, 221, 296-300`
+- `docs/development/event-sourcing.md`, `docs/development/error-handling.md`, `CLAUDE.md`
+- [`docs/research/nonblocking-external-work-observation.md`](nonblocking-external-work-observation.md) — supervisor/delivery-loop prior art, Temporal journal-vs-business-truth distinction (§2.3)
+
+**AWS SQS (developer guide + API reference):**
+
+- [Q1] Using dead-letter queues in Amazon SQS — redrive policy, `maxReceiveCount`, retention
+  best practice: <https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-dead-letter-queues.html>
+- [Q2] Configure a dead-letter queue (console) — maximum receives 1-1000:
+  <https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-dead-letter-queue.html>
+- [Q3] Configure a dead-letter queue redrive — move semantics, "considered new messages",
+  retention reset, velocity, no filtering/modifying, 36 h/100-task limits, cancel behavior,
+  minimum IAM (Receive+Delete on DLQ, Send on destination):
+  <https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-configure-dead-letter-queue-redrive.html>
+- [Q4] `StartMessageMoveTask` API — asynchronous task, `TaskHandle`, DLQ-source-only, default
+  destination = original source, `MaxNumberOfMessagesPerSecond` ≤ 500, one active task per
+  queue: <https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_StartMessageMoveTask.html>
+
+**Particular Software (NServiceBus / ServiceControl / ServicePulse):**
+
+- [P1] Failed Message Monitoring — per-message/selection/group retry, grouping keys, group
+  progress, "may not have been processed yet":
+  <https://docs.particular.net/servicepulse/intro-failed-messages>
+- [P2] Retrying failed messages — hidden while sent-for-retry, reappears on failure, retry
+  attempts tracked and shown:
+  <https://docs.particular.net/servicepulse/intro-failed-message-retries>
+- [P3] Archived (deleted) messages — soft `Deleted` mark, restore tab, retention-scheduled
+  removal: <https://docs.particular.net/servicepulse/intro-archived-messages>
+- [P4] Pending Retries — the fire-and-forget limbo state, retry-again / mark-as-resolved,
+  duplicate-processing warning:
+  <https://docs.particular.net/servicepulse/intro-pending-retries>
+- [P5] NServiceBus Recoverability — immediate/delayed retries, move to error queue with
+  exception details: <https://docs.particular.net/nservicebus/recoverability/>
+- Note: `docs.particular.net/servicecontrol/errors` returned 404 at research time (content
+  reorganized into the ServicePulse pages above); the claim that a ServiceControl-retried
+  message passes through full endpoint recoverability again is marked [secondary] in §2.2.
+
+**MassTransit:**
+
+- [M1] Exceptions — `_error` queues, fault headers, broker-tool extraction/resend, pointer to
+  Particular's platform: <https://masstransit.io/documentation/concepts/exceptions> (redirects
+  to masstransit.massient.com; fetched there)
+
+**Kafka / Confluent:**
+
+- [K1] Robin Moffatt, *Kafka Connect Deep Dive — Error Handling and Dead Letter Queues*
+  (Confluent blog) — `errors.tolerance`, DLQ topic + context headers, chained-connector
+  reprocessing, retention-based (non-deleting) disposition:
+  <https://www.confluent.io/blog/kafka-connect-deep-dive-error-handling-dead-letter-queues/>
+
+**Sidekiq (Mike Perham's wiki + source, main branch @ 2026-08-05):**
+
+- [SK1] Error Handling wiki — 25 retries/backoff formula, Dead set ("holding pen"), 10,000
+  jobs / 6 months cap, `retry: false` discarded, `:kill`/`:discard` outcomes, Web UI tabs:
+  <https://github.com/sidekiq/sidekiq/wiki/Error-Handling>
+- [SK2] `lib/sidekiq/api.rb` — `SortedEntry#retry` (`retry_count -= 1` + re-push),
+  `SortedEntry#kill`, `DeadSet#kill` (death handlers), `DeadSet#trim`:
+  <https://github.com/sidekiq/sidekiq/blob/main/lib/sidekiq/api.rb>
+- [SK3] `lib/sidekiq/web/application.rb` — morgue/retries routes: per-key and selected-set
+  `retry_or_delete_or_kill`, `/morgue/all/retry` (`DeadSet#retry_all`), `/morgue/all/delete`
+  (`DeadSet#clear`), `/retries/all/kill`:
+  <https://github.com/sidekiq/sidekiq/blob/main/lib/sidekiq/web/application.rb>
+
+**Oban:**
+
+- [O1] `Oban.retry_job` / `retry_all_jobs` / `cancel_job` — "adding attempts if already maxed
+  out", `available`/`executing` ignored, `cancelled` vs `discarded`:
+  <https://hexdocs.pm/oban/Oban.html>
+
+**Temporal:**
+
+- [T1] Workflow Execution reset — terminates and re-creates with truncated history, optional
+  signal re-application: <https://docs.temporal.io/workflow-execution/event#reset>
+- [T2] `temporal workflow reset` CLI — reset points, batch reset types:
+  <https://docs.temporal.io/cli/workflow>
+- [T3] `temporal activity` CLI — `reset` ("as if it were first being scheduled", resets
+  attempts + timeout), `pause`/`unpause --reset-attempts`, `update-options`:
+  <https://docs.temporal.io/cli/activity>
+
+**Enterprise Integration Patterns (Hohpe & Woolf):**
+
+- [E1] Dead Letter Channel: <https://www.enterpriseintegrationpatterns.com/patterns/messaging/DeadLetterChannel.html>
+- [E2] Invalid Message Channel: <https://www.enterpriseintegrationpatterns.com/patterns/messaging/InvalidMessageChannel.html>
+
+**Erlang/OTP:**
+
+- [ER1] Supervisor behaviour — restart intensity/period, self-termination and escalation,
+  rationale: <https://www.erlang.org/doc/system/sup_princ.html>
+
+**systemd:**
+
+- [SD1] `systemctl(1)` — `reset-failed`: failed-state semantics, start rate limit counter and
+  service restart counter reset, "make it startable again":
+  <https://man7.org/linux/man-pages/man1/systemctl.1.html> (freedesktop.org canonical page
+  returned HTTP 403 at research time; man7.org mirrors the same man page)
+
+---
+
+*These findings are research input to a decision, not normative policy. Nothing here changes the
+constitution or any spec until adopted through an OpenSpec change.*

--- a/openspec/changes/stalled-work-recovery/.openspec.yaml
+++ b/openspec/changes/stalled-work-recovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/stalled-work-recovery/design.md
+++ b/openspec/changes/stalled-work-recovery/design.md
@@ -1,0 +1,113 @@
+# Design — stalled-work-recovery
+
+## Context
+
+See proposal.md — Why. The machinery is nearly all in place at v3.16.0: dead letters are rows
+`(subscription, globalSeq, error, occurredAt, streamId)` in each module's store; the in-memory
+`StalledReadModel` seeds from them at boot; the startup re-drive derives pending work from
+folded state under the dispatch mutex and skips stalled streams; a later successful dispatch
+already clears letters + exposure through one seam; both facades already emit a `stalled` flag
+the web never reads. What is missing is a trigger that does not require a restart, the facade
+reads/verbs around it, and the two registers' surfaces. Evidence base:
+`docs/research/dead-letter-redrive-semantics.md` (all five verdicts + the ten-item pitfall
+checklist, which this design tracks item by item); grill decisions 2026-08-05 in-conversation.
+Depends on `auth-roles` (the `authorize` seam, `system:redrive` reserved).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Retire the DB-surgery redrive procedure: see, diagnose, and recover stalled work from the UI.
+- Keep the domain pure: no stall/redrive concept enters events, commands, or deciders.
+- Make the supervisor's undeliverable-outcome pathology visible to `/health`.
+
+**Non-Goals:**
+
+- No episode counter / letters archive (research §5.1–5.2 refinements; trigger: scripted or
+  repeated redrive against the same stream becomes a real pattern).
+- No pending-retries subsystem (research §5.3 — the stalled flag's stay-cleared-or-return
+  behavior is the outcome signal, the Sidekiq property).
+- No SSE/liveness changes; the existing self-refresh carries the stalled telling.
+- No importer-supervisor work: the delivery-loop changes are downloader-only (the importer has
+  no supervisor).
+
+## Decisions
+
+**D1 — The redrive operation lives on the reactor, exposed via the facade.** Each module's
+reactor gains `redriveStalled(streamId)`: take the dispatch mutex (pitfall 2 — same seat as the
+startup re-drive's check-then-act guard), verify letters exist (pitfall 1 — modeled refusal
+otherwise; concurrent submissions collapse to one refusal + one run), log the letters about to
+clear (pitfall 5), clear via the existing `clearStream` + `stalled.clear` seam (pitfall 4 — one
+seam, read model can never disagree with the table), then reuse the existing `redriveStream`
+logic minus its stalled-skip (pitfall 3 — normal ladder, fresh budget, no special mode; pitfall
+7 — no arguments beyond the stream). The facade wraps it as a fire-and-forget verb returning
+accepted/refused (pitfall 8). Alternative considered — a standalone application service
+orchestrating store + reactor: rejected, it would duplicate the mutex and the pending-effect
+derivation the reactor already owns.
+
+**D2 — Stalled-work read is a facade query over existing parts.** `listStalled()` joins the
+dead-letter rows (diagnostics, `occurredAt`) with the stream's work identity — additive DTO,
+operator-register fields explicitly documented as such (raw error text is the point; the
+recorder-style scrub question does not arise because nothing leaves the process). The web
+composes both modules' reads; no cross-module contract (the compose stays in the BFF like the
+attention queue's).
+
+**D3 — Registers split exactly as grilled.** User register: `stalled` tone/copy joins the
+existing decided-flag consumption path in `copy.ts`/detail/list (no re-derivation; the S2
+hardening batch's `z.literal(true)` alignment is assumed but not required — `boolean` reads the
+same). Operator register: a `/system` route behind `authorize(session, 'system:redrive')`;
+its copy is exempt from the narration register (spec'd in `web-operations`), and the verb
+inventory gains the redrive entry as non-destructive (pitfall 10) with cancellation offered
+through the existing destructive-gated form.
+
+**D4 — Supervisor backoff + readiness.** The `deliver` loop's flat `pollIntervalMs` sleep
+becomes escalating backoff (base = poll cadence, factor 2, env-capped ceiling), keeping the
+existing warn→error escalation cadence. Persistent failure past a configured attempt threshold
+sets a delivery-failure gauge the runtime's `readiness()` consults; success (in-process or
+post-restart re-emit) clears it. Threshold and ceiling are ordinary env config with defaults;
+no new durable store (restart re-emit remains the heal). Stalled streams deliberately do NOT
+degrade readiness (spec'd in `runtime-baseline`) — they are operator work, not process faults.
+
+**D5 — E2E forces the stall with permissions, tunes the budget with env.** The phase makes the
+staged library destination unwritable (root-owned read-only bind mount), submits a normally-
+completing flow, waits for the stalled telling (env-tuned budget: retry count and backoff base
+already flow from composition config; the e2e run sets them small), restarts once to prove
+durability, repairs the mount, redrives via the operations route with an owner session (the
+harness already mints cookies via the production codec — it gains the role claim from
+`auth-roles`), and asserts ordinary completion. Copy scraped through `helpers.ts`'s centralized
+phrase maps (the S3 batch moves the strays there).
+
+**D6 — Naming.** The user-facing telling avoids "stalled" (jargon-adjacent); the register pass
+picks the phrase during implementation, in the narrator's voice, with the tone map extended
+exhaustively (`satisfies` totality as everywhere else). "Redrive" is the operator surface's
+verb name verbatim — the operator register speaks infrastructure.
+
+## Risks / Trade-offs
+
+- **[Redrive races a concurrently-arriving event on the same stream]** → Both paths serialize on
+  the dispatch mutex, and whichever runs second sees post-fold state; a duplicate effect settles
+  as stale through `decide` (pitfall 6; spec'd scenario).
+- **[The importer's multi-effect loop interacts with redrive]** → The S1 hardening batch fixes
+  the sibling-drop hazard first; redrive dispatches whatever pending effects folded state
+  derives, so it inherits the fixed semantics. Sequencing: S1 merges before this ships.
+- **[Forcing exhaustion via env-tuned budgets weakens the e2e's production fidelity]** → The
+  tuning uses the ordinary config surface only (spec'd); the restart-durability scenario runs
+  under the same tuning, and production timings stay covered by the unit/integration tiers.
+- **[A stalled item's diagnostics could contain peer usernames]** → Operator-register-only
+  surface behind the owner gate; the S1 redaction work covers the log/dead-letter payload side.
+- **[`waitingSince` plumbing]** → The operations surface orders by ledger `occurredAt`
+  directly; the user-facing attention queue's dead `waitingSince` optional stays untouched (its
+  producers remain the facades, per its own recorded deferral).
+
+## Migration Plan
+
+Ships after `auth-roles`. Additive contracts only; no data migration (existing dead-letter rows
+surface immediately — any stall live on flight at deploy time becomes visible, which is the
+point). Rollback is the previous image; letters and stalled exposure behave as today.
+
+## Open Questions
+
+- The exact user-register phrase and tone for the stalled telling — a copy decision inside the
+  established register rules, settled at implementation with the usual copy tests.
+- The default backoff ceiling and readiness threshold values — tuned at implementation against
+  the supervisor's existing cadences; env-overridable either way.

--- a/openspec/changes/stalled-work-recovery/proposal.md
+++ b/openspec/changes/stalled-work-recovery/proposal.md
@@ -1,0 +1,86 @@
+# Proposal: stalled-work-recovery
+
+## Why
+
+Both modules' reactors dead-letter an effect after its retry budget exhausts, mark the stream
+stalled, and wait for an operator — but the whole-project review sweep (2026-08-05) confirmed
+the flag dies at the BFF: nothing under `packages/web` reads `stalled`, so a dead-lettered
+import renders as ordinary in-flight work forever, and recovery is DB surgery plus a restart
+(the chroma-plugin incident, verbatim). The download supervisor has the sibling gap: an
+undeliverable outcome retries on a flat 1s cadence forever, invisible to `/health` — the
+consciously deferred v3.16.0 follow-up. The grilling session (2026-08-05) converged the design;
+the evidence base is `docs/research/dead-letter-redrive-semantics.md`, whose verdicts attest
+every decision below and whose pitfall checklist shapes the specs.
+
+## What Changes
+
+- **Stalled work becomes visible in two registers.** The user register tells the truth in the
+  narrator's voice — a stalled acquisition/import reads as stuck and needing the system's
+  operator, never as an eternal "Adding to the library…" — on detail pages and list rows, with
+  no verb attached. The attention queue stays scoped to user-resolvable judgments; operator
+  work is expressly not its concern (its charter is amended to say so).
+- **An owner-gated operations surface** (first consumer of `auth-roles`' `authorize` seam and
+  its reserved `system:redrive` action) lists exactly the stalled work across both modules —
+  linked item, when it stalled (the ledger's `occurredAt`, finally a real producer for
+  longest-waiting ordering), and the dead-letter diagnostics in the operator's register — with
+  per-item **redrive** and a redrive-all convenience. Expansion trigger: a second operational
+  concern needing eyes (the supervisor's delivery-failure state is the named candidate).
+- **The redrive verb is an infra operation, not a domain fact** (research §4: the
+  systemd/ServiceControl camp; Temporal-style history mutation explicitly rejected). Per module,
+  fire-and-forget: under the dispatch mutex, clear the stream's letters and stalled mark through
+  the one existing seam, log the cleared trail (count, errors, ages — research §5.2), and
+  re-dispatch the pending effect derived from folded state through the normal
+  park → backoff → exhaust → dead-letter ladder — a fresh full budget (research §5.1, the
+  majority camp), re-stalling honestly at its end. No domain event; duplicate settlement is
+  absorbed by `decide` as stale (research §5.3). Redriving a non-stalled stream is a modeled
+  no-op refusal; concurrent redrives are idempotent.
+- **No letters-dismissal verb** — in this architecture a dismissed-but-unredriven stream is just
+  a deferred redrive (the next boot re-derives the effect), so give-up remains the domain's own
+  cancellation, offered alongside redrive on the operations surface (research §5.5, the
+  altitude-split pairing).
+- **The supervisor's delivery loop escalates beyond logs**: bounded escalating backoff replaces
+  the flat 1s cadence, and persistent delivery failure degrades the module's readiness snapshot
+  so `/health` finally sees it. Restart re-emit stays the durable heal; no new durable store.
+- **The e2e tier gains a recovery phase**: force a genuine importer stall (unwritable library
+  mount) against an env-tunable retry budget, witness the user-register telling, repair, redrive
+  from the operations surface, and witness completion — the operator's golden path, exercised
+  out-of-process.
+- **Non-goals:** no domain/event-schema change in either module; no letters archive/episode
+  counter (surfaced as a recorded refinement trigger, not built); no broader ops cockpit; no
+  changes to the Needs-attention queue's membership.
+
+## Capabilities
+
+### New Capabilities
+
+- `web-operations`: the owner-gated operations surface — the stalled-work list with operator
+  diagnostics, the redrive verbs (per-item and all), the cancellation pairing, and its gating
+  through the authorization seam.
+
+### Modified Capabilities
+
+- `cross-module-delivery`: dead-lettered work becomes operator-redrivable — the redrive
+  operation's semantics (precondition, mutex seat, one clearing seam, fresh budget through the
+  normal ladder, logged trail, fire-and-forget) join the park/dead-letter contract.
+- `download-management`: the undeliverable-outcome delivery loop gains bounded escalating
+  backoff and a readiness consequence.
+- `runtime-baseline`: the readiness snapshot reflects persistent outcome-delivery failure, not
+  only halted subscriptions.
+- `web-ui`: stalled work tells the truth in the user register; the attention queue's charter is
+  scoped to user-resolvable judgments.
+- `out-of-process-e2e`: the stall → surface → redrive → recovery phase.
+
+## Impact
+
+- **Code:** both modules' application layers (redrive operation on the reactor, facade queries
+  for stalled diagnostics, facade redrive verb), the downloader's slskd supervisor (backoff +
+  readiness wiring), both facades' additive DTO growth, `packages/web` (user-register tellings,
+  the `/system` operations route behind `authorize`, verb-inventory entries), `test/e2e` (new
+  phase + env-tunable retry budget), contract tiers for the additive facade shapes.
+- **Contracts:** additive only — new facade queries/verbs and optional DTO fields; the wire
+  `stalled` flag already exists on both facades (the downloader's encoding is being aligned to
+  `z.literal(true)` by the concurrent S2 hardening batch; this change builds on it either way).
+- **Dependencies:** requires `auth-roles` (the seam and the `system:redrive` action) merged
+  first.
+- **Operations:** closes the review sweep's sole Critical-severity gap and retires the
+  DB-surgery redrive procedure memorialized in the incident notes.

--- a/openspec/changes/stalled-work-recovery/specs/cross-module-delivery/spec.md
+++ b/openspec/changes/stalled-work-recovery/specs/cross-module-delivery/spec.md
@@ -1,0 +1,51 @@
+# cross-module-delivery — delta for stalled-work-recovery
+
+## ADDED Requirements
+
+### Requirement: Dead-lettered work is operator-redrivable without a restart
+
+Each module SHALL expose, through its facade, a stalled-work read (every stalled stream with its
+dead-letter diagnostics and recorded stall time) and a per-stream redrive operation. Redrive
+SHALL be an infrastructure operation — no domain command, no event appended — that runs on the
+same dispatch serialization as the startup re-drive and, in order: verifies the stream is
+actually stalled (refusing otherwise as a modeled outcome, idempotent under concurrent
+requests); logs the letters it is about to clear (count, errors, ages) so the trail never
+vanishes silently; clears the stream's letters and stalled exposure through the module's single
+existing clearing seam; and re-dispatches the stream's pending effect, derived from folded
+state, through the normal dispatch path with a fresh full retry budget — the ordinary
+park/backoff/exhaustion ladder, dead-lettering again at its end. The operation SHALL take no
+arguments beyond the stream identity — no payload or state editing — and SHALL return once
+dispatch is initiated, not once the work settles. A redriven effect whose earlier execution
+partially succeeded SHALL settle through the domain's ordinary stale-command absorption.
+
+#### Scenario: Redrive re-dispatches through the normal ladder
+
+- **GIVEN** a stalled stream whose failure cause has been repaired
+- **WHEN** its redrive is invoked
+- **THEN** the letters are logged then cleared, the stalled exposure lifts, the pending effect
+  dispatches through the normal path, and the stream proceeds to its ordinary outcome
+
+#### Scenario: A still-broken stream re-stalls with a fresh trail
+
+- **GIVEN** a stalled stream whose failure cause persists
+- **WHEN** its redrive is invoked and the effect exhausts a fresh retry budget
+- **THEN** the stream is dead-lettered and marked stalled again through the ordinary machinery,
+  with the new failure recorded
+
+#### Scenario: Redriving a non-stalled stream is refused as a value
+
+- **WHEN** redrive is invoked for a stream with no dead letters
+- **THEN** the operation returns a modeled refusal, dispatches nothing, and clears nothing
+
+#### Scenario: A duplicate-settling redrive is absorbed
+
+- **GIVEN** a stalled stream whose dead-lettered effect had actually completed its side effect
+  before the failure was recorded
+- **WHEN** it is redriven and the effect's outcome reports work already settled
+- **THEN** the domain absorbs it as a stale command and the stream converges without corruption
+
+#### Scenario: The event history is untouched
+
+- **WHEN** any redrive is invoked, succeeding or failing
+- **THEN** no event is appended, edited, or deleted in either module's store on account of the
+  redrive itself

--- a/openspec/changes/stalled-work-recovery/specs/download-management/spec.md
+++ b/openspec/changes/stalled-work-recovery/specs/download-management/spec.md
@@ -1,0 +1,32 @@
+# download-management — delta for stalled-work-recovery
+
+## ADDED Requirements
+
+### Requirement: Undeliverable outcomes escalate beyond logs
+
+When a settled download outcome cannot be delivered to the module's decision path, the delivery
+loop SHALL retry with bounded escalating backoff up to a configured ceiling — not a fixed
+cadence — and persistent delivery failure SHALL be reported into the module's readiness
+snapshot (see `runtime-baseline`) so the composed health surface reflects it. Delivery SHALL
+remain at-least-once with restart re-emit as the durable recovery; no additional durable store
+is introduced for undelivered outcomes. When delivery eventually succeeds, the readiness
+contribution SHALL clear.
+
+#### Scenario: Backoff escalates instead of spinning
+
+- **GIVEN** a settled outcome whose delivery keeps failing
+- **WHEN** the delivery loop retries
+- **THEN** successive attempts are spaced by escalating delays up to the ceiling, not a flat
+  cadence
+
+#### Scenario: Persistent failure degrades readiness
+
+- **GIVEN** an outcome whose delivery has failed persistently past the configured threshold
+- **WHEN** the module's readiness snapshot is read
+- **THEN** it reports the module degraded on account of undeliverable outcomes
+
+#### Scenario: Recovery clears the signal
+
+- **GIVEN** readiness degraded by undeliverable outcomes
+- **WHEN** a subsequent delivery attempt succeeds (in-process or after a restart re-emit)
+- **THEN** the readiness snapshot no longer reports the delivery failure

--- a/openspec/changes/stalled-work-recovery/specs/out-of-process-e2e/spec.md
+++ b/openspec/changes/stalled-work-recovery/specs/out-of-process-e2e/spec.md
@@ -1,0 +1,33 @@
+# out-of-process-e2e — delta for stalled-work-recovery
+
+## ADDED Requirements
+
+### Requirement: The stall-recovery phase proves the operator's golden path
+
+The e2e tier SHALL include an isolated phase that forces a genuine dead-letter stall in the
+running image — by making the library destination unwritable so the import's apply effect
+exhausts its retry budget against real infrastructure — and then witnesses the full recovery
+path over HTTP: the user-register surfaces stop claiming progress and tell the stalled truth;
+the operations surface (authenticated as an owner) lists the stalled item with its diagnostics;
+after the underlying cause is repaired, submitting the redrive resumes the work; and the story
+reaches its ordinary imported outcome with the stalled telling gone. The retry budget and
+backoff SHALL be tunable through the environment so the phase forces exhaustion in seconds, not
+production timings; the tuning SHALL use the ordinary configuration surface, not a test-only
+code path in the image.
+
+#### Scenario: A forced stall surfaces, redrives, and completes
+
+- **GIVEN** the image running with an e2e-tuned retry budget and an unwritable library
+  destination
+- **WHEN** an import's apply effect exhausts its budget, the destination is then repaired, and
+  the phase submits the item's redrive through the operations surface
+- **THEN** before the redrive the story reads as stalled (not in-progress) and the operations
+  surface lists it with diagnostics; after the redrive the import completes into the library and
+  the stalled telling is gone
+
+#### Scenario: The stall survives a restart before the redrive
+
+- **GIVEN** a forced stall as above
+- **WHEN** the container restarts before any redrive
+- **THEN** the item is still reported stalled after boot — the exposure is durable, not
+  in-memory — and the redrive path still recovers it

--- a/openspec/changes/stalled-work-recovery/specs/runtime-baseline/spec.md
+++ b/openspec/changes/stalled-work-recovery/specs/runtime-baseline/spec.md
@@ -1,0 +1,44 @@
+# runtime-baseline — delta for stalled-work-recovery
+
+## MODIFIED Requirements
+
+### Requirement: Each module runtime exposes a readiness snapshot
+
+Each module runtime SHALL expose a synchronous, side-effect-free readiness snapshot reporting
+whether that module is currently able to serve — reflecting in-memory runtime state (its store,
+reactors, and seam subscription being live and not halted, and no persistent
+outcome-delivery failure past its configured threshold), not a query computed against its event
+store. Reading the snapshot SHALL NOT perform I/O, SHALL NOT scan the event store, SHALL NOT
+reach any third-party dependency, and SHALL return a value rather than throwing. The snapshot
+SHALL be readable by the composed process's interface layer without importing module-internal
+code and without coupling one module's readiness to the other's. Stalled (dead-lettered) work
+SHALL NOT degrade readiness: it is waiting on an operator, not a process fault, and it has its
+own surface.
+
+#### Scenario: Snapshot reflects a healthy runtime
+
+- **WHEN** the interface reads a booted module runtime's readiness snapshot while its store, reactors, and seam subscription are live
+- **THEN** the snapshot reports the module as up, returned as a value with no I/O and no event-store access
+
+#### Scenario: Snapshot reflects a halted runtime
+
+- **WHEN** a module runtime's seam subscription has halted (for example, parked on a poison event) and the interface reads its readiness snapshot
+- **THEN** the snapshot reports the module as down without throwing
+
+#### Scenario: Reading readiness has no side effects
+
+- **WHEN** the readiness snapshot is read repeatedly, including at probe frequency
+- **THEN** each read is free of I/O and side effects and does not advance, mutate, or scan the module's event store
+
+#### Scenario: Persistent delivery failure degrades the snapshot
+
+- **WHEN** a module's outcome delivery has failed persistently past its configured threshold and
+  the interface reads its readiness snapshot
+- **THEN** the snapshot reports the module degraded, still as a value with no I/O
+
+#### Scenario: Stalled work does not degrade the snapshot
+
+- **GIVEN** a module with dead-lettered, stalled streams but live machinery
+- **WHEN** the interface reads its readiness snapshot
+- **THEN** the snapshot reports the module as up — stalled work is an operator concern, not a
+  process fault

--- a/openspec/changes/stalled-work-recovery/specs/web-operations/spec.md
+++ b/openspec/changes/stalled-work-recovery/specs/web-operations/spec.md
@@ -1,0 +1,88 @@
+# web-operations — delta for stalled-work-recovery
+
+## Purpose
+
+Give the system's operator a gated surface for work only an operator can do: see everything
+currently stalled across the modules with the diagnostics an intervention needs, and recover it
+with the redrive verb — paired with the domain's own give-up — without shell access, DB surgery,
+or a restart.
+
+## ADDED Requirements
+
+### Requirement: The operations surface is owner-gated through the authorization seam
+
+The operations surface — its pages and every verb it offers — SHALL be reachable only when the
+authorization seam permits the presenting session the corresponding privileged action (see
+`web-authorization`); the redrive verbs SHALL be gated by the `system:redrive` action. A refusal
+SHALL produce no side effects and SHALL NOT reveal the surface's content. The surface SHALL NOT
+appear in the base navigation shown to guest sessions.
+
+#### Scenario: A guest cannot reach the surface
+
+- **WHEN** a request with a valid guest-role session targets the operations surface or submits a
+  redrive
+- **THEN** the authorization seam refuses it, nothing is listed or executed, and the response
+  reveals no operational detail
+
+#### Scenario: The owner reaches the surface
+
+- **WHEN** a request with a valid owner-role session targets the operations surface
+- **THEN** the stalled-work list is served
+
+### Requirement: The operations surface lists exactly the stalled work
+
+The operations surface SHALL list every currently stalled item across both modules, composed by
+the web layer from each module facade's own stalled-work read — introducing no cross-module
+contract — and ordered longest-stalled first using the dead-letter ledger's recorded time. Each
+item SHALL identify the work it belongs to (linked to its detail page), when it stalled, and the
+recorded failure diagnostics. This surface speaks the operator's register: technical diagnostics
+(error text, subscription names) MAY render verbatim, and the one-voice narration register does
+not apply. When one module's read fails, the other module's items SHALL still render alongside a
+modeled error for the failed section.
+
+#### Scenario: Stalled items from both modules appear with diagnostics
+
+- **GIVEN** a stalled import and a stalled acquisition
+- **WHEN** the owner opens the operations surface
+- **THEN** both appear in one list, longest-stalled first, each linking to its detail page and
+  showing when it stalled and the recorded error text
+
+#### Scenario: Nothing stalled renders an empty state
+
+- **WHEN** the owner opens the operations surface while no work is stalled
+- **THEN** an explicit all-clear empty state renders, not a blank page
+
+#### Scenario: One module failing does not empty the surface
+
+- **GIVEN** one module's stalled-work read fails
+- **WHEN** the owner opens the operations surface
+- **THEN** the other module's items are listed and the failed section renders a modeled error
+
+### Requirement: Redrive is offered per item, with give-up as the domain's own verb
+
+Each stalled item SHALL offer a redrive action, and the surface SHALL offer a redrive-all
+convenience that is one iteration of the per-item verb. Submitting a redrive SHALL be
+fire-and-forget: the response acknowledges acceptance and the outcome is read from the existing
+status surfaces — the item leaves the stalled list, and either progresses or returns to it. The
+surface SHALL NOT offer any dismiss/ignore verb that clears letters without redriving; where
+giving up is wanted, the surface SHALL point to (or offer, where it already exists) the work's
+own domain cancellation, in its ordinary destructive-confirmation form.
+
+#### Scenario: Redriving a stalled item
+
+- **GIVEN** a stalled import whose underlying cause has been repaired
+- **WHEN** the owner submits its redrive
+- **THEN** the response acknowledges acceptance without awaiting settlement, and the item
+  disappears from the stalled list while the work resumes
+
+#### Scenario: A failed redrive re-stalls honestly
+
+- **GIVEN** a stalled item whose underlying cause persists
+- **WHEN** the owner redrives it and the effect exhausts its fresh retry budget again
+- **THEN** the item returns to the stalled list with fresh diagnostics, and nothing is lost
+
+#### Scenario: No dismiss verb exists
+
+- **WHEN** the owner views a stalled item's actions
+- **THEN** the offered verbs are redrive and the domain's cancellation — there is no
+  clear-without-redrive affordance

--- a/openspec/changes/stalled-work-recovery/specs/web-ui/spec.md
+++ b/openspec/changes/stalled-work-recovery/specs/web-ui/spec.md
@@ -1,0 +1,69 @@
+# web-ui — delta for stalled-work-recovery
+
+## ADDED Requirements
+
+### Requirement: Stalled work tells the truth in the user register
+
+When a module facade reports work stalled, the web UI SHALL say so in the narration register's
+own voice — the work is stuck and needs the system's operator — on the acquisition detail page,
+the import section of the timeline, and the corresponding list rows, replacing any telling that
+implies ordinary progress. The stalled telling SHALL carry no verb for guest sessions and SHALL
+NOT expose operator diagnostics in the user register; the determination SHALL come from the
+facades' decided stalled flags, never re-derived. A stalled story SHALL remain live (it can
+recover), so self-refresh continues. When the stall clears, the telling SHALL return to the
+ordinary narration with no residue.
+
+#### Scenario: A stalled import stops claiming progress
+
+- **GIVEN** an import whose facade status reports stalled
+- **WHEN** a user views the acquisition's detail page or the pending row
+- **THEN** the telling states the work is stuck and needs the system's operator — not an
+  in-progress phrase — and offers the user no operator verb
+
+#### Scenario: The stalled telling derives from the decided flag
+
+- **WHEN** the stalled telling is composed
+- **THEN** it follows the facade's stalled flag alone, not a status-enum or timing heuristic
+
+#### Scenario: Recovery leaves no residue
+
+- **GIVEN** a stalled import that an operator redrives to completion
+- **WHEN** the user next views the story
+- **THEN** it reads as ordinary completed narration with no stall telling remaining
+
+## MODIFIED Requirements
+
+### Requirement: The attention queue unifies work awaiting a human
+
+The web UI SHALL present a single attention queue that lists every item across modules currently waiting on a decision the signed-in user can make themselves — at minimum the importer's pending match reviews and the downloader's acquisitions awaiting manual edition selection — as one list ordered longest-waiting first. Operator-only conditions (stalled work awaiting the system's operator) SHALL NOT appear in this queue; they belong to the operations surface (see `web-operations`). Each item SHALL name **the ask** — the decision waiting on the user — in plain, action-oriented language, SHALL be titled by its musical intent where the correlation is available (degrading as the review titling requirement specifies), and SHALL link to the surface where the decision is made. Visible queue text SHALL NOT name the owning module or any architecture noun; a machine-readable module attribute MAY remain on the row for styling and tests. The queue SHALL be composed by the web layer from the module facades' own read models; the composition SHALL NOT introduce a cross-module contract between the bounded contexts. When one module's read fails, the queue SHALL render the other module's items alongside a modeled error for the failed section, not fail as a whole. Any capability that adds a new pause waiting on a user-resolvable decision SHALL surface its pending items in this queue.
+
+#### Scenario: Items from both modules appear as one queue
+
+- **GIVEN** a pending import review and an acquisition awaiting manual edition selection
+- **WHEN** the user opens the attention queue
+- **THEN** both items appear in one list, longest-waiting first, each naming the decision asked of the user in action-oriented language and linking to its resolution surface
+
+#### Scenario: The queue never names the machinery
+
+- **GIVEN** attention items originating from both modules
+- **WHEN** the user reads the queue
+- **THEN** no visible text names a module or architecture noun, while each row still carries its machine-readable module attribute
+
+#### Scenario: Resolving an item removes it from the queue
+
+- **GIVEN** an attention queue showing an awaiting-selection acquisition
+- **WHEN** the user follows its link and selects an edition
+- **THEN** the acquisition proceeds and no longer appears in the attention queue
+
+#### Scenario: One module failing does not empty the queue
+
+- **GIVEN** one module's facade read fails
+- **WHEN** the user opens the attention queue
+- **THEN** the other module's items are listed and the failed section renders a modeled error message
+
+#### Scenario: Stalled work never enters the queue
+
+- **GIVEN** a stalled import awaiting the system's operator
+- **WHEN** any user opens the attention queue
+- **THEN** the stalled item is absent — its user-register telling lives on its own pages, and
+  its actionable form lives on the operations surface

--- a/openspec/changes/stalled-work-recovery/tasks.md
+++ b/openspec/changes/stalled-work-recovery/tasks.md
@@ -1,0 +1,68 @@
+# Tasks — stalled-work-recovery
+
+Red-first TDD throughout: the failing test precedes every production edit, visible in commit
+order. Prerequisite: `auth-roles` merged (the `authorize` seam and `system:redrive` action);
+S1's importer multi-effect fix merged.
+
+## 1. The redrive operation (both modules)
+
+- [ ] 1.1 Downloader reactor `redriveStalled(streamId)` (red first): mutex seat, stalled
+      precondition as a modeled refusal, letters logged then cleared through the one seam,
+      re-dispatch via the existing re-drive logic with a fresh budget; tests pin the refusal on
+      a non-stalled stream, idempotent concurrent submissions, the logged trail, the
+      fresh-ladder re-stall, and the untouched event history.
+- [ ] 1.2 Importer reactor: the same operation and test set, in the importer's own voice.
+- [ ] 1.3 Stale-settlement path (red first): a redriven effect whose earlier execution had
+      settled lands as a stale command through `decide` — one test per module.
+
+## 2. Facade growth (additive)
+
+- [ ] 2.1 Downloader facade (red first): `listStalled()` (work identity, `occurredAt`,
+      diagnostics) and the fire-and-forget redrive verb returning accepted/refused; DTO schemas
+      additive with operator-register fields documented; JSON round-trip + re-parse tests.
+- [ ] 2.2 Importer facade: the same pair, same tests.
+- [ ] 2.3 Contract tier: additive-DTO gates extended to the new shapes in both packages.
+
+## 3. Supervisor escalation (downloader only)
+
+- [ ] 3.1 Escalating backoff in the delivery loop (red first): base = poll cadence, factor 2,
+      env-capped ceiling; existing warn→error cadence preserved; deterministic-timer tests.
+- [ ] 3.2 Delivery-failure gauge into `readiness()` (red first): degraded past the configured
+      threshold, cleared on success; stalled streams asserted NOT to degrade readiness.
+- [ ] 3.3 Config surface: threshold + ceiling env vars with defaults, validated at boot.
+
+## 4. Web — user register
+
+- [ ] 4.1 Stalled telling (red first): tone map + copy for detail, timeline import section, and
+      list rows, driven by the decided flags only; `satisfies` totality preserved; recovery
+      leaves no residue; story stays live (self-refresh unchanged).
+- [ ] 4.2 Attention queue exclusion (red first): stalled items never enter the queue; the
+      queue's charter test updated to the amended wording.
+
+## 5. Web — operations surface
+
+- [ ] 5.1 `/system` route behind `authorize(session, 'system:redrive')` (red first): guest
+      refused with no content leak and no nav entry; owner served.
+- [ ] 5.2 Stalled-work list (red first): both modules composed in the BFF, longest-stalled
+      first by ledger time, diagnostics verbatim, linked items, per-section modeled error on a
+      failed read, explicit all-clear empty state.
+- [ ] 5.3 Redrive verbs (red first): per-item form + redrive-all iteration, fire-and-forget
+      acceptance, verb-inventory entries (redrive non-destructive; cancellation pairing points
+      at the existing destructive-gated form); no dismiss verb exists (asserted).
+
+## 6. E2E and verification
+
+- [ ] 6.1 Env-tunable retry budget/backoff threaded through the ordinary config surface;
+      documented in the e2e harness.
+- [ ] 6.2 The stall-recovery phase (red first against the phase's own probes): unwritable
+      library mount → stalled telling witnessed → restart proves durable exposure → repair →
+      redrive via the operations route with an owner-role session → ordinary completion, no
+      residue; scraped copy goes through the centralized phrase maps.
+- [ ] 6.3 `run.sh` phase registration + honest phase-count comment; full local e2e run green.
+
+## 7. Gate and done
+
+- [ ] 7.1 Full gate (`pnpm check`) green across packages; 100% coverage without waivers.
+- [ ] 7.2 Post-deploy verification (with Jake): any pre-existing stall on flight surfaces
+      immediately; a live redrive recovers one; `/health` reflects a simulated delivery
+      failure.


### PR DESCRIPTION
## Summary

Drafted OpenSpec change for **stalled-work-recovery** — proposal only, no implementation, no version bump.

Closes the whole-project review sweep's sole Critical finding (2026-08-05): both modules dead-letter failing effects and mark streams stalled, but the `stalled` flag dies at the BFF — nothing in `packages/web` reads it, there is no redrive verb, and recovery today is DB surgery plus a restart (the chroma incident procedure).

The draft covers:
- Stalled work told truthfully in the user register; the attention queue's charter amended to user-resolvable judgments only
- A new owner-gated `web-operations` surface (first consumer of the `authorize` seam from the auth-roles draft): stalled list with diagnostics, per-item redrive + redrive-all, give-up as the domain's existing cancellation
- Redrive as an infra operation on the reactor — fresh full retry budget through the normal ladder, letters logged then cleared through the one seam, no domain event
- The download supervisor's undeliverable-outcome loop gains escalating backoff and a readiness consequence
- A new e2e stall→surface→redrive→recovery phase with env-tunable retry budget

Evidence base included: `docs/research/dead-letter-redrive-semantics.md` (cited prior-art survey; all five design verdicts attested, pitfall checklist tracked item-by-item in design.md).

Depends on the auth-roles draft (#136) for the `authorize` seam and the `system:redrive` action. Implementation follows via /ship as its own lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)