### PR TITLE
chore(openspec): draft e2e-review-resolution-loop proposal

### DIFF
--- a/openspec/changes/e2e-review-resolution-loop/.openspec.yaml
+++ b/openspec/changes/e2e-review-resolution-loop/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/e2e-review-resolution-loop/design.md
+++ b/openspec/changes/e2e-review-resolution-loop/design.md
@@ -1,0 +1,62 @@
+# Design — e2e-review-resolution-loop
+
+## Context
+
+See proposal.md — Why. The e2e harness (test/e2e) already: runs the real image with WireMock'd
+slskd and stubbed outermost third parties, seeds source fixtures at stub-reported locations,
+walks HTTP flows with deadline-bounded polling probes, and scrapes UI copy through centralized
+phrase maps in `helpers.ts`. The full-loop phase proves submission → auto-apply → library. The
+revival loop's production machinery (verdict consumer, decider revival, second delivery) is
+fully unit/contract-covered; only the out-of-process composition is unwitnessed.
+
+## Goals / Non-Goals
+
+**Goals:** one deterministic phase for the revival loop; premise-asserting setup so beets drift
+fails loudly.
+
+**Non-Goals:** accept-after-review phase; refine-search; any production change (absent
+evidence of a broken wire); Playwright involvement (this is the HTTP tier's job).
+
+## Decisions
+
+**D1 — Forcing the review band with real beets.** The seeded fixture's tags deviate from the
+stub-metadata identity just enough to score inside the review band (the gap between the
+auto-apply threshold and no-match) for the image's pinned beets. The deviation recipe (e.g. a
+title variant + a duration nudge) is calibrated at implementation against the pinned version and
+documented next to the fixture; the phase's review-queued assertion is the guard that keeps the
+calibration honest over time. Alternative considered — lowering the auto-apply threshold via
+env for the phase: rejected, it tests a configuration the product doesn't run and weakens the
+premise the phase exists to prove.
+
+**D2 — Two-candidate WireMock script.** The slskd stub serves a search yielding the
+weak-match candidate first and a second, better candidate for the post-verdict re-hunt
+(stateful WireMock scenario, same mechanism the Hold-scenario stubs use). The second candidate's
+fixture matches cleanly so the revived story auto-applies — the phase's terminal probe is the
+existing delivered/imported narration via the centralized phrase maps.
+
+**D3 — Resolution over HTTP, session via the production codec.** The phase posts the
+resolution form exactly as a browser would, authenticated with a cookie minted by the imported
+production `signSession` (the tier's established doctrine). After `auth-roles` merges, minted
+claims carry a role; this phase needs only the base interface, so it mints a guest — asserting
+in passing that review resolution requires no privilege.
+
+**D4 — Staging-cleanup assertion.** The rejection's contract (files deleted, hunt resumes) is
+asserted from outside: the staged first-delivery directory is gone after resolution, per the
+destructive verb's documented consequence. This doubles as the black-box witness for the
+consequence copy's determinism principle.
+
+## Risks / Trade-offs
+
+- **[Beets scoring drift breaks the band calibration]** → The explicit review-queued setup
+  assertion names the premise; the fixture-provenance discipline (beets pin recorded beside the
+  fixture) makes re-calibration a deliberate act, mirroring the bridge tier.
+- **[Phase runtime]** → One extra image boot plus two delivery cycles; bounded by the same
+  polling budgets as existing phases. Acceptable against the wire it uniquely covers.
+- **[Flake via WireMock scenario state]** → The Hold-scenario precedent shows stateful stubs
+  stable in this harness; the journal assertions (single enqueue per candidate) carry over.
+
+## Migration Plan
+
+Test-tier only; lands with `run.sh` registration and the phase-count comment updated (S3 fixes
+the current count drift; this change keeps it honest). No version bump unless the wire proves
+broken — then the fix rides this change as `fix:` and bumps normally.

--- a/openspec/changes/e2e-review-resolution-loop/proposal.md
+++ b/openspec/changes/e2e-review-resolution-loop/proposal.md
@@ -1,0 +1,50 @@
+# Proposal: e2e-review-resolution-loop
+
+## Why
+
+The whole-project review sweep (2026-08-05) found that no tier ever drives a human review
+**resolution** out-of-process: e2e only ever observes the review queue empty, so the entire
+cross-context loop — importer `ReviewResolved` → published verdict → downloader verdict consumer
+→ decider revival → a second delivery — is unwitnessed across the real stores and the real wire,
+despite being the path with the scariest silent failure (a user's rejection publishing a verdict
+that never revives the hunt). The grilling session (2026-08-05) chose the revival loop as the
+one scenario worth the tier's cost: it is the only resolution path whose cross-context half no
+other tier exercises, while the accept path's store-crossing is identical to the auto-apply flow
+the full-loop phase already proves.
+
+## What Changes
+
+- **A new isolated e2e phase forces a genuine low-confidence review and resolves it as
+  `reject-unusable-delivery` over HTTP**, then witnesses the downloader resume the hunt, deliver
+  a second candidate, and the story complete into the library. Determinism comes from fixture
+  engineering against the pinned beets version: the seeded source's tags land the match in the
+  band between the auto-apply threshold and no-match, and the phase asserts the review actually
+  queued (so a beets bump that moves the band fails loudly, not silently — the bridge tier's
+  provenance discipline extended to e2e).
+- **Test-tier only.** No production code, no version bump (the S3/PR-#107 precedent) — unless
+  the phase reveals the revival wire actually broken, in which case the fix ships in this same
+  change, evidence-driven (the boundary rule the slskd contract-truth change established).
+- **Non-goals:** no accept-after-review phase (covered by unit/Playwright tiers plus the
+  full-loop auto-apply path); no free-text re-search coverage (`refine-search` remains
+  deferred); no interaction with the stalled-work-recovery phase (independent scenarios; phase
+  numbering composes in whichever order ships first).
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `out-of-process-e2e`: the tier additionally proves the review-resolution revival loop across
+  both stores and the published-verdict seam.
+
+## Impact
+
+- **Code:** `test/e2e` only — one new phase spec, its seeded fixture set, `run.sh` phase
+  registration, and any shared-helper growth (scraped phrases via the centralized maps).
+- **Dependencies:** none on other drafted changes; sequencing with `stalled-work-recovery`'s
+  phase is cosmetic. The slskd WireMock stubs gain a second-candidate script for the re-hunt.
+- **Risk retired:** the review sweep's "no e2e review resolution" Important; the revival wire
+  gains a regression gate before any future verdict-schema evolution.

--- a/openspec/changes/e2e-review-resolution-loop/specs/out-of-process-e2e/spec.md
+++ b/openspec/changes/e2e-review-resolution-loop/specs/out-of-process-e2e/spec.md
@@ -1,0 +1,34 @@
+# out-of-process-e2e — delta for e2e-review-resolution-loop
+
+## ADDED Requirements
+
+### Requirement: The review-resolution revival loop is proven end to end
+
+The e2e tier SHALL include an isolated phase that drives a human review resolution over the web
+interface's HTTP endpoints against the real image and witnesses the full cross-context
+consequence: a genuinely low-confidence import (real beets scoring a seeded fixture into the
+band between auto-apply and no-match) queues a review; resolving it as the unusable-delivery
+rejection publishes the verdict; the downloader consumes it, revives the hunt, and delivers a
+second candidate; and the story completes into the library. The phase SHALL assert the review
+actually queued before resolving — so a metadata-scoring shift under a future beets version
+fails the phase loudly at the setup assertion rather than silently downgrading the scenario —
+and SHALL assert the first delivery's rejection left no partial state behind (the rejected
+files are gone from staging per the rejection's contract). The phase SHALL drive resolution
+through the same HTTP surface a user submits, not a facade or store back-door.
+
+#### Scenario: A rejected delivery revives the hunt and completes
+
+- **GIVEN** the image running with a seeded source whose best match scores into the review band
+  and a stub source offering a second, better candidate
+- **WHEN** the phase confirms the review queued, then resolves it as reject-unusable-delivery
+  over HTTP
+- **THEN** the downloader resumes the hunt without a new submission, the second candidate is
+  delivered and imported, the story reaches its ordinary completed outcome, and the review queue
+  is empty
+
+#### Scenario: The setup asserts its own premise
+
+- **WHEN** the seeded fixture no longer scores into the review band (for example, after a beets
+  version change)
+- **THEN** the phase fails at its explicit review-queued assertion, naming the premise that
+  broke, rather than passing vacuously or failing obscurely downstream

--- a/openspec/changes/e2e-review-resolution-loop/tasks.md
+++ b/openspec/changes/e2e-review-resolution-loop/tasks.md
@@ -1,0 +1,34 @@
+# Tasks — e2e-review-resolution-loop
+
+Red-first: each phase probe is written against its target behavior before the harness wiring
+that satisfies it. Test-tier only unless task 4.2 triggers.
+
+## 1. Fixtures and stubs
+
+- [ ] 1.1 Calibrate the review-band fixture against the image's pinned beets (deviation recipe
+      documented beside the fixture, provenance note with the beets pin).
+- [ ] 1.2 Two-candidate WireMock scenario: weak match first, clean second candidate for the
+      re-hunt; journal-assertable single enqueue per candidate.
+
+## 2. The phase
+
+- [ ] 2.1 Setup probes: submission lands, first delivery imports into a queued review — the
+      explicit review-queued premise assertion naming its purpose.
+- [ ] 2.2 Resolution over HTTP with a production-codec guest session; assert acceptance and
+      queue emptiness after.
+- [ ] 2.3 Revival probes: hunt resumes without a new submission, second candidate delivers,
+      story completes with the ordinary narration (centralized phrase maps only); staged
+      first-delivery directory gone.
+
+## 3. Harness integration
+
+- [ ] 3.1 `run.sh` phase registration with honest phase-count comment; per-phase isolation
+      (fresh stores) preserved.
+- [ ] 3.2 Full local `pnpm test:e2e` green, all phases.
+
+## 4. Evidence gate
+
+- [ ] 4.1 If the revival wire holds: no production change, no version bump — test-tier PR.
+- [ ] 4.2 If the phase reveals the wire broken: the failing probe is the red; fix the
+      production defect in this change as `fix:` with its own unit-tier regression pin, and
+      re-run the full gate.


### PR DESCRIPTION
Drafted OpenSpec proposal only — no implementation, no version bump.

Closes the review sweep's "no e2e review resolution" gap: no tier ever drives a human review resolution out-of-process, leaving the importer `ReviewResolved` → published verdict → downloader verdict consumer → revival → second delivery loop unwitnessed across the real stores and wire.

The drafted change adds one isolated e2e phase proving that loop end to end: a genuinely low-confidence import (real beets scoring a calibrated fixture into the review band, premise-asserted) is resolved as `reject-unusable-delivery` over HTTP, and the phase witnesses the hunt resume, a second candidate deliver, and the story complete. Test-tier only, with an evidence-driven rider: if the phase reveals the revival wire broken, the fix ships in the same change as `fix:`.

Design grilled 2026-08-05; implementation to follow via /ship as its own lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)