### PR TITLE
chore(openspec): draft end-to-end-correlation proposal

### DIFF
--- a/docs/research/correlation-causation-conventions.md
+++ b/docs/research/correlation-causation-conventions.md
@@ -1,0 +1,438 @@
+# How do event-sourced systems mint and carry correlation/causation identity?
+
+**Research date:** 2026-08-05.
+
+**Question.** `docs/development/logging.md` requires that "you should be able to follow a single
+operation through the whole system by its correlation id" — but `EventMetadata.correlationId`
+(optional, both contexts) is populated nowhere, no child-logger binding exists, and adapter log
+lines omit even the stream id they hold in scope. We are designing the correlation
+implementation for a two-bounded-context event-sourced modular monolith (single Node process,
+SQLite event stores, pino, a SvelteKit BFF, reactors dispatching effects, cross-context
+integration via durable in-process catch-up subscriptions behind ACLs). Six open forks:
+(1) single `correlationId` vs the correlation+causation pair; (2) where the id is minted and how
+it flows request → command → event → reactor follow-ups → published integration events;
+(3) whether the consuming context adopts the producer's correlation id or mints its own and
+records the foreign one as provenance; (4) whether OpenTelemetry / W3C Trace Context is attested
+practice or overkill for a single-process homelab monolith; (5) pino child-logger binding
+conventions per unit of work; (6) what the field warns about retrofitting correlation onto
+existing stores under an additive-only contract policy.
+
+**Method.** Primary sources fetched 2026-08-05: the Kurrent (EventStoreDB) discussion forum
+(Greg Young answering in person) and the Kurrent blog on the Visualize tab / `$by_correlation_id`
+projection; Particular Software's NServiceBus header and message-correlation docs; Axon
+Framework 4.12 reference (message correlation / `MessageOriginProvider`); the message-db GitHub
+README (schema and `write_message` signature); Rails Event Store's correlation-causation doc and
+the Arkency post that popularized the rules; Marten's event-metadata doc; the W3C Trace Context
+recommendation; the OpenTelemetry logs spec; pino's `child-loggers.md` and `api.md` on GitHub;
+Maxim Orlov's pino + AsyncLocalStorage write-up; Last9's correlation-id-vs-trace-id practitioner
+guide; Hohpe & Woolf's enterpriseintegrationpatterns.com. House constraints from
+`docs/development/logging.md`, `event-sourcing.md`, and `api-compatibility.md`, plus the actual
+ports and facades in this repo. **Unreachable-source honesty:** `getpino.io` did not resolve
+(DNS timeout) — the same pages were fetched from the pino GitHub repo instead;
+`docs.eventide-project.org` is served over plain HTTP and returns 404 over HTTPS, which the
+fetch tool forces, so Eventide's metadata definitions below come from search-result excerpts of
+those pages and are marked **[secondary]**; one context-switching strategy note cites a Q&A
+aggregator and is marked **[secondary]**.
+
+---
+
+## 1. The house shape being decided (facts from this repo)
+
+- `EventMetadata` is `{ acquisitionId | importId, occurredAt, correlationId? }` — one metadata
+  value per **append batch**, not per event
+  (`packages/downloader/src/application/ports/event-store-port.ts:11-15,36-41`;
+  `packages/importer/src/application/ports/event-store-port.ts:11-15`). `correlationId` is
+  declared and never set (no writer anywhere in `src/`).
+- The logger is a bare pino root with env-configured level and central redaction; no `child()`
+  call exists in production code
+  (`packages/downloader/src/application/logging/logger.ts`, importer twin).
+- The BFF's only generated id today is the `handleError` fault id: "no record on the pino root,
+  no error id, no correlation" without it
+  (`packages/web/src/hooks.server.ts:78-96`).
+- Reactor doc-comments already promise stream-scoped correlation that the log lines don't
+  deliver: "Operational logs are correlated by `acquisitionId`"
+  (`packages/downloader/src/application/acquisition/reactor.ts:36`), "Operational logs are
+  correlated by `importId`" (`packages/importer/src/application/import/reactor.ts:64`).
+- A **business** correlation key already crosses the seam and is deliberately additive: the
+  importer read model carries "the originating acquisition, when this import arrived from one —
+  the web-side correlation key"
+  (`packages/importer/src/application/projections/read-models.ts:57`,
+  `packages/importer/src/facade/schemas.ts:276`). This is domain provenance, not the
+  operational id this research is about — the distinction matters in §3.3.
+- The seam is producer-owned: the outbound feed renders published events through a
+  producer-owned mapping; "the producer does not know its consumers"
+  (`packages/importer/src/application/events/outbound-feed.ts`).
+- Constitution constraints: correlation on every log line (`logging.md` §Correlation); events
+  are business facts, "not incidental telemetry" (`event-sourcing.md` §Events are facts); the
+  domain is pure — no logging, no metadata plumbing (`logging.md` §Keep logging out of the
+  domain); event schemas are public contracts, additive-only, upcast on read
+  (`api-compatibility.md`, `event-sourcing.md` §Schema evolution).
+
+---
+
+## 2. Prior art, system by system
+
+### 2.1 Greg Young / EventStoreDB — the canonical three-id rule
+
+Greg Young, answering "causation or correlation id?" on the official forum, states the rule the
+rest of the field quotes: every message carries three ids — its own id, a correlation id, and a
+causation id — and "if you are responding to a message, you copy its correlation id as your
+correlation id, its message id is your causation id. This allows you to see an entire
+conversation (correlation id) or to see what causes what (causation id)"
+([Kurrent forum, Greg Young](https://discuss.kurrent.io/t/causation-or-correlation-id/828/4)).
+
+EventStoreDB reifies this as reserved metadata keys `$correlationId` and `$causationId`. The
+built-in `$by_correlation_id` projection groups "every event which has a correlation id … set in
+its metadata" into `$bc-<correlationId>` streams, and the Visualize tab draws the causation
+graph from them; in the worked order/payment example "the `$correlationId` stays the same …
+the `$causationId` is set to the event ID of the previous OrderPlaced event"
+([Kurrent blog](https://www.kurrent.io/blog/eventstoredb-visualise-tab/)). Two operational
+capabilities fall out, each bought by a different id: *conversation replay* (fetch everything
+with one correlation id) and *causal debugging* (walk parents). A single id buys only the first.
+
+### 2.2 NServiceBus — three headers, and the conversation id is immutable
+
+NServiceBus splits the concern across headers
+([headers doc](https://docs.particular.net/nservicebus/messaging/headers),
+[message-correlation doc](https://docs.particular.net/nservicebus/messaging/message-correlation)):
+
+- **`ConversationId`** — "the identifier of the conversation that this message is part of. It
+  enables the tracking of message flows that span more than one message exchange." The first
+  message in a new flow receives a unique conversation id **that propagates to all subsequent
+  messages**, across endpoint (service) boundaries; it is "always copied from the incoming
+  message being handled," and "attempting to override an existing Conversation ID is not
+  supported" — it errors. This is Greg Young's correlation id under another name, with
+  immutability enforced.
+- **`RelatedTo`** — "the `MessageId` that caused the current message to be sent": the causation
+  id.
+- **`CorrelationId`** — *narrower* than the name suggests: the Hohpe/Woolf request-reply
+  correlation for callbacks and `ReplyToOriginator` ("the `Correlation Id` of the response
+  message is the `Correlation Id` of its corresponding request message").
+
+The lesson for naming: the industry's "correlation id" is overloaded. NServiceBus's
+conversation/related-to pair maps exactly onto Young's correlation/causation pair; its
+"CorrelationId" is a third, older thing.
+
+### 2.3 Axon Framework — the same pair, with the names swapped
+
+Axon's default `MessageOriginProvider` "is responsible for two values to be passed around from
+one Message to another": "the `correlationId` of a message always references the identifier of
+the message it originates from (that is, the parent message)," while "the `traceId` … references
+the message identifier which started the chain of messages (that is, the root message)" —
+`traceId` constant, `correlationId` per-parent
+([Axon 4.12 reference](https://docs.axoniq.io/axon-framework-reference/4.12/messaging-concepts/message-correlation/)).
+So Axon's `correlationId` is Young's *causation* id and its `traceId` is Young's *correlation*
+id. Mechanically, a `CorrelationDataProvider` transports selected metadata from the handled
+message to every message created in the same unit of work, and it lands persisted in event
+metadata. Two takeaways: (a) even a major framework inverts the vocabulary — a design doc must
+define its terms, not assume them; (b) propagation is an *infrastructure* concern (unit of
+work), never handler code — the Axon analogue of keeping it out of deciders.
+
+### 2.4 Eventide / Message DB — coordinate-based causation, stream-based correlation
+
+Eventide's message metadata **[secondary — docs site unreachable over HTTPS; quotes from
+search excerpts of docs.eventide-project.org]** records causation as *store coordinates*, not a
+uuid: `causation_message_stream_name`, `causation_message_position`, and
+`causation_message_global_position` "denote which stream caused the message to be written."
+Correlation is likewise a stream name: "the `correlation_stream_name` attribute allows a
+component to tag an outbound message with its origin. Before the source component sends the
+message to the receiving component, the source component assigns its own stream name to the
+message metadata's `correlation_stream_name` attribute. That attribute is carried from message
+to message through messaging workflows" — explicitly a **cross-component pub/sub** mechanism:
+the originating component later subscribes to a category filtered by its own stream name
+(Message DB's `get_category_messages` takes a `correlation` filter on exactly this attribute —
+[message-db README](https://github.com/message-db/message-db)). The `follow()` message
+constructor copies correlation/reply attributes from the preceding message and points the
+causation attributes at it; the `follows?` predicate checks the whole set.
+
+Two things are notable for this codebase: causation needs no new uuid when every stored event
+already has a stable address (here: `streamId` + `version`, or `globalSeq`); and correlation
+crossing a component boundary *by design* is fifteen-year-old precedent, not an ACL violation.
+
+### 2.5 Rails Event Store / Arkency — the same rules, plus retrofit-relevant defaults
+
+RES stores `correlation_id` / `causation_id` in event metadata, cites Young's rule verbatim, and
+ships `correlate_with(previous_event)` plus `LinkByCorrelationId` / `LinkByCausationId`
+subscribers that build queryable `correlation-{id}` / `causation-{id}` streams — "what happened
+because of event X?" as a projection, not a source of truth
+([RES doc](https://railseventstore.org/docs/core-concepts/correlation-causation),
+[Arkency post](https://blog.arkency.com/correlation-id-and-causation-id-in-evented-systems/)).
+The Arkency post states the minting rule for the start of a story: "when initiating a message,
+both `correlation_id` and `causation_id` are newly generated" (in practice: a first message is
+its own story; some shops set the first message's causation to null instead — both are
+attested). One operational trap they document: synchronous handlers get correlation for free,
+but **async handlers need explicit opt-in** (`RailsEventStore::CorrelatedHandler`) — i.e., every
+async hop is a place the chain silently breaks unless the infrastructure carries it.
+
+### 2.6 Marten — metadata is opt-in, and correlation converges with OTel
+
+Marten is the strongest precedent for the retrofit story: "By default, Marten runs 'lean' by
+omitting the extra metadata storage on events" — `CorrelationIdEnabled`, `CausationIdEnabled`,
+and headers are individually enabled flags, values are set **session-scoped** ("values will flow
+through to new events captured by a session when `SaveChangesAsync()` is called"), and — key —
+"the `CorrelationId` and `CausationId` is taken automatically from any active OpenTelemetry
+span, so these values should just flow from ASP.NET Core requests"
+([Marten metadata doc](https://martendb.io/events/metadata.html)). So in Marten's model the
+correlation id *is* the trace id when tracing exists, and a plain string when it doesn't — the
+two schemes are the same slot.
+
+### 2.7 Hohpe & Woolf — what "Correlation Identifier" originally meant
+
+The EIP pattern is narrow: "a unique identifier that indicates which request message this reply
+is for" — request/reply matching, nothing about conversations
+([enterpriseintegrationpatterns.com](https://www.enterpriseintegrationpatterns.com/patterns/messaging/CorrelationIdentifier.html)).
+The modern "follow one operation everywhere" id is a *generalization* the ES community built on
+top (Young's rule, NServiceBus's ConversationId). Citing EIP for the end-to-end id is a common
+mis-citation; the doc a proposal cites should be Young/NServiceBus, not EIP.
+
+### 2.8 W3C Trace Context / OpenTelemetry — the format, and when the machinery pays
+
+The `traceparent` header is `version-traceid-parentid-flags`: trace-id is "16-byte … lowercase
+hexadecimal" (32 chars), "the ID of the whole trace forest," constant across the transaction;
+parent-id is 8 bytes, "the ID of this request as known by the caller," changing at each hop
+([W3C Trace Context](https://www.w3.org/TR/trace-context/)). Note the structural identity with
+Young's pair: trace-id ≙ correlation id, parent-id ≙ causation id — the field converged on the
+same two-level shape twice, independently. The OTel logs spec's whole correlation story is
+"including TraceId and SpanId in the LogRecords" so logs join traces by execution context
+([OTel logs spec](https://opentelemetry.io/docs/specs/otel/logs/)).
+
+On monoliths, practitioner guidance is consistent: correlation ids suit "smaller applications
+where full distributed tracing might be overkill" and "a basic correlation ID system can be
+implemented in just hours"; trace trees pay off "when dealing with dozens or hundreds of
+interconnected services"; and the recommended convergence path is "the trace ID functions as
+your correlation ID for log correlation"
+([Last9, Correlation ID vs Trace ID](https://last9.io/blog/correlation-id-vs-trace-id/)).
+Marten (§2.6) is a shipping example of exactly that convergence. The attested middle path is
+therefore: no SDK, no spans, no backend — but an id that is *format-compatible* (32 lowercase
+hex chars, or simply a uuid you're willing to rename later), so a future OTel adoption changes
+the minting line, not the plumbing.
+
+### 2.9 pino — children are the mechanism; ALS is the escape hatch
+
+- **Child loggers** pin bindings — "key-value pairs … pinned to a logger causing them to be
+  output on every log line" — inherit the parent's stream and level, and are cheap enough to
+  create per unit of work: creating 10k children benchmarks at the same order as using the root,
+  and "logging via the child logger of a child logger also has negligible overhead"
+  ([pino child-loggers.md](https://github.com/pinojs/pino/blob/main/docs/child-loggers.md),
+  [api.md](https://github.com/pinojs/pino/blob/main/docs/api.md)). Bindings should sit under
+  application-controlled keys (never raw user data as keys).
+- **`mixin`** is the per-line dynamic hook: "called each time one of the active logging methods
+  is called … the properties of the returned object will be added to the logged JSON" — the
+  documented seam for pulling ambient context (e.g., AsyncLocalStorage) into every line without
+  holding a child ([api.md](https://github.com/pinojs/pino/blob/main/docs/api.md)).
+- **Request scoping**: pino-http mints `req.id` via `genReqId` (honoring an inbound header or
+  generating a uuid — the default sequential integer is documented as unsuitable for
+  production) and hangs a bound child on `req.log`
+  ([pino-http README](https://github.com/pinojs/pino-http)). Where parameter-passing is
+  impractical, the attested pattern stores the request-bound child in AsyncLocalStorage —
+  middleware does `logger.child({ requestId: uuid.v4() })`, `context.run(store, next)`, and a
+  proxy resolves `context.getStore()?.get('logger') || target`
+  ([Maxim Orlov](https://maximorlov.com/logging-with-pino-and-asynclocalstorage-in-nodejs/)).
+  This codebase already injects `Logger` through constructors and use-case dependency bags, so
+  child-passing needs no ALS magic on the write path; ALS remains the fallback for surfaces that
+  can't thread a parameter (e.g., SvelteKit `load` internals).
+
+### 2.10 Crossing bounded contexts
+
+No surveyed messaging system re-mints the story id at an internal boundary: NServiceBus's
+ConversationId crosses endpoints unchanged and *refuses* override (§2.2); Eventide's
+`correlation_stream_name` exists precisely so a *different component's* streams can carry the
+originator's identity (§2.4); W3C trace context crosses every service by construction (§2.8).
+The ids these systems protect per-context are **business** identifiers: the DDD-flavored
+guidance is to keep the operational correlation constant across hops while each context appends
+its own domain keys — "OrderPlaced carries orderId … PaymentAuthorized introduces paymentId
+while preserving orderId," and where an entity genuinely changes story, append the new id while
+retaining the original as provenance **[secondary — Q&A aggregator]**
+([Codemia](https://codemia.io/knowledge-hub/path/handling_correlation_id_changes_in_event_sourcing_when_an_entity_switches_context)).
+The ACL literature (Context Mapper, Evans) concerns *model* translation — vocabulary, structure,
+invariants — not observability envelopes; none of the surveyed ACL sources treats an opaque
+correlation id as model leakage. This codebase already embodies the split: `acquisitionId` on an
+import is the translated *business* provenance key (§1), which is a different thing from the
+operational id `logging.md` demands.
+
+---
+
+## 3. Where the field converges, where it splits
+
+**Converged (unanimous among surveyed systems):**
+
+- Correlation/causation live in the **metadata envelope**, never the event payload (ESDB
+  `$correlationId`, RES `metadata`, Eventide `metadata`, Marten metadata columns, Axon
+  `MetaData`, NServiceBus headers). The domain object never sees them.
+- Propagation is done by **infrastructure at the unit-of-work seam** (Axon's
+  `CorrelationDataProvider`, Marten's session, Eventide's `follow()`, NServiceBus's pipeline,
+  RES's `CorrelatedHandler`), not by handler/decider code.
+- The story id is **minted at the first message of the flow** and copied verbatim forever after,
+  across async hops and component boundaries.
+- Two levels of identity, not one: a constant story id plus a per-message parent pointer
+  (Young, ESDB, NServiceBus, Axon, Eventide, RES, W3C — seven independent designs, same shape).
+- Correlation-keyed lookups (`$bc-` streams, `LinkByCorrelationId`) are **projections** —
+  disposable, rebuildable, never truth.
+
+**Split (design freedom):**
+
+- *Naming*: correlation/causation (ESDB, RES, Marten) vs conversation/related-to (NServiceBus)
+  vs trace/correlation (Axon, inverted) vs trace-id/parent-id (W3C).
+- *Causation reference form*: parent message uuid (ESDB, RES, NServiceBus, Axon) vs store
+  coordinates — stream name + position (Eventide).
+- *First message's causation*: self-caused/fresh (Arkency) vs absent (common elsewhere); both
+  attested.
+- *Ambient vs explicit carriage in-process*: ALS/session ambience (Marten, pino-ALS) vs
+  explicit `follow()`/parameter passing (Eventide). A codebase that already injects
+  dependencies explicitly loses nothing by staying explicit.
+
+---
+
+## Verdict
+
+**Fork 1 — pair, not single id.** Adopt both: `correlationId` = the story, constant from first
+trigger to last published event; `causationId` = the immediate parent. Every surveyed system
+that started from event sourcing carries both, and each id buys a distinct operator capability —
+"see an entire conversation" vs "see what causes what" (§2.1). For causation, this store
+doesn't need a new per-event uuid: Eventide's coordinate form (§2.4) legitimizes
+`streamId@version` / `globalSeq` as the causation reference, and commands get an id minted at
+issuance (or the causation of a decision's events is simply the triggering event's coordinates —
+the reactor case — or the BFF request id — the command case). One `EventMetadata` per append
+batch is fine: all events of one decision share one parent, which is semantically correct.
+Define the terms in the OpenSpec doc explicitly — Axon proves even frameworks invert them
+(§2.3).
+
+**Fork 2 — minted at the outermost trigger; carried by the shell.** Field-unanimous: the id is
+born where the story starts, which here is (a) the BFF request handler in `hooks.server.ts`
+(generate per request, pino-http-style; honoring an inbound header is optional and low-value
+behind the Plex gate), and (b) non-HTTP entry points — startup redrive, intake scanner, pollers
+— each minting a fresh id per unit of work. Flow: request id → facade command (additive optional
+field on the command DTO or an application-level context argument — *not* a domain command
+field) → `EventStorePort.append` metadata → reactor copies `correlationId` from the triggering
+`StoredEvent` into follow-up commands and their appends → outbound feed renders it onto
+published events. The async effect gap (the v3.16 supervisor) must carry it through the
+callback, or the chain breaks exactly where RES warns async handlers break (§2.5). Deciders
+never see any of it — propagation is the shell's job, matching every surveyed system and the
+purity rule.
+
+**Fork 3 — one operational id end to end; business provenance stays translated.** The consumer
+context adopts the producer's `correlationId` verbatim into its own event metadata; it does not
+mint a replacement. This is what NServiceBus's ConversationId (override "not supported"),
+Eventide's `correlation_stream_name`, and trace context all do (§2.10), and it is what the
+constitution's own sentence requires — "follow a single operation through the whole system by
+its correlation id" (`logging.md`) is unsatisfiable if each context re-mints. ACL purity is not
+violated: the ACL translates the *model*; an opaque operational id in the metadata envelope is
+not producer vocabulary. Keep the existing business-provenance pattern (`acquisitionId` on
+imports) exactly as is — that one *is* domain language and *is* translated. Optionally record
+the consumed feed position as the cross-context causation reference (Eventide-style provenance
+coordinates). Report-as-designed: the published integration event schema gains an additive
+optional metadata block carrying `correlationId` (and causation coordinates if desired).
+
+**Fork 4 — no OTel SDK now; keep the exit open.** For one process, one operator, no tracing
+backend, practitioner guidance is consistent that correlation ids suffice and full tracing "might
+be overkill" (§2.8); the OTel machinery's payoff (span trees, timing, backend UIs) has no
+consumer here. The attested middle path costs one decision: mint ids in a format that can later
+*become* a trace id (32 lowercase hex, or a uuid you rename), because the convergence direction
+is "trace id functions as your correlation id" (Last9) and "CorrelationId is taken automatically
+from any active OpenTelemetry span" (Marten). Do not import `traceparent` parsing, spans, or
+context propagation APIs for this.
+
+**Fork 5 — request-scoped and dispatch-scoped pino children, passed explicitly.** Pattern:
+(a) BFF — mint the id in the `handle` hook, create `logger.child({ correlationId })`, hang it on
+`event.locals`, and let `handleError` include it alongside `errorId`; (b) reactors — per
+delivered event, `logger.child({ correlationId, streamId, globalSeq })` and use that child for
+the whole dispatch, passing it to effects; (c) adapters — keep receiving `Logger` via
+constructor/argument, so they inherit whatever bindings the caller bound (this fixes "adapter
+log lines omit the stream id" without adapters knowing about correlation at all). Children are
+benchmark-cheap per unit of work (§2.9). ALS + `mixin` is the attested alternative and is worth
+it only where explicit passing is impossible; this codebase's explicit-DI style makes children
+the lower-magic fit. Bindings under app-controlled keys; existing central redaction untouched.
+
+**Fork 6 — additive metadata is the industry retrofit path; never backfill.** Message DB's
+`metadata` column is nullable jsonb with `write_message` defaulting it to NULL (§2.4); Marten
+ships metadata off-by-default and lets you turn it on for events-from-now-on (§2.6). Old events
+without correlation are normal and permanent: readers, projections, and the BFF must treat
+`correlationId` as absent-able **forever** — no upcaster may invent one (an upcaster can reshape
+facts, not fabricate provenance that never existed), and events are never edited. The published
+zod schemas gain an optional metadata field — additive, contract-tested. Correlation indexes or
+`$bc`-style lookups, if ever wanted, are rebuildable projections.
+
+**Conflicts with the constitution:** none found. The design the field converges on is the one
+the constitution already implies: metadata-envelope carriage preserves "events are facts, not
+incidental telemetry" and domain purity; adopting one id end to end is the only reading under
+which `logging.md`'s "through the whole system" sentence is achievable; additive optional fields
+satisfy `api-compatibility.md`. The only *tension* worth minuting: a strict
+"mint-per-context, translate at the ACL" position — defensible in pure context-mapping terms —
+would conflict with `logging.md` and with all surveyed messaging practice; this research
+recommends against it.
+
+**Pitfall checklist for the OpenSpec proposal:**
+
+- [ ] Define the vocabulary in the design doc (`correlationId` = story, `causationId` =
+      immediate parent) — Axon-style inversion is a real hazard (§2.3).
+- [ ] `correlationId` stays optional in every reader forever; pre-change events never get one;
+      no upcaster fabricates ids.
+- [ ] Metadata envelope only — no correlation field in any domain event payload, command type,
+      or decider signature.
+- [ ] Published integration schemas: additive optional metadata block; contract tests updated;
+      tolerant readers on the consuming side.
+- [ ] Every async hop is a break point: reactor dispatch, the download supervisor's
+      settle-callback, catch-up subscription delivery, startup redrive. Each must copy the id
+      from the triggering `StoredEvent` (or mint fresh where no trigger exists, e.g. redrive).
+- [ ] Batch-append granularity: one `EventMetadata` per decision means one causation per batch —
+      document that this is intended (the trigger is the parent of all its events).
+- [ ] Reactor follow-up commands and effect-outcome commands carry the id explicitly; don't rely
+      on ambient state across `await` gaps.
+- [ ] Logger bindings under application-controlled keys; confirm no new binding collides with
+      redaction paths or pino internals.
+- [ ] If the id ever surfaces in the UI (e.g., quoting it in error messages next to `errorId`),
+      audit `test/e2e` and Playwright parity first — scraped-surface blast radius.
+- [ ] Choose the id format once (uuid vs 32-hex trace-id-compatible) and record why; either is
+      fine, changing later is churn.
+- [ ] Correlation-keyed queries, if wanted, are projections — rebuildable, never a second source
+      of truth.
+
+---
+
+*Non-normative. This document records prior art and its convergences as of the research date; it
+decides nothing. The OpenSpec change owns the actual design.*
+
+## Sources
+
+- Greg Young, "causation or correlation id?" — Kurrent forum:
+  <https://discuss.kurrent.io/t/causation-or-correlation-id/828/4>
+- Kurrent blog, "Did you know that EventStoreDB has a Visualize tab?" (`$correlationId`,
+  `$causationId`, `$by_correlation_id`, `$bc-` streams):
+  <https://www.kurrent.io/blog/eventstoredb-visualise-tab/>
+- NServiceBus message headers (ConversationId, RelatedTo, CorrelationId, MessageId):
+  <https://docs.particular.net/nservicebus/messaging/headers>
+- NServiceBus message correlation:
+  <https://docs.particular.net/nservicebus/messaging/message-correlation>
+- Axon Framework 4.12, Message Correlation (`MessageOriginProvider`, correlation data
+  providers):
+  <https://docs.axoniq.io/axon-framework-reference/4.12/messaging-concepts/message-correlation/>
+- Eventide metadata & messages docs **[secondary — site HTTP-only, quotes via search excerpts]**:
+  <http://docs.eventide-project.org/user-guide/messages-and-message-data/metadata.html>,
+  <http://docs.eventide-project.org/user-guide/messages-and-message-data/messages.html>
+- Message DB (schema, nullable `metadata` jsonb, `write_message`, `correlation` filter):
+  <https://github.com/message-db/message-db>
+- Rails Event Store, Correlation and Causation:
+  <https://railseventstore.org/docs/core-concepts/correlation-causation>
+- Arkency, "Correlation id and causation id in evented systems":
+  <https://blog.arkency.com/correlation-id-and-causation-id-in-evented-systems/>
+- Marten, Event Metadata (opt-in flags, session scoping, OTel span sourcing):
+  <https://martendb.io/events/metadata.html>
+- W3C Trace Context (traceparent format):
+  <https://www.w3.org/TR/trace-context/>
+- OpenTelemetry logs spec (TraceId/SpanId in LogRecords):
+  <https://opentelemetry.io/docs/specs/otel/logs/>
+- pino child loggers and API (`child`, `mixin`, bindings) — GitHub (getpino.io unreachable):
+  <https://github.com/pinojs/pino/blob/main/docs/child-loggers.md>,
+  <https://github.com/pinojs/pino/blob/main/docs/api.md>
+- pino-http (`genReqId`, `req.log`):
+  <https://github.com/pinojs/pino-http>
+- Maxim Orlov, "Logging with Pino and AsyncLocalStorage in Node.js":
+  <https://maximorlov.com/logging-with-pino-and-asynclocalstorage-in-nodejs/>
+- Last9, "Correlation ID vs Trace ID":
+  <https://last9.io/blog/correlation-id-vs-trace-id/>
+- Hohpe & Woolf, Correlation Identifier:
+  <https://www.enterpriseintegrationpatterns.com/patterns/messaging/CorrelationIdentifier.html>
+- Commanded issue #70 (framework adoption of Young's rule) **[secondary]**:
+  <https://github.com/commanded/commanded/issues/70>
+- Codemia, correlation id changes across contexts **[secondary]**:
+  <https://codemia.io/knowledge-hub/path/handling_correlation_id_changes_in_event_sourcing_when_an_entity_switches_context>

--- a/openspec/changes/end-to-end-correlation/.openspec.yaml
+++ b/openspec/changes/end-to-end-correlation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/end-to-end-correlation/design.md
+++ b/openspec/changes/end-to-end-correlation/design.md
@@ -1,0 +1,97 @@
+# Design — end-to-end-correlation
+
+## Context
+
+See proposal.md — Why. Current state: `EventMetadata` (both contexts) has `acquisitionId`/
+`importId`, `occurredAt`, and a dormant optional `correlationId`; appends are performed by
+application services and reactors; the BFF has a single `handle` hook and a server logger;
+adapters already receive injected pino loggers; published events are rendered through
+producer-owned zod schemas with additivity gates. Evidence base:
+`docs/research/correlation-causation-conventions.md` (adopted wholesale, grill 2026-08-05);
+its 11-item pitfall checklist is tracked below.
+
+## Goals / Non-Goals
+
+**Goals:** the pair end to end (request → command → events → reactor follow-ups → published
+events → consuming context), logs joined to stories, zero domain impact, additive-only.
+
+**Non-Goals:** OTel SDK/backends; inbound `traceparent` adoption; UI surfacing; backfill;
+correlation-keyed read models (a rebuildable projection may come later if ever needed).
+
+## Decisions
+
+**D1 — Names and shapes.** `correlationId`: 32-hex-char W3C-trace-id-compatible string, minted
+via `crypto.randomBytes(16)`. `causation`: a discriminated reference — `{kind: 'event',
+streamId, version}` for stored-event parents, `{kind: 'command', commandId}` for
+request-minted commands (commandId a fresh UUID minted with the context). Store coordinates
+over per-event UUIDs (Eventide precedent) — no new identity columns, replay-stable. Terms fixed
+correlation/causation; the research's Axon-inversion hazard is documented at the type.
+
+**D2 — CommandContext at the application seam.** A `CommandContext {correlationId, causation}`
+travels as an explicit argument alongside commands into the application services (never inside
+the command object the domain sees). Append attaches it to `EventMetadata` (additive optional
+fields: `causation` joins the existing dormant `correlationId`). Alternative — ALS ambient
+context: rejected per research (explicit passing is the attested default; ALS only where
+passing is impossible, which is nowhere in this codebase).
+
+**D3 — Minting points enumerated (pitfall: async-hop break points).**
+- BFF `handle` hook: mint per request, stash on `locals` with a request-scoped child logger;
+  facade command calls thread the context.
+- Reactor dispatch: copy the story from the triggering `StoredEvent`'s metadata (fresh mint if
+  absent — pre-change events), causation = that event's coordinates; per-dispatch child logger
+  binds `{correlationId, streamId, globalSeq}`.
+- Supervisor: the watch pins the originating dispatch's context at creation; all async
+  callbacks, teardown, and outcome delivery log and deliver under it (the v3.16 callback is the
+  research's named break point).
+- Poll ticks, intake scanner, boot re-emit, redrive verb (drafted in stalled-work-recovery):
+  each mints fresh at its trigger. The redrive draft needs no artifact change — its verb is an
+  outermost trigger by this design's definition.
+- Batch appends (pitfall: causation granularity): every event of one decision shares the one
+  causation reference — the deciding command — not chained event-to-event within the batch.
+
+**D4 — Seam carriage.** Producer renders the optional metadata block; the consumer's tolerant
+intake reader parses it (absent ⇒ mint fresh, per spec) and the intake's command context
+adopts the story id with causation = consumed event coordinates (namespaced by the producer
+context, e.g. `downloader:streamId@version`, so coordinates stay unambiguous across stores).
+
+**D5 — Logger topology.** One binding rule: whoever starts a unit of work creates the child;
+everyone else logs through the logger they're handed. Web: `locals.logger`. Reactors/
+supervisor: dispatch-scoped child passed into interpreters/effect handlers, which already
+receive loggers — adapters change zero lines beyond what S1's structured-field cleanups
+already touch. `DEFAULT_REDACT_PATHS` unaffected (ids are not secrets).
+
+**D6 — Contract growth.** Both published schemas gain the optional block; additivity gates and
+frozen fixtures prove compatibility (spec'd). The stored-event side needs no upcaster — optional
+fields on metadata, absent forever on old rows (pitfall: never fabricated).
+
+**D7 — Testing shape (pitfall: e2e blast radius).** Ids never render in UI copy, so the e2e
+scrape surface is untouched; e2e gains only a log-side assertion (one submission's story id
+appears in both modules' log lines — cheap grep against captured container logs, no new phase).
+Unit tiers pin: mint-once-copy-verbatim, causation rewrite per hop, seam adoption, absence
+degradation, and the domain-blindness boundary (a grep-backed test that no domain signature
+names the pair, same style as the boundaries tier).
+
+## Risks / Trade-offs
+
+- **[Context threading touches every command call site]** → Mechanical, compiler-driven (new
+  required parameter on application services; facades construct it from `locals` or trigger
+  mints); domain untouched keeps the diff shallow per site.
+- **[A missed hop silently breaks the chain]** → The e2e log-join assertion catches the
+  golden path; unit pins cover each enumerated hop from D3; the pitfall checklist's hop
+  inventory is the review checklist for the implementing PR.
+- **[Two stores' coordinates could collide in causation references]** → D4's context
+  namespacing makes references unambiguous by construction.
+- **[Future OTel adoption]** → Format-compatible ids mean adoption is additive (span context
+  wraps the same id); no rework debt minted.
+
+## Migration Plan
+
+Additive deploy; no data migration; old events trace-degrade by design. Rollback is the
+previous image — new metadata is ignored by old readers (optional fields under tolerant
+schemas).
+
+## Open Questions
+
+- Whether the reactor's fresh-mint-on-absent path should log at info or debug when it
+  synthesizes a story for a pre-change stream — a log-noise calibration settled at
+  implementation.

--- a/openspec/changes/end-to-end-correlation/proposal.md
+++ b/openspec/changes/end-to-end-correlation/proposal.md
@@ -1,0 +1,71 @@
+# Proposal: end-to-end-correlation
+
+## Why
+
+`docs/development/logging.md` promises "follow a single operation through the whole system by
+its correlation id" — and none of it exists. The whole-project review sweep (2026-08-05) found
+`EventMetadata.correlationId` declared in both contexts and populated nowhere, zero child-logger
+bindings, and adapter log lines omitting even the stream identity in scope, so an incident's
+adapter half cannot be joined to its acquisition. The design follows
+`docs/research/correlation-causation-conventions.md` (adopted wholesale, grill 2026-08-05):
+seven independent designs converge on the same shape, and the constitution's promise is
+unsatisfiable with anything less.
+
+## What Changes
+
+- **The pair, defined once.** Every unit of work carries a **correlation id** — the story,
+  minted once at the outermost trigger in a W3C-trace-id-compatible format and copied verbatim
+  through every hop — and a **causation reference** — the immediate parent, rewritten at each
+  hop, expressed as store coordinates (`streamId@version`) when the parent is an event rather
+  than a fresh UUID. Terminology is fixed as correlation/causation (the Young/ESDB naming; the
+  research documents the Axon inversion hazard).
+- **Minted at the outermost trigger, carried by the shell.** The BFF's request hook mints per
+  request; non-HTTP triggers (pollers, the intake scanner, boot re-emit, the drafted redrive
+  verb) mint fresh per unit of work. Commands carry an application-level context; append writes
+  it into event metadata; reactors copy the story id from the triggering stored event and point
+  causation at it; the supervisor pins the watch's originating context at watch creation so its
+  async callbacks and outcome delivery inherit it. Deciders and evolve never see any of it.
+- **One operational id crosses the seam.** Published integration events gain an optional,
+  additive metadata block; the consuming context adopts the producer's correlation id as its own
+  operational story id (causation pointing at the consumed event), per the unanimous field
+  practice — the ACL translates the model, never the observability envelope. Business
+  provenance (`acquisitionId`) is untouched and remains a separate concept.
+- **Logs bind the same identity.** Request-scoped pino child at the BFF (on `locals`),
+  per-dispatch children in reactors and the supervisor binding
+  `{correlationId, streamId, globalSeq}`, adapters inheriting through the already-injected
+  logger — no adapter-code awareness, no ambient AsyncLocalStorage.
+- **Additive-only retrofit.** Metadata fields are optional in every reader forever; historical
+  events are never backfilled and upcasters never fabricate ids; published schemas evolve
+  additively under the existing contract gates. Correlation-keyed queries, if ever wanted, are
+  projections — never truth.
+- **Non-goals:** no OpenTelemetry SDK, exporter, or tracing backend (trace-id-compatible format
+  keeps that door open); no inbound `traceparent` trust at the BFF (we mint, we don't adopt
+  callers' ids); no UI surfacing of ids (log-and-store-only — keeps the e2e copy blast radius at
+  zero); no retroactive correlation of pre-change events.
+
+## Capabilities
+
+### New Capabilities
+
+- `operation-correlation`: the correlation/causation identity contract — pair semantics,
+  minting points, shell-only carriage, cross-seam adoption, log binding, and the additive
+  retrofit rules.
+
+### Modified Capabilities
+
+- `outbound-events`: the downloader's published events gain the optional correlation metadata
+  block under the additive-only contract.
+- `importer-outbound-events`: the importer's published verdicts gain the same optional block.
+
+## Impact
+
+- **Code:** both modules' application layers (command context, append metadata, reactor
+  propagation, supervisor context pinning), both facades' command entry points, the BFF request
+  hook and server logger, adapters only via the loggers they already receive; both published
+  event renderers/schemas (additive) and their contract gates; no domain-layer changes.
+- **Contracts:** additive only — optional metadata on stored events and published events;
+  tolerant readers unchanged in behavior when the block is absent.
+- **Docs:** `logging.md`'s Correlation section becomes true rather than aspirational; the
+  research doc's 11-item pitfall checklist is tracked in design.md.
+- **Operations:** incident debugging gains story-joined logs across BFF → reactor → adapter →
+  cross-context consumer; nothing changes for existing data.

--- a/openspec/changes/end-to-end-correlation/specs/importer-outbound-events/spec.md
+++ b/openspec/changes/end-to-end-correlation/specs/importer-outbound-events/spec.md
@@ -1,0 +1,25 @@
+# importer-outbound-events — delta for end-to-end-correlation
+
+## ADDED Requirements
+
+### Requirement: Published verdicts carry optional correlation metadata
+
+The importer's published `release.verdict` events SHALL carry an optional metadata block with
+the operation's correlation id and a causation reference (see `operation-correlation`),
+rendered by the producer alongside the payload and validated by the published schema. The block
+SHALL be additive under the existing contract gate: prior fixtures without it remain valid, and
+the consuming module's tolerant reader is unaffected when it is absent. Where the verdict's
+operation originated from a consumed downloader event, the correlation id SHALL be the one that
+crossed the seam — so the full story downloader → importer → verdict → downloader shares one
+id.
+
+#### Scenario: A verdict continues the cross-seam story
+
+- **GIVEN** an import whose intake adopted a downloader-minted correlation id
+- **WHEN** its review is resolved and the verdict is published
+- **THEN** the published verdict's metadata carries that same correlation id verbatim
+
+#### Scenario: The block is additive under the gate
+
+- **WHEN** the contract gate runs against the grown schema and the frozen verdict fixtures
+- **THEN** it passes — the block is optional and every prior fixture still validates

--- a/openspec/changes/end-to-end-correlation/specs/operation-correlation/spec.md
+++ b/openspec/changes/end-to-end-correlation/specs/operation-correlation/spec.md
@@ -1,0 +1,114 @@
+# operation-correlation — delta for end-to-end-correlation
+
+## Purpose
+
+Make one operation followable through the whole system: define the correlation/causation
+identity pair, where each id is minted and rewritten, how the pair rides commands, events,
+logs, and the cross-context seam, and the additive rules that let it retrofit onto stores that
+predate it.
+
+## ADDED Requirements
+
+### Requirement: Every unit of work carries the correlation/causation pair
+
+Every unit of work SHALL carry a correlation id — the story identifier, minted exactly once at
+the operation's outermost trigger and copied verbatim through every subsequent hop — and a
+causation reference identifying its immediate parent, rewritten at each hop. When the parent is
+a stored event, the causation reference SHALL be that event's store coordinates rather than a
+newly minted identifier. Correlation ids SHALL use a W3C-trace-id-compatible format. The terms
+SHALL mean exactly this — correlation = story, causation = parent — everywhere in code, logs,
+and docs.
+
+#### Scenario: A command's events inherit the story and point at their trigger
+
+- **WHEN** a request-minted command is decided and its events are appended
+- **THEN** each event's metadata carries the request's correlation id and a causation reference
+  to the command's context
+
+#### Scenario: A reactor-issued follow-up continues the story
+
+- **GIVEN** a stored event carrying correlation metadata
+- **WHEN** the reactor dispatches its effect and a follow-up command produces further events
+- **THEN** those events carry the same correlation id verbatim, with causation referencing the
+  triggering stored event's coordinates
+
+#### Scenario: Non-HTTP triggers mint fresh stories
+
+- **WHEN** a unit of work starts without an inbound request — a poll tick, the intake scanner,
+  boot re-emit, an operator redrive
+- **THEN** a fresh correlation id is minted at that trigger and flows exactly as a
+  request-minted one does
+
+### Requirement: The pair is carried by the shell, never the domain
+
+Correlation and causation SHALL live in command context and event metadata only. Deciders,
+evolve functions, and every other domain-layer construct SHALL NOT receive, read, or emit
+either id; propagation SHALL be performed by application-layer infrastructure at the
+unit-of-work seam.
+
+#### Scenario: The domain is blind to identity plumbing
+
+- **WHEN** the domain layer's inputs and outputs are inspected across both modules
+- **THEN** no domain signature or event payload names correlation or causation — the pair
+  exists only in metadata the shell attaches
+
+### Requirement: One operational id crosses the context seam
+
+A consuming context SHALL adopt the producer's correlation id, carried in the published event's
+metadata, as the operational story id for the work the consumption triggers — its causation
+referencing the consumed event — so one id follows the operation across both stores. The
+anti-corruption layer SHALL translate the domain model only; it SHALL NOT re-mint or translate
+the observability envelope. When a consumed event carries no metadata (an older producer or a
+pre-change event), the consumer SHALL mint fresh and proceed — absence degrades the trace, not
+the work. Business provenance identifiers remain separate concepts, unaffected by this
+capability.
+
+#### Scenario: The story survives the seam
+
+- **GIVEN** a downloader event published with correlation metadata
+- **WHEN** the importer consumes it and runs its intake
+- **THEN** the importer's resulting events carry the downloader-minted correlation id verbatim,
+  with causation referencing the consumed event
+
+#### Scenario: A metadata-less event still integrates
+
+- **WHEN** the consumer reads a published event without the metadata block
+- **THEN** consumption proceeds unchanged with a freshly minted story id
+
+### Requirement: Log lines are joinable to their unit of work
+
+Within a unit of work, structured log lines SHALL carry the correlation id and the work's
+subject identity (the stream id where one exists), bound once per unit of work via child
+loggers — request-scoped at the web layer, per-dispatch in reactors and the download supervisor
+— and inherited by adapters through the loggers they are already injected with. Adapter code
+SHALL NOT construct or manage correlation state itself. Ids SHALL NOT appear in user-visible
+interface text.
+
+#### Scenario: An adapter line joins its acquisition
+
+- **WHEN** a source adapter logs during an effect dispatched for an acquisition
+- **THEN** the line carries the correlation id and stream identity bound by the dispatch,
+  without the adapter having handled either
+
+#### Scenario: A request's lines share one id
+
+- **WHEN** the web layer serves one request that reads facades and logs several lines
+- **THEN** every line of that request carries the same request-minted correlation id
+
+### Requirement: Correlation retrofits additively and is never fabricated
+
+Correlation and causation metadata SHALL be optional in every reader, indefinitely. Historical
+events SHALL NOT be backfilled; upcasters SHALL NOT fabricate ids; published-contract growth
+SHALL be additive under the existing contract gates. Any correlation-keyed lookup SHALL be a
+rebuildable projection, never a source of truth.
+
+#### Scenario: Pre-change history reads unchanged
+
+- **WHEN** streams written before this capability are folded, projected, or replayed through
+  upcasters
+- **THEN** behavior is identical to today, with no fabricated metadata and no reader error
+
+#### Scenario: Published contracts stay compatible
+
+- **WHEN** the additivity contract gates run against the grown published schemas
+- **THEN** they pass — the metadata block is optional and prior fixtures still parse

--- a/openspec/changes/end-to-end-correlation/specs/outbound-events/spec.md
+++ b/openspec/changes/end-to-end-correlation/specs/outbound-events/spec.md
@@ -1,0 +1,23 @@
+# outbound-events — delta for end-to-end-correlation
+
+## ADDED Requirements
+
+### Requirement: Published events carry optional correlation metadata
+
+The downloader's published events SHALL carry an optional metadata block with the operation's
+correlation id and a causation reference (see `operation-correlation`), rendered by the producer
+alongside the payload and validated by the outbound schema. The block SHALL be additive under
+the existing contract gate: prior fixtures without it remain valid, and consumers reading
+through tolerant schemas are unaffected when it is absent.
+
+#### Scenario: A published event carries its story
+
+- **GIVEN** an acquisition operation carrying correlation metadata
+- **WHEN** its fulfilment event is rendered onto the outbound feed
+- **THEN** the published event includes the metadata block with the operation's correlation id
+
+#### Scenario: The block is additive under the gate
+
+- **WHEN** the schema-additivity contract gate runs against the grown schema and the historical
+  fixtures
+- **THEN** it passes — the block is optional and every prior fixture still validates

--- a/openspec/changes/end-to-end-correlation/tasks.md
+++ b/openspec/changes/end-to-end-correlation/tasks.md
@@ -1,0 +1,55 @@
+# Tasks — end-to-end-correlation
+
+Red-first TDD throughout; the failing test precedes every production edit, visible in commit
+order. Domain layers are untouched by construction — any task needing a domain edit is a design
+error to raise, not implement.
+
+## 1. The pair's home (both modules)
+
+- [ ] 1.1 Types + mint (red first): `correlationId` format, `CommandContext`, the causation
+      reference union with context-namespaced event coordinates; mint helper; terminology note
+      (incl. the Axon-inversion hazard) at the type.
+- [ ] 1.2 `EventMetadata` grows optional `causation` beside the existing `correlationId` (red
+      first): append paths write the context; readers tolerate absence; no upcaster changes —
+      pinned by a legacy-row read test.
+
+## 2. Carriage through the shell
+
+- [ ] 2.1 Application services take `CommandContext` (red first, compiler-driven call-site
+      sweep): facades construct from their trigger; events of one decision share the deciding
+      command's causation.
+- [ ] 2.2 Reactor propagation (red first): story copied from the triggering stored event,
+      causation = its coordinates, fresh mint on absent metadata (with the calibrated log
+      line); per-dispatch child logger binds `{correlationId, streamId, globalSeq}`.
+- [ ] 2.3 Supervisor context pinning (red first): watch pins the dispatch context at creation;
+      callbacks, teardown, and outcome delivery log/deliver under it — the async-hop test from
+      the research checklist.
+- [ ] 2.4 Non-HTTP triggers mint fresh (red first): poll ticks, intake scanner, boot re-emit —
+      one test per trigger naming it as an outermost mint point.
+
+## 3. The web layer
+
+- [ ] 3.1 `handle` hook mints per request; request-scoped child on `locals`; facade command
+      calls thread the context (red first: one-request-one-id log test; the hooks test
+      register).
+- [ ] 3.2 Boundary pin: no id in any user-visible copy (grep-backed test over the copy layer,
+      e2e scrape surface untouched).
+
+## 4. The seam
+
+- [ ] 4.1 Producers render the optional metadata block (red first): both outbound renderers +
+      schemas; additivity gates green against frozen fixtures.
+- [ ] 4.2 Consumers adopt the story (red first): tolerant intake reads the block, adopts the
+      id with consumed-event causation; absent block ⇒ fresh mint, consumption unchanged —
+      contract-tier tests against the producers' fixtures both ways.
+- [ ] 4.3 The verdict continues the story (red first): downloader-origin import → resolved
+      review → published verdict carries the original id — the full-circle contract test.
+
+## 5. Domain blindness and gates
+
+- [ ] 5.1 Grep-backed boundary test: no domain-layer signature or payload names correlation or
+      causation (boundaries-tier style).
+- [ ] 5.2 E2E log-join assertion: one submission's story id appears in both modules' captured
+      log lines (no new phase; rides an existing phase's teardown).
+- [ ] 5.3 `logging.md` Correlation section reviewed against the shipped reality; full gate
+      (`pnpm check`) green; local out-of-process e2e green.


### PR DESCRIPTION
Implements the OpenSpec draft for `logging.md`'s correlation promise — the 2026-08-05 whole-project review sweep found it entirely unimplemented (`EventMetadata.correlationId` populated nowhere, no child-logger bindings, adapter lines unjoinable to their acquisition).

Design per `docs/research/correlation-causation-conventions.md` (included in this PR): the correlation/causation pair (story id minted once at the outermost trigger + per-hop parent reference as store coordinates), one operational id end-to-end across the module seam, pino child loggers passed explicitly, additive-only retrofit (no backfill, no upcaster fabrication, no OTel SDK). Grilled + research-adopted 2026-08-05.

Proposal-only: new capability `operation-correlation` plus additive deltas on `outbound-events` / `importer-outbound-events`. No implementation, no runtime change, no version bump — implementation follows via /ship as its own lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)