### PR TITLE
fix: process-safety & silent-failure hardening batch (S1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,8 @@ SLSKD_BASE_URL=http://localhost:5030
 SLSKD_API_KEY=change-me
 #MUSICBRAINZ_BASE_URL=
 #MUSICBRAINZ_USER_AGENT=
+# Per-file kill budget for the ffprobe/decode validation passes:
+#FFMPEG_TIMEOUT_MS=120000
 
 # --- importer module ---------------------------------------------------------
 INTAKE_ROOT=/music/intake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.16.1](https://github.com/jgchk/music-downloader/compare/v3.16.0...v3.16.1) (2026-08-05)
+
+### Bug Fixes
+
+* **downloader:** back a failed landing off instead of re-firing the exhausted effect every tick ([024bdbf](https://github.com/jgchk/music-downloader/commit/024bdbf7c00e6d623c815445754a14a29b6493a6))
+* **downloader:** bound and instrument the ffmpeg probe; decode subprocess output as a stream ([5f9ef50](https://github.com/jgchk/music-downloader/commit/5f9ef50db994db6358a057fbe2f6c4356bfbef7b))
+* **downloader:** refuse to boot on a failed projection rebuild; harden the composed boot and shutdown ([f1f3956](https://github.com/jgchk/music-downloader/commit/f1f39562fec71eef10a13fec7f82f7a0b0f791d1))
+* **downloader:** require the slskd client injected; redact peer usernames from logs ([581b9ef](https://github.com/jgchk/music-downloader/commit/581b9eff1051b9a5c2aea78b472e8254c51983a4))
+* **importer:** contain reactor and seam-subscription defects; settle sibling effects independently ([4cf147d](https://github.com/jgchk/music-downloader/commit/4cf147d005f3ff2d455c3aeef78e5a582189e1d5))
+* **importer:** count the files the bridge skips as unreadable on stderr ([7d736e7](https://github.com/jgchk/music-downloader/commit/7d736e7b5af7494fdc91185e354d21fa14394c4d))
 ## [3.16.0](https://github.com/jgchk/music-downloader/compare/v3.15.1...v3.16.0) (2026-08-02)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "private": true,
   "description": "An extensible, event-sourced music downloader and importer — a modular monolith.",
   "type": "module",

--- a/packages/downloader/src/adapters/ffmpeg/probe.test.ts
+++ b/packages/downloader/src/adapters/ffmpeg/probe.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { silentLogger } from '../../application/__fixtures__/fakes.js';
+import { createLogger } from '../../application/logging/logger.js';
 import { FfmpegAudioProbe } from './probe.js';
 import type { CommandResult, CommandRunner } from './runner.js';
 
-const OK = { code: 0, stdout: '', stderr: '' };
+const OK = { code: 0, stdout: '', stderr: '', timedOut: false };
 
 function runner(probe: CommandResult, decode: CommandResult): CommandRunner {
   return {
@@ -12,7 +13,7 @@ function runner(probe: CommandResult, decode: CommandResult): CommandRunner {
 }
 
 function ffprobeJson(streams: unknown[], format?: unknown): CommandResult {
-  return { code: 0, stdout: JSON.stringify({ streams, format }), stderr: '' };
+  return { code: 0, stdout: JSON.stringify({ streams, format }), stderr: '', timedOut: false };
 }
 
 function probeWith(runnerImpl: CommandRunner): FfmpegAudioProbe {
@@ -52,7 +53,7 @@ describe('FfmpegAudioProbe', () => {
 
   it('marks a file unplayable when the decode pass fails', async () => {
     const meta = ffprobeJson([{ codec_type: 'audio', codec_name: 'flac', duration: '10' }]);
-    const decodeFailed = { code: 1, stdout: '', stderr: 'Invalid data' };
+    const decodeFailed = { code: 1, stdout: '', stderr: 'Invalid data', timedOut: false };
 
     const probeResult2 = await probeWith(runner(meta, decodeFailed)).probe('/x.flac');
     const result = probeResult2._unsafeUnwrap();
@@ -62,8 +63,73 @@ describe('FfmpegAudioProbe', () => {
     expect(result.durationMs).toBe(10_000);
   });
 
+  it('logs the decode stderr when folding a failed decode to unplayable', async () => {
+    // The unplayable fold is the designed business outcome, but discarding ffmpeg's own words
+    // hides a *systematic* environmental fault (a permissions problem, a missing codec in the
+    // image) that makes every candidate read "corrupt" — the diagnosis lives in this one line.
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: 'warn',
+      destination: { write: (line: string) => void lines.push(line) },
+    });
+    const meta = ffprobeJson([{ codec_type: 'audio', codec_name: 'flac', duration: '10' }]);
+    const decodeFailed = {
+      code: 1,
+      stdout: '',
+      stderr: '/staging/x.flac: Permission denied',
+      timedOut: false,
+    };
+
+    const result = await new FfmpegAudioProbe(logger, runner(meta, decodeFailed)).probe('/x.flac');
+
+    expect(result._unsafeUnwrap().decodedCleanly).toBe(false);
+    const logged = lines.join('');
+    expect(logged).toContain('Permission denied');
+    expect(logged).toContain('/x.flac');
+  });
+
+  it('logs the ffprobe stderr when metadata could not be read', async () => {
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: 'warn',
+      destination: { write: (line: string) => void lines.push(line) },
+    });
+    const probeFailed = { code: 1, stdout: '', stderr: 'moov atom not found', timedOut: false };
+
+    const result = await new FfmpegAudioProbe(logger, runner(probeFailed, OK)).probe('/x.m4a');
+
+    expect(result._unsafeUnwrap().decodedCleanly).toBe(false);
+    expect(lines.join('')).toContain('moov atom not found');
+  });
+
+  it('surfaces a timed-out run as an InfraError, never as a bad-file verdict', async () => {
+    // A kill-on-timeout is NOT a confirmed read of a corrupt file: a stalled staging mount would
+    // otherwise burn every candidate to "corrupt" (the misclassification family from the
+    // reactor-misclassified-permanent incidents). Timeouts stay infrastructure faults.
+    const timedOut = { code: null, stdout: '', stderr: '', timedOut: true };
+
+    const result = await probeWith(runner(timedOut, OK)).probe('/x.flac');
+
+    const error = result._unsafeUnwrapErr();
+    expect(error.kind).toBe('InfraError');
+    expect(error.operation).toBe('ffmpeg.probe');
+    expect(error.message).toContain('timed out');
+    expect(error.message).toContain('ffprobe'); // names the binary that hung
+  });
+
+  it('names ffmpeg when the decode pass is the run that timed out', async () => {
+    const meta = ffprobeJson([{ codec_type: 'audio', codec_name: 'flac', duration: '10' }]);
+    const hungDecode = { code: null, stdout: '', stderr: '', timedOut: true };
+
+    const result = await probeWith(runner(meta, hungDecode)).probe('/x.flac');
+
+    const error = result._unsafeUnwrapErr();
+    expect(error.kind).toBe('InfraError');
+    expect(error.message).toContain('ffmpeg timed out');
+  });
+
   it('yields empty metadata when ffprobe itself fails', async () => {
-    const probeFailed = { code: 1, stdout: '', stderr: 'not found' };
+    const probeFailed = { code: 1, stdout: '', stderr: 'not found', timedOut: false };
 
     const probeResult3 = await probeWith(runner(probeFailed, OK)).probe('/x.flac');
     const result = probeResult3._unsafeUnwrap();
@@ -90,7 +156,7 @@ describe('FfmpegAudioProbe', () => {
   });
 
   it('handles ffprobe output with no streams at all', async () => {
-    const meta = { code: 0, stdout: '{}', stderr: '' };
+    const meta = { code: 0, stdout: '{}', stderr: '', timedOut: false };
 
     const probeResult5 = await probeWith(runner(meta, OK)).probe('/empty');
     const result = probeResult5._unsafeUnwrap();
@@ -164,7 +230,7 @@ describe('FfmpegAudioProbe', () => {
   it('surfaces an InfraError naming ffprobe when it exits 0 with non-JSON output', async () => {
     // A successful exit that is not JSON is a broken/incompatible ffprobe (a `-print_format json`
     // run always emits JSON) — a boundary fault to surface, not a bad-file business outcome.
-    const garbage = { code: 0, stdout: 'not json at all', stderr: '' };
+    const garbage = { code: 0, stdout: 'not json at all', stderr: '', timedOut: false };
 
     const result = await probeWith(runner(garbage, OK)).probe('/x.flac');
 
@@ -177,7 +243,12 @@ describe('FfmpegAudioProbe', () => {
   it('surfaces an InfraError when ffprobe JSON violates the consumed contract shape', async () => {
     // Exit 0, valid JSON, but `streams` is not an array — a consumed field changed type, which the
     // tolerant schema rejects rather than silently degrading to all-undefined metadata.
-    const drifted = { code: 0, stdout: JSON.stringify({ streams: 'not-an-array' }), stderr: '' };
+    const drifted = {
+      code: 0,
+      stdout: JSON.stringify({ streams: 'not-an-array' }),
+      stderr: '',
+      timedOut: false,
+    };
 
     const result = await probeWith(runner(drifted, OK)).probe('/x.flac');
 

--- a/packages/downloader/src/adapters/ffmpeg/probe.ts
+++ b/packages/downloader/src/adapters/ffmpeg/probe.ts
@@ -14,7 +14,10 @@ import type { FfprobeOutput, FfprobeStream } from './schemas.js';
  * (`ffmpeg -f null`), which catches truncated/corrupt P2P downloads a header parse would miss;
  * the audio metadata (codec, ground-truth duration, sample rate, bit depth, bitrate, channels)
  * comes from `ffprobe`. A bad/unreadable file is a *business* outcome (`decodedCleanly: false`),
- * not an infra fault — only a failure to spawn the binaries surfaces as an `InfraError`.
+ * not an infra fault — only a failure to spawn the binaries, or a run killed on timeout, surfaces
+ * as an `InfraError`. A timeout is deliberately NOT a bad-file verdict: a kill is not a confirmed
+ * read of a corrupt file, and folding it to unplayable would let a stalled staging mount burn
+ * every candidate to "corrupt" (the misclassified-permanent incident family).
  */
 
 interface AudioMetadata {
@@ -29,7 +32,12 @@ interface AudioMetadata {
 export interface FfmpegConfig {
   readonly ffprobePath?: string;
   readonly ffmpegPath?: string;
+  /** Per-run kill budget; a hung decode inside the reactor's dispatch must never wedge it. */
+  readonly timeoutMs?: number;
 }
+
+/** Generous per-file bound: a full decode pass of a large lossless file on a slow mount. */
+const DEFAULT_TIMEOUT_MS = 120_000;
 
 /**
  * Parse a numeric ffprobe field, tolerating absence, an empty string, and the literal `N/A` ffprobe
@@ -91,6 +99,7 @@ function parseAudioMetadata(output: FfprobeOutput): AudioMetadata | undefined {
 export class FfmpegAudioProbe implements AudioProbePort {
   private readonly ffprobe: string;
   private readonly ffmpeg: string;
+  private readonly timeoutMs: number;
 
   constructor(
     private readonly logger: Logger,
@@ -99,6 +108,7 @@ export class FfmpegAudioProbe implements AudioProbePort {
   ) {
     this.ffprobe = config.ffprobePath ?? 'ffprobe';
     this.ffmpeg = config.ffmpegPath ?? 'ffmpeg';
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
 
   probe(filePath: string): ResultAsync<ProbedAudio, InfraError> {
@@ -110,17 +120,37 @@ export class FfmpegAudioProbe implements AudioProbePort {
   private async runProbe(filePath: string): Promise<ProbedAudio> {
     this.logger.debug({ filePath }, 'probing audio file');
     const [meta, decode] = await Promise.all([
-      this.runner.run(this.ffprobe, [
-        '-v',
-        'error',
-        '-show_streams',
-        '-show_format',
-        '-print_format',
-        'json',
-        filePath,
-      ]),
-      this.runner.run(this.ffmpeg, ['-v', 'error', '-i', filePath, '-f', 'null', '-']),
+      this.runner.run(
+        this.ffprobe,
+        ['-v', 'error', '-show_streams', '-show_format', '-print_format', 'json', filePath],
+        this.timeoutMs,
+      ),
+      this.runner.run(
+        this.ffmpeg,
+        ['-v', 'error', '-i', filePath, '-f', 'null', '-'],
+        this.timeoutMs,
+      ),
     ]);
+
+    if (meta.timedOut || decode.timedOut) {
+      const binary = meta.timedOut ? this.ffprobe : this.ffmpeg;
+      throw new Error(`${binary} timed out after ${this.timeoutMs}ms on ${filePath}`);
+    }
+    // The folds below are the designed business outcome, but the binaries' own words are the only
+    // diagnosis when a *systematic* environmental fault (permissions, a missing codec in the
+    // image) starts reading every candidate as "corrupt" — so they are never discarded silently.
+    if (decode.code !== 0) {
+      this.logger.warn(
+        { filePath, code: decode.code, stderr: decode.stderr },
+        'audio decode failed; treating the file as unplayable',
+      );
+    }
+    if (meta.code !== 0) {
+      this.logger.warn(
+        { filePath, code: meta.code, stderr: meta.stderr },
+        'ffprobe could not read audio metadata',
+      );
+    }
 
     const audio = meta.code === 0 ? parseAudioMetadata(parseFfprobeOutput(meta.stdout)) : undefined;
     return {

--- a/packages/downloader/src/adapters/ffmpeg/runner.test.ts
+++ b/packages/downloader/src/adapters/ffmpeg/runner.test.ts
@@ -7,15 +7,44 @@ const node = process.execPath;
 
 describe('nodeCommandRunner', () => {
   it('captures stdout, stderr, and the exit code of a completed process', async () => {
-    const result = await nodeCommandRunner.run(node, [
-      '-e',
-      "process.stdout.write('out'); process.stderr.write('err'); process.exit(2)",
-    ]);
+    const result = await nodeCommandRunner.run(
+      node,
+      ['-e', "process.stdout.write('out'); process.stderr.write('err'); process.exit(2)"],
+      5000,
+    );
 
-    expect(result).toEqual({ code: 2, stdout: 'out', stderr: 'err' });
+    expect(result).toEqual({ code: 2, stdout: 'out', stderr: 'err', timedOut: false });
+  });
+
+  it('kills a run that exceeds its timeout and flags it', async () => {
+    // A hung decode (a pathological stream, a stalled network read under the staging mount) must
+    // never wedge the caller forever — the run is killed and flagged, like the beets runner's.
+    const result = await nodeCommandRunner.run(
+      node,
+      ['-e', 'setTimeout(() => undefined, 60_000)'],
+      100,
+    );
+
+    expect(result.timedOut).toBe(true);
+    expect(result.code).toBeNull();
+  });
+
+  it('decodes multi-byte UTF-8 split across chunk boundaries intact', async () => {
+    // A per-chunk `Buffer#toString` corrupts a code point whose bytes straddle two chunks; the
+    // runner must decode the stream, not the chunks (metadata is full of non-ASCII titles).
+    const script =
+      "const b = Buffer.from('✓', 'utf8');" +
+      'process.stdout.write(b.subarray(0, 2));' +
+      'setTimeout(() => { process.stdout.write(b.subarray(2)); }, 20);';
+
+    const result = await nodeCommandRunner.run(node, ['-e', script], 5000);
+
+    expect(result.stdout).toBe('✓');
   });
 
   it('rejects when the command cannot be spawned', async () => {
-    await expect(nodeCommandRunner.run('md-no-such-binary-xyz', [])).rejects.toBeInstanceOf(Error);
+    await expect(nodeCommandRunner.run('md-no-such-binary-xyz', [], 1000)).rejects.toBeInstanceOf(
+      Error,
+    );
   });
 });

--- a/packages/downloader/src/adapters/ffmpeg/runner.test.ts
+++ b/packages/downloader/src/adapters/ffmpeg/runner.test.ts
@@ -47,4 +47,39 @@ describe('nodeCommandRunner', () => {
       Error,
     );
   });
+
+  it('resolves within the post-kill grace even when stdio never closes (the D-state shape)', async () => {
+    // SIGKILL cannot unstick uninterruptible I/O, and 'close' additionally waits for stdio to
+    // drain — a grandchild holding the inherited stdout simulates exactly that: the child is
+    // killed at the timeout but 'close' stays pending. The run must resolve as timed out after
+    // a short grace instead of wedging the reactor's dispatch behind a pipe that never closes.
+    const script =
+      "const { spawn } = require('node:child_process');" +
+      "spawn(process.execPath, ['-e', 'setTimeout(() => undefined, 2000)'], { stdio: ['ignore', 'inherit', 'inherit'] });" +
+      'setTimeout(() => undefined, 60_000);';
+    const startedAt = Date.now();
+
+    const result = await nodeCommandRunner.run(node, ['-e', script], 100);
+
+    expect(result.timedOut).toBe(true);
+    expect(result.code).toBeNull();
+    expect(Date.now() - startedAt).toBeLessThan(1900); // resolved by grace, not by the pipe
+  });
+
+  it('never stamps a false timeout on a process that already exited', async () => {
+    // The exit→close window can span the timeout deadline when stdio is still draining (here: a
+    // grandchild holds stdout after the child exits cleanly). The timer must recognize the
+    // process as already exited and leave the result untainted — a completed decode reported as
+    // a timeout would turn a good verdict into a retryable fault.
+    const script =
+      "const { spawn } = require('node:child_process');" +
+      "spawn(process.execPath, ['-e', 'setTimeout(() => undefined, 1200)'], { stdio: ['ignore', 'inherit', 'inherit'] }).unref();" +
+      "process.stdout.write('done');";
+
+    const result = await nodeCommandRunner.run(node, ['-e', script], 300);
+
+    expect(result.timedOut).toBe(false);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe('done');
+  });
 });

--- a/packages/downloader/src/adapters/ffmpeg/runner.ts
+++ b/packages/downloader/src/adapters/ffmpeg/runner.ts
@@ -18,16 +18,32 @@ export interface CommandRunner {
   run(command: string, arguments_: readonly string[], timeoutMs: number): Promise<CommandResult>;
 }
 
+/**
+ * How long a killed child gets to reach 'close' before the run resolves without it. SIGKILL
+ * cannot unstick uninterruptible I/O (a D-state read against a stalled staging mount — the very
+ * scenario the timeout exists for), and 'close' additionally waits for stdio to drain; past this
+ * grace the run resolves as timed out with whatever was captured, accepting an orphaned child
+ * rather than a wedged reactor dispatch.
+ */
+const KILL_GRACE_MS = 1000;
+
 export const nodeCommandRunner: CommandRunner = {
   run(command, arguments_, timeoutMs) {
     return new Promise<CommandResult>((resolve, reject) => {
       const child = spawn(command, [...arguments_]);
       let stdout = '';
       let stderr = '';
+      let graceTimer: NodeJS.Timeout | undefined;
       let isTimedOut = false;
       const timer = setTimeout(() => {
+        // Already exited, 'close' merely pending on stdio drain: not a timeout — stamping one
+        // would turn a completed decode into a retryable fault. Let 'close' report the truth.
+        if (child.exitCode !== null) return;
         isTimedOut = true;
         child.kill('SIGKILL');
+        graceTimer = setTimeout(() => {
+          resolve({ code: null, stdout, stderr, timedOut: true });
+        }, KILL_GRACE_MS);
       }, timeoutMs);
       // Decode the stream, not the chunks: a multi-byte code point split across two chunks
       // corrupts under a per-chunk `Buffer#toString`, and tag metadata is full of non-ASCII.
@@ -35,12 +51,16 @@ export const nodeCommandRunner: CommandRunner = {
       child.stderr.setEncoding('utf8');
       child.stdout.on('data', (chunk: string) => (stdout += chunk));
       child.stderr.on('data', (chunk: string) => (stderr += chunk));
+      // A settled promise ignores later resolve/reject calls, so a 'close' that limps in after
+      // the grace resolution needs no guard — it just clears the timers.
       child.on('error', (cause) => {
         clearTimeout(timer);
+        clearTimeout(graceTimer);
         reject(cause);
       });
       child.on('close', (code) => {
         clearTimeout(timer);
+        clearTimeout(graceTimer);
         resolve({ code, stdout, stderr, timedOut: isTimedOut });
       });
     });

--- a/packages/downloader/src/adapters/ffmpeg/runner.ts
+++ b/packages/downloader/src/adapters/ffmpeg/runner.ts
@@ -3,29 +3,46 @@ import { spawn } from 'node:child_process';
 /**
  * A minimal process-runner seam for the ffmpeg/ffprobe adapters. It resolves with the child's
  * exit code and captured output for *any* completed run (a non-zero exit is a normal business
- * signal — an unplayable file), and rejects only when the process cannot be spawned at all
- * (e.g. the binary is missing) — which the adapter maps to an `InfraError`.
+ * signal — an unplayable file), flags a run that had to be killed on timeout (a hung decode must
+ * never wedge the reactor's dispatch forever), and rejects only when the process cannot be
+ * spawned at all (e.g. the binary is missing) — which the adapter maps to an `InfraError`.
  */
 export interface CommandResult {
   readonly code: number | null; // null when the process was terminated by a signal
   readonly stdout: string;
   readonly stderr: string;
+  readonly timedOut: boolean;
 }
 
 export interface CommandRunner {
-  run(command: string, arguments_: readonly string[]): Promise<CommandResult>;
+  run(command: string, arguments_: readonly string[], timeoutMs: number): Promise<CommandResult>;
 }
 
 export const nodeCommandRunner: CommandRunner = {
-  run(command, arguments_) {
+  run(command, arguments_, timeoutMs) {
     return new Promise<CommandResult>((resolve, reject) => {
       const child = spawn(command, [...arguments_]);
       let stdout = '';
       let stderr = '';
-      child.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()));
-      child.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()));
-      child.on('error', reject);
-      child.on('close', (code) => resolve({ code, stdout, stderr }));
+      let isTimedOut = false;
+      const timer = setTimeout(() => {
+        isTimedOut = true;
+        child.kill('SIGKILL');
+      }, timeoutMs);
+      // Decode the stream, not the chunks: a multi-byte code point split across two chunks
+      // corrupts under a per-chunk `Buffer#toString`, and tag metadata is full of non-ASCII.
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', (chunk: string) => (stdout += chunk));
+      child.stderr.on('data', (chunk: string) => (stderr += chunk));
+      child.on('error', (cause) => {
+        clearTimeout(timer);
+        reject(cause);
+      });
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        resolve({ code, stdout, stderr, timedOut: isTimedOut });
+      });
     });
   },
 };

--- a/packages/downloader/src/adapters/slskd/client.test.ts
+++ b/packages/downloader/src/adapters/slskd/client.test.ts
@@ -87,6 +87,33 @@ describe('SlskdClient', () => {
     await expect(client.get('/api/v0/searches/s1')).rejects.toThrow('slskd responded 500');
   });
 
+  it('keeps the peer username out of every thrown message (dead-letter-bound strings)', async () => {
+    // These messages land in parked-effect lastError fields and dead-letter payloads, where the
+    // pino redaction paths cannot follow (redaction covers structured fields, not string
+    // interpolation). The downloads path embeds the URL-encoded peer username, so the thrown
+    // message must carry the route shape, never the raw path.
+    const { http } = recordingClient({ status: 500, body: 'boom' });
+    const client = new SlskdClient(http);
+    const path = '/api/v0/transfers/downloads/peer%40name.42';
+
+    for (const attempt of [
+      client.get(path),
+      client.getOr(path, {}),
+      client.delIfPresent(`${path}/t-1?remove=false`),
+    ]) {
+      let thrown: Error | undefined;
+      try {
+        await attempt;
+      } catch (error) {
+        thrown = error as Error;
+      }
+      expect(thrown, 'expected a non-2xx throw').toBeDefined();
+      expect(thrown!.message).toContain('500');
+      expect(thrown!.message).not.toContain('peer%40name.42');
+      expect(thrown!.message).toContain('/transfers/downloads/');
+    }
+  });
+
   describe('getOr', () => {
     it('returns the fallback for a 404 (an absent collection is a state, not a fault)', async () => {
       const { http } = recordingClient({ status: 404, body: '' });

--- a/packages/downloader/src/adapters/slskd/client.ts
+++ b/packages/downloader/src/adapters/slskd/client.ts
@@ -15,6 +15,16 @@ export function downloadsPath(username: string): string {
   return `/api/v0/transfers/downloads/${encodeURIComponent(username)}`;
 }
 
+/**
+ * The path as thrown messages may carry it: the downloads route embeds the URL-encoded peer
+ * username (third-party PII), and these messages travel into parked-effect `lastError` fields and
+ * dead-letter payloads where pino's structured redaction cannot follow. The route shape survives
+ * for diagnosis; the peer segment does not.
+ */
+function redactedPath(path: string): string {
+  return path.replace(/(\/transfers\/downloads\/)[^/?]+/, '$1<peer>');
+}
+
 export interface SlskdConfig {
   readonly baseUrl?: string;
   readonly apiKey?: string;
@@ -77,7 +87,7 @@ export class SlskdClient {
     const response = await this.dispatch('GET', path);
     if (response.status === 404) return notFound;
     if (response.status < 200 || response.status >= 300) {
-      throw new Error(`slskd responded ${response.status} for GET ${path}`);
+      throw new Error(`slskd responded ${response.status} for GET ${redactedPath(path)}`);
     }
     return response.body === '' ? undefined : JSON.parse(response.body);
   }
@@ -91,7 +101,7 @@ export class SlskdClient {
     const response = await this.dispatch('DELETE', path);
     if (response.status === 404) return;
     if (response.status < 200 || response.status >= 300) {
-      throw new Error(`slskd responded ${response.status} for DELETE ${path}`);
+      throw new Error(`slskd responded ${response.status} for DELETE ${redactedPath(path)}`);
     }
   }
 
@@ -102,7 +112,7 @@ export class SlskdClient {
   ): Promise<unknown> {
     const response = await this.dispatch(method, path, body);
     if (response.status < 200 || response.status >= 300) {
-      throw new Error(`slskd responded ${response.status} for ${method} ${path}`);
+      throw new Error(`slskd responded ${response.status} for ${method} ${redactedPath(path)}`);
     }
     return response.body === '' ? undefined : JSON.parse(response.body);
   }

--- a/packages/downloader/src/adapters/slskd/download.test.ts
+++ b/packages/downloader/src/adapters/slskd/download.test.ts
@@ -710,10 +710,14 @@ describe('SlskdDownload', () => {
 
     const started = await harness.adapter.start(ACQ, candidate, policy(1000, 1000));
 
-    expect(started._unsafeUnwrapErr()).toMatchObject({
+    const infraError = started._unsafeUnwrapErr();
+    expect(infraError).toMatchObject({
       kind: 'InfraError',
       operation: 'slskd.download',
     });
+    // The durable observable of the redaction decision: this message lands in parked-effect
+    // lastError fields and dead-letter payloads, where structured redaction cannot reach.
+    expect(infraError.message).not.toContain('u1');
   });
 
   it('surfaces a 429 enqueue response as a retryable InfraError', async () => {

--- a/packages/downloader/src/adapters/slskd/download.ts
+++ b/packages/downloader/src/adapters/slskd/download.ts
@@ -202,7 +202,9 @@ export class SlskdDownload implements DownloadPort {
         // matching every other GET/POST path in this adapter. Marking it a candidate failure would
         // manufacture AcquisitionExhausted from a transient slskd overload.
         // The peer username stays out of the message: this string reaches dead-letter payloads,
-        // where the redaction paths cannot follow it. The debug line above carries it structured.
+        // where pino's structured redaction cannot follow interpolated text. The debug line above
+        // carries the username as a structured field, which the composed logger's redaction paths
+        // scrub from shipped lines — so the peer is deliberately recoverable nowhere downstream.
         throw new Error(`slskd responded ${enqueue.status} for the download enqueue POST`);
       }
       if (enqueue.status < 200 || enqueue.status >= 300) {

--- a/packages/downloader/src/adapters/slskd/download.ts
+++ b/packages/downloader/src/adapters/slskd/download.ts
@@ -16,8 +16,8 @@ import type {
   SourceResourceKey,
 } from '../../application/ports/resource-ledger-port.js';
 import type { Logger } from '../../application/logging/logger.js';
-import { downloadsPath, SlskdClient } from './client.js';
-import type { SlskdConfig } from './client.js';
+import { downloadsPath } from './client.js';
+import type { SlskdConfig, SlskdClient } from './client.js';
 import { remoteFilename } from './mapping.js';
 import { pollOwnedTransfers } from './poll.js';
 import { StagedFileResolver } from './staged-files.js';
@@ -89,7 +89,7 @@ export class SlskdDownload implements DownloadPort {
     ledger: ResourceLedgerStore,
     config: SlskdDownloadConfig,
     private readonly observer: DownloadObserverPort,
-    client: SlskdClient = new SlskdClient(),
+    client: SlskdClient,
     private readonly timer: Timer = realTimer,
   ) {
     this.client = client;
@@ -201,7 +201,9 @@ export class SlskdDownload implements DownloadPort {
         // maps it to a retryable InfraError (the reactor parks and retries the short start effect),
         // matching every other GET/POST path in this adapter. Marking it a candidate failure would
         // manufacture AcquisitionExhausted from a transient slskd overload.
-        throw new Error(`slskd responded ${enqueue.status} for POST ${downloadsPath(username)}`);
+        // The peer username stays out of the message: this string reaches dead-letter payloads,
+        // where the redaction paths cannot follow it. The debug line above carries it structured.
+        throw new Error(`slskd responded ${enqueue.status} for the download enqueue POST`);
       }
       if (enqueue.status < 200 || enqueue.status >= 300) {
         // A 4xx (other than 401/403) means slskd answered and refused THIS candidate's enqueue

--- a/packages/downloader/src/adapters/slskd/resource-remover.ts
+++ b/packages/downloader/src/adapters/slskd/resource-remover.ts
@@ -6,7 +6,8 @@ import type {
   SourceResourceRemover,
 } from '../../application/ports/resource-ledger-port.js';
 import type { Logger } from '../../application/logging/logger.js';
-import { downloadsPath, SlskdClient } from './client.js';
+import type { SlskdClient } from './client.js';
+import { downloadsPath } from './client.js';
 import { slskdTransfersSchema } from './schemas.js';
 import { realTimer } from './timer.js';
 import type { Timer } from './timer.js';
@@ -33,7 +34,7 @@ export class SlskdResourceRemover implements SourceResourceRemover {
 
   constructor(
     private readonly logger: Logger,
-    private readonly client: SlskdClient = new SlskdClient(),
+    private readonly client: SlskdClient,
     private readonly timer: Timer = realTimer,
     pollIntervalMs: number = DEFAULT_POLL_INTERVAL_MS,
   ) {

--- a/packages/downloader/src/adapters/slskd/search.ts
+++ b/packages/downloader/src/adapters/slskd/search.ts
@@ -9,7 +9,7 @@ import type {
   SourceResourceKey,
 } from '../../application/ports/resource-ledger-port.js';
 import type { Logger } from '../../application/logging/logger.js';
-import { SlskdClient } from './client.js';
+import type { SlskdClient } from './client.js';
 import type { SlskdConfig } from './client.js';
 import { mapSearchResponses } from './mapping.js';
 import { slskdSearchResponsesSchema, slskdSearchStateSchema } from './schemas.js';
@@ -47,7 +47,7 @@ export class SlskdSearch implements SearchPort {
   constructor(
     private readonly logger: Logger,
     private readonly ledger: ResourceLedgerStore,
-    client: SlskdClient = new SlskdClient(),
+    client: SlskdClient,
     private readonly timer: Timer = realTimer,
     config: SlskdConfig = {},
   ) {

--- a/packages/downloader/src/application/acquisition/reactor.test.ts
+++ b/packages/downloader/src/application/acquisition/reactor.test.ts
@@ -695,6 +695,81 @@ describe('Reactor — budget exhaustion lands somewhere modeled (reactor-durabil
     r.stop();
   });
 
+  it('backs a failed landing off at the policy cap instead of re-firing the effect every tick', async () => {
+    // Budget exhausted AND the landing itself fails on infrastructure (the dead-letter write
+    // errors): leaving the past-due park untouched would re-dispatch the live effect on every
+    // drain tick — unbounded, with no backoff. The failed landing reschedules like every other
+    // infra failure, so the next attempt waits a full backoff step at the policy cap.
+    const a = matchingCandidate('a');
+    await seed([
+      ...selectedHistory([a]),
+      { type: 'DownloadFailed', candidate: a.identity, reason: 'Stalled' },
+      { type: 'CandidateRejected', candidate: a.identity, files: sampleFiles },
+    ]);
+    await checkpoints.save(REACTOR_CONSUMER, 7); // nothing pending — only the park is due
+    await parked.park({
+      streamId: 'acq-1',
+      globalSeq: 7,
+      attempt: 3,
+      parkedAt: '2026-07-22T10:00:00.000Z', // budget long spent
+      nextRetryAt: '2026-07-22T11:59:00.000Z', // due now
+      lastError: 'fs: denied',
+    });
+    deadLetters.failRecord = true;
+    const discardStaging = vi.fn(() => errAsync(infraError('fs', 'denied')));
+    const r = reactor(stubPorts({ library: { import: vi.fn(), discardStaging } }), {
+      retryPolicy: TIGHT_BUDGET,
+    });
+    await r.start();
+
+    const entry = parked.peek('acq-1');
+    expect(entry).toBeDefined();
+    expect(new Date(entry!.nextRetryAt).getTime()).toBeGreaterThan(clock.now().getTime());
+
+    // The very next tick must NOT re-fire the effect: the park is no longer due.
+    const fired = discardStaging.mock.calls.length;
+    await r.drain();
+    expect(discardStaging).toHaveBeenCalledTimes(fired);
+    r.stop();
+  });
+
+  it('says so loudly when the failed landing cannot even be re-parked', async () => {
+    // Landing failed AND the backoff re-park failed: the entry stays past-due (it will re-fire
+    // next tick — the last-resort behavior), but never silently.
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: 'error',
+      destination: { write: (line: string) => void lines.push(line) },
+    });
+    const a = matchingCandidate('a');
+    await seed([
+      ...selectedHistory([a]),
+      { type: 'DownloadFailed', candidate: a.identity, reason: 'Stalled' },
+      { type: 'CandidateRejected', candidate: a.identity, files: sampleFiles },
+    ]);
+    await checkpoints.save(REACTOR_CONSUMER, 7);
+    await parked.park({
+      streamId: 'acq-1',
+      globalSeq: 7,
+      attempt: 3,
+      parkedAt: '2026-07-22T10:00:00.000Z',
+      nextRetryAt: '2026-07-22T11:59:00.000Z',
+      lastError: 'fs: denied',
+    });
+    deadLetters.failRecord = true;
+    parked.failPark = true;
+    const discardStaging = vi.fn(() => errAsync(infraError('fs', 'denied')));
+    const r = reactor(stubPorts({ library: { import: vi.fn(), discardStaging } }), {
+      retryPolicy: TIGHT_BUDGET,
+      logger,
+    });
+    await r.start();
+
+    expect(lines.join('')).toContain('could not be re-parked');
+    expect(parked.peek('acq-1')?.nextRetryAt).toBe('2026-07-22T11:59:00.000Z'); // untouched
+    r.stop();
+  });
+
   it('dead-letters an exhausted Search — an empty result would be a fabricated fact', async () => {
     await seed(resolvedHistory()); // ends TargetResolved -> Search effect
     await checkpoints.save(REACTOR_CONSUMER, 1); // only the search dispatch is pending
@@ -802,6 +877,7 @@ describe('Reactor — budget exhaustion lands somewhere modeled (reactor-durabil
     expect(parked.peek('acq-1')).toBeDefined(); // still parked — the landing must not be lost
 
     deadLetters.failRecord = false;
+    clock.advance(TIGHT_BUDGET.maxDelayMs + 1); // the failed landing backed off at the policy cap
     await r.drain();
     expect(parked.count()).toBe(0);
     expect(deadLetters.letters).toHaveLength(1);
@@ -917,6 +993,7 @@ describe('Reactor — budget exhaustion lands somewhere modeled (reactor-durabil
     expect(parked.peek('acq-1')).toBeDefined(); // the modeled landing must not be lost
 
     store.failAppends = false;
+    clock.advance(TIGHT_BUDGET.maxDelayMs + 1); // the failed landing backed off at the policy cap
     await r.drain();
     expect(parked.count()).toBe(0);
     expect(streamEventTypes('acq-1')).toContain('MetadataResolutionFailed');

--- a/packages/downloader/src/application/acquisition/reactor.test.ts
+++ b/packages/downloader/src/application/acquisition/reactor.test.ts
@@ -724,7 +724,11 @@ describe('Reactor — budget exhaustion lands somewhere modeled (reactor-durabil
 
     const entry = parked.peek('acq-1');
     expect(entry).toBeDefined();
-    expect(new Date(entry!.nextRetryAt).getTime()).toBeGreaterThan(clock.now().getTime());
+    // Exactly the policy cap from the fixed clock — "backed off" means at the cap, not merely
+    // any future instant (a 1ms reschedule would also read as later-than-now).
+    expect(entry!.nextRetryAt).toBe(
+      new Date(clock.now().getTime() + TIGHT_BUDGET.maxDelayMs).toISOString(),
+    );
 
     // The very next tick must NOT re-fire the effect: the park is no longer due.
     const fired = discardStaging.mock.calls.length;

--- a/packages/downloader/src/application/acquisition/reactor.ts
+++ b/packages/downloader/src/application/acquisition/reactor.ts
@@ -463,7 +463,31 @@ export class Reactor {
     );
     if (schedule.kind === 'exhausted') {
       const isLanded = await this.lander.land(stored, outcome.effect, outcome.error, attempt);
-      if (isLanded) await this.resumeStream(entry, stream.value);
+      if (isLanded) {
+        await this.resumeStream(entry, stream.value);
+        return;
+      }
+      // The landing itself failed on infrastructure: leaving the past-due park untouched would
+      // re-dispatch the live effect on EVERY tick — unbounded, with no backoff. The budget is
+      // spent, so only the landing is owed; back the park off at the policy cap and let the next
+      // due tick re-attempt it, like every neighbouring infra-failure path reschedules.
+      const heldOver = await this.dependencies.parked.park({
+        ...entry,
+        attempt,
+        nextRetryAt: new Date(now.getTime() + this.policy.maxDelayMs).toISOString(),
+        lastError: describeCommandError(outcome.error),
+      });
+      if (heldOver.isErr()) {
+        this.dependencies.logger.error(
+          { acquisitionId: entry.streamId, err: heldOver.error },
+          'failed landing could not be re-parked; its effect will re-fire next tick',
+        );
+        return;
+      }
+      this.dependencies.logger.error(
+        { acquisitionId: entry.streamId, effect: outcome.effect.type, attempt, err: outcome.error },
+        'exhausted effect could not be landed; parked again at the policy cap',
+      );
       return;
     }
     const rescheduled = await this.dependencies.parked.park({

--- a/packages/downloader/src/application/acquisition/reactor.ts
+++ b/packages/downloader/src/application/acquisition/reactor.ts
@@ -468,9 +468,11 @@ export class Reactor {
         return;
       }
       // The landing itself failed on infrastructure: leaving the past-due park untouched would
-      // re-dispatch the live effect on EVERY tick — unbounded, with no backoff. The budget is
-      // spent, so only the landing is owed; back the park off at the policy cap and let the next
-      // due tick re-attempt it, like every neighbouring infra-failure path reschedules.
+      // re-dispatch the live effect on EVERY tick — unbounded, with no backoff. Back the park
+      // off at the policy cap, like every neighbouring infra-failure path reschedules. The next
+      // due tick re-enters the ordinary dispatch: the live effect re-fires once more
+      // (idempotently — at-least-once is the system-wide delivery contract) and the landing is
+      // re-attempted only if it fails again; the entry carries no landing-only mode.
       const heldOver = await this.dependencies.parked.park({
         ...entry,
         attempt,

--- a/packages/downloader/src/application/logging/logger.test.ts
+++ b/packages/downloader/src/application/logging/logger.test.ts
@@ -82,6 +82,23 @@ describe('createLogger', () => {
     expect(lines[0]).not.toContain('nested-secret-token');
   });
 
+  it('redacts Soulseek peer usernames — third-party PII never reaches the log stream', () => {
+    // The same leak class the contract recorder's scrub closed on the fixture side: peer
+    // usernames are other people's identifiers, logged only as structured fields so this
+    // redaction can catch every site at once.
+    const { stream, lines } = collectingDestination();
+    const logger = createLogger({ destination: stream });
+
+    logger.warn({ username: 'peer-42' }, 'slskd download failed');
+    logger.warn({ transfer: { username: 'peer-42' } }, 'tearing down a transfer');
+
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(line).toContain('[REDACTED]');
+      expect(line).not.toContain('peer-42');
+    }
+  });
+
   it('honours custom redaction paths', () => {
     const { stream, lines } = collectingDestination();
     const logger = createLogger({ destination: stream, redactPaths: ['secretField'] });

--- a/packages/downloader/src/application/logging/logger.ts
+++ b/packages/downloader/src/application/logging/logger.ts
@@ -10,8 +10,11 @@ export type Logger = PinoLogger;
 export const DEFAULT_LOG_LEVEL = 'info';
 
 /**
- * Paths pino redacts so credentials and file contents never reach the log stream (D15).
- * Wildcards match the field at any object depth pino supports.
+ * Paths pino redacts so credentials, file contents, and third-party PII never reach the log
+ * stream (D15). Wildcards match the field at any object depth pino supports. Soulseek peer
+ * usernames are other people's identifiers (the same leak class the contract recorder scrubs
+ * from fixtures) — adapters log them only as structured `username` fields so one path here
+ * covers every site.
  */
 export const DEFAULT_REDACT_PATHS: readonly string[] = [
   'password',
@@ -25,6 +28,8 @@ export const DEFAULT_REDACT_PATHS: readonly string[] = [
   'req.headers.authorization',
   'fileContents',
   '*.fileContents',
+  'username',
+  '*.username',
 ];
 
 export interface CreateLoggerOptions {

--- a/packages/downloader/src/composition/runtime.test.ts
+++ b/packages/downloader/src/composition/runtime.test.ts
@@ -94,8 +94,16 @@ afterEach(async () => {
   cleanups.length = 0;
 });
 
+/** Boot the factory and unwrap: these wiring specs assert the healthy path. */
+async function bootDownloaderRuntime(
+  ...factoryArguments: Parameters<typeof createDownloaderRuntime>
+): Promise<DownloaderRuntime> {
+  const booted = await createDownloaderRuntime(...factoryArguments);
+  return booted._unsafeUnwrap();
+}
+
 async function testRuntime(databaseFile = ':memory:'): Promise<DownloaderRuntime> {
-  const runtime = await createDownloaderRuntime(
+  const runtime = await bootDownloaderRuntime(
     {
       databaseFile,
       libraryRoot: '/library',
@@ -171,7 +179,7 @@ describe('createDownloaderRuntime', () => {
         abort: () => okAsync([]),
       },
     });
-    const runtime = await createDownloaderRuntime(
+    const runtime = await bootDownloaderRuntime(
       {
         databaseFile: ':memory:',
         libraryRoot: '/library',
@@ -203,7 +211,7 @@ describe('createDownloaderRuntime', () => {
     // No acquisitions are submitted, so nothing dispatches — this pins real-adapter construction
     // and executes the stop seam (`slskdDownload.stop()` before the store closes); the latch
     // BEHAVIOR itself is owned by the adapter tier's "stop() latches every watch" test.
-    const runtime = await createDownloaderRuntime(
+    const runtime = await bootDownloaderRuntime(
       {
         databaseFile: ':memory:',
         libraryRoot: '/library',
@@ -256,7 +264,7 @@ describe('createDownloaderRuntime', () => {
   it('stops the connected verdict subscription on stop() so its poll loop cannot outlive the db', async () => {
     vi.useFakeTimers();
     try {
-      const runtime = await createDownloaderRuntime(
+      const runtime = await bootDownloaderRuntime(
         {
           databaseFile: ':memory:',
           libraryRoot: '/library',
@@ -319,7 +327,7 @@ describe('createDownloaderRuntime', () => {
   it('constructs real adapters when no overrides are given', async () => {
     const directory = mkdtempSync(path.join(tmpdir(), 'runtime-'));
     cleanups.push(() => rmSync(directory, { recursive: true, force: true }));
-    const runtime = await createDownloaderRuntime(
+    const runtime = await bootDownloaderRuntime(
       {
         databaseFile: path.join(directory, 'data', 'events.db'),
         libraryRoot: path.join(directory, 'library'),
@@ -367,39 +375,6 @@ describe('createDownloaderRuntime', () => {
     // A pure read of runtime state advances no stream and creates no work.
     expect(runtime.facade.listAcquisitions()).toEqual({ acquisitions: [] });
   });
-
-  it('logs and continues when the projection rebuild cannot read the backlog', async () => {
-    const directory = mkdtempSync(path.join(tmpdir(), 'runtime-'));
-    cleanups.push(() => rmSync(directory, { recursive: true, force: true }));
-    const file = path.join(directory, 'events.db');
-    const seed = openEventDatabase(file);
-    seed
-      .prepare(
-        `INSERT INTO events (stream_id, version, type, schema_version, data, metadata)
-         VALUES ('acq-x', 1, 'Broken', 1, 'not-json', 'also-not-json')`,
-      )
-      .run();
-    seed.close();
-
-    const errors: string[] = [];
-    const logger = createLogger({
-      level: 'error',
-      destination: { write: (line: string) => void errors.push(line) },
-    });
-    const runtime = await createDownloaderRuntime(
-      {
-        databaseFile: file,
-        libraryRoot: '/library',
-        stagingRoot: '/staging',
-        musicbrainz: {},
-        slskd: {},
-      },
-      logger,
-      { ports: fakePorts },
-    );
-    cleanups.push(() => runtime.stop());
-    expect(errors.join('')).toContain('projection rebuild failed');
-  });
 });
 
 describe('stalled exposure at boot (reactor-durability D2)', () => {
@@ -433,7 +408,7 @@ describe('stalled exposure at boot (reactor-durability D2)', () => {
     });
     database.close();
 
-    const runtime = await createDownloaderRuntime(
+    const runtime = await bootDownloaderRuntime(
       {
         databaseFile: file,
         libraryRoot: '/library',
@@ -465,7 +440,7 @@ describe('stalled exposure at boot (reactor-durability D2)', () => {
       level: 'warn',
       destination: { write: (line: string) => void lines.push(line) },
     });
-    const runtime = await createDownloaderRuntime(
+    const runtime = await bootDownloaderRuntime(
       {
         databaseFile: ':memory:',
         libraryRoot: '/library',
@@ -529,7 +504,7 @@ describe('boot readiness (reactor-durability D4)', () => {
     });
 
     // The pending resolution hangs indefinitely; boot must return anyway (backgrounded drain).
-    const runtime = await createDownloaderRuntime(
+    const runtime = await bootDownloaderRuntime(
       {
         databaseFile: file,
         libraryRoot: '/library',
@@ -549,5 +524,43 @@ describe('boot readiness (reactor-durability D4)', () => {
       const status = runtime.facade.getAcquisition({ id: 'acq-hung' });
       expect(status).toMatchObject({ ok: true, value: { status: 'MetadataFailed' } });
     });
+  });
+
+  it('refuses to boot when the projection rebuild cannot read the backlog', async () => {
+    const directory = mkdtempSync(path.join(tmpdir(), 'downloader-runtime-'));
+    cleanups.push(() => rmSync(directory, { recursive: true, force: true }));
+    const file = path.join(directory, 'events.db');
+    const seed = openEventDatabase(file);
+    seed
+      .prepare(
+        `INSERT INTO events (stream_id, version, type, schema_version, data, metadata)
+         VALUES ('acq-x', 1, 'Broken', 1, 'not-json', 'also-not-json')`,
+      )
+      .run();
+    seed.close();
+
+    const errors: string[] = [];
+    const logger = createLogger({
+      level: 'error',
+      destination: { write: (line: string) => void errors.push(line) },
+    });
+    const result = await createDownloaderRuntime(
+      {
+        databaseFile: file,
+        libraryRoot: '/library',
+        stagingRoot: '/staging',
+        musicbrainz: {},
+        slskd: {},
+      },
+      logger,
+      { ports: fakePorts },
+    );
+
+    // A half-rebuilt projection boots half-blind: every acquisition list/detail answers "nothing
+    // exists" while readiness still reads `up` — an infra fault masquerading as a business answer.
+    // Mirror the importer's contract: never boot on a projection we could not fully rebuild.
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr().kind).toBe('ProjectionRebuildFailed');
+    expect(errors.join('')).toContain('projection rebuild failed');
   });
 });

--- a/packages/downloader/src/composition/runtime.ts
+++ b/packages/downloader/src/composition/runtime.ts
@@ -53,6 +53,11 @@ import { verdictEventConsumer } from '../interfaces/events/verdict-consumer.js';
 import { createDownloaderFacade } from '../facade/index.js';
 import type { DownloaderFacade } from '../facade/index.js';
 
+// The module's log-redaction defaults, exposed on the runtime surface: the composed process
+// constructs the ONE pino root both runtimes share, so redaction must be composed there — a
+// module-internal default the composition root cannot see would never apply to a shipped line.
+export { DEFAULT_REDACT_PATHS } from '../application/logging/logger.js';
+
 /**
  * The downloader module's runtime factory (merge-modular-monolith D8): everything the module runs
  * in a composed process — store, bus, projections, reactor, sweep — behind one constructor, with

--- a/packages/downloader/src/composition/runtime.ts
+++ b/packages/downloader/src/composition/runtime.ts
@@ -16,6 +16,7 @@ import {
   SqliteResourceLedger,
   buildUpcasterRegistry,
   fetchHttpClient,
+  nodeCommandRunner,
   openEventDatabase,
   realTimer,
 } from '../adapters/index.js';
@@ -65,6 +66,8 @@ export interface DownloaderRuntimeConfig {
   readonly stagingRoot: string;
   readonly musicbrainz: { readonly baseUrl?: string; readonly userAgent?: string };
   readonly slskd: { readonly baseUrl?: string; readonly apiKey?: string };
+  /** Probe/decode kill budget (per file); unset falls back to the adapter's generous default. */
+  readonly ffmpeg?: { readonly timeoutMs?: number };
   /** Parked-effect retry tuning (reactor-durability D2); defaults are production-sane. */
   readonly reactor?: {
     readonly retry?: Partial<RetryPolicy>;
@@ -197,7 +200,9 @@ export async function createDownloaderRuntime(
       }),
       search: new SlskdSearch(logger, ledger, slskdClient, realTimer),
       download: slskdDownload,
-      probe: new FfmpegAudioProbe(logger),
+      probe: new FfmpegAudioProbe(logger, nodeCommandRunner, {
+        timeoutMs: config.ffmpeg?.timeoutMs,
+      }),
       library: new FilesystemLibrary(
         { libraryRoot: config.libraryRoot, stagingRoot: config.stagingRoot },
         logger,

--- a/packages/downloader/src/composition/runtime.ts
+++ b/packages/downloader/src/composition/runtime.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto';
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
+import { err, ok } from 'neverthrow';
+import type { Result } from 'neverthrow';
 import {
   FfmpegAudioProbe,
   FilesystemLibrary,
@@ -105,6 +107,15 @@ export interface DownloaderReadiness {
   readonly status: 'up' | 'down';
 }
 
+/**
+ * Startup failures are values (mirroring the importer's factory): a runtime that cannot fully
+ * rebuild its projections must refuse to boot, not serve empty answers with readiness `up`.
+ */
+export type DownloaderStartupError = {
+  readonly kind: 'ProjectionRebuildFailed';
+  readonly detail: string;
+};
+
 export interface DownloaderRuntime {
   readonly facade: DownloaderFacade;
   /** This module's outbound seam surface, consumed by the importer's subscription. */
@@ -121,7 +132,7 @@ export async function createDownloaderRuntime(
   config: DownloaderRuntimeConfig,
   logger: Logger,
   overrides: DownloaderRuntimeOverrides = {},
-): Promise<DownloaderRuntime> {
+): Promise<Result<DownloaderRuntime, DownloaderStartupError>> {
   const clock = overrides.clock ?? { now: () => new Date() };
   const ids = overrides.ids ?? { next: () => randomUUID() };
 
@@ -144,12 +155,18 @@ export async function createDownloaderRuntime(
   await seedStalledReadModel(deadLetters, stalledModel, REACTOR_CONSUMER, horizon, logger);
 
   const backlog = await store.readAll(0);
-  if (backlog.isOk()) {
-    status.rebuild(backlog.value);
-    for (const stored of backlog.value) libraryView.apply(stored);
-  } else {
-    logger.error({ err: backlog.error }, 'projection rebuild failed');
+  if (backlog.isErr()) {
+    // A projection rebuilt from a failed read boots half-blind: every acquisition list/detail
+    // answers "nothing exists" and the library dedup view is empty, all while readiness still
+    // reads `up` — an infra fault masquerading as a business answer. Fail the boot loudly,
+    // exactly as the importer's factory does — never boot on a projection we could not fully
+    // rebuild.
+    logger.error({ err: backlog.error }, 'projection rebuild failed; refusing to boot');
+    database.close();
+    return err({ kind: 'ProjectionRebuildFailed', detail: backlog.error.message });
   }
+  status.rebuild(backlog.value);
+  for (const stored of backlog.value) libraryView.apply(stored);
   // These two read models are kept live by the bus alone: boot-rebuilt from `readAll(0)` above,
   // then followed forward here with NO catch-up cursor of their own. The event bus now isolates
   // each handler in its own try/catch, so a throw from an `apply` is swallowed and logged rather
@@ -266,7 +283,7 @@ export async function createDownloaderRuntime(
   // halted-on-poison state is this module's one exposed "down" signal (design D4).
   let verdicts: CatchUpSubscription | undefined;
 
-  return {
+  return ok({
     facade,
     feed,
     wakeups,
@@ -305,5 +322,5 @@ export async function createDownloaderRuntime(
       database.close();
       return Promise.resolve();
     },
-  };
+  });
 }

--- a/packages/importer/src/adapters/beets/bridge-adapter.test.ts
+++ b/packages/importer/src/adapters/beets/bridge-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { silentLogger } from '../../application/__fixtures__/fakes.js';
+import { createLogger } from '../../application/logging/logger.js';
 import type { ApplyMode, ManualTags } from '../../domain/import/events.js';
 import { toPositiveInt } from '../../domain/shared/positive-int.js';
 import { BeetsBridge, defaultBridgeScript } from './bridge-adapter.js';
@@ -340,6 +341,39 @@ describe('failure surfaces', () => {
     const proposeResult6 = await bridge(runner).propose('/intake/a', {});
     const error = proposeResult6._unsafeUnwrapErr();
     expect(error.message).toContain('by signal');
+  });
+
+  it('surfaces stderr from a successful run as a warn line, never a swallowed string', async () => {
+    // The bridge reports partial degradation (e.g. "collect: skipped 3 unreadable file(s)") on
+    // stderr while still exiting 0 with a proposal built on the readable subset. The non-zero
+    // path already carries stderr in its error; this is the ONLY channel for the success path —
+    // dropping it makes the degradation invisible to the operator.
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: 'warn',
+      destination: { write: (line: string) => void lines.push(line) },
+    });
+    const runner = runnerReturning(
+      completed(PROPOSAL_JSON, { stderr: 'collect: skipped 3 unreadable file(s)\n' }),
+    );
+    const proposeOk = await new BeetsBridge(logger, CONFIG, runner).propose('/intake/a', {});
+    expect(proposeOk.isOk()).toBe(true);
+    const joined = lines.join('');
+    expect(joined).toContain('bridge reported diagnostics on a successful run');
+    expect(joined).toContain('skipped 3 unreadable');
+    expect(joined).toContain('propose');
+  });
+
+  it('stays quiet when a successful run writes nothing to stderr', async () => {
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: 'warn',
+      destination: { write: (line: string) => void lines.push(line) },
+    });
+    const runner = runnerReturning(completed(PROPOSAL_JSON));
+    const proposeQuiet = await new BeetsBridge(logger, CONFIG, runner).propose('/intake/a', {});
+    expect(proposeQuiet.isOk()).toBe(true);
+    expect(lines).toHaveLength(0);
   });
 
   it('maps non-JSON output to an InfraError', async () => {

--- a/packages/importer/src/adapters/beets/bridge-adapter.ts
+++ b/packages/importer/src/adapters/beets/bridge-adapter.ts
@@ -207,6 +207,15 @@ export class BeetsBridge implements TaggerPort {
         ),
       );
     }
+    if (result.stderr.trim() !== '') {
+      // A zero exit with stderr is the bridge reporting partial degradation (e.g. files skipped
+      // as unreadable) — stderr is that report's only channel on the success path, so it is
+      // logged here, never dropped: the operator's alternative is an unexplained thin proposal.
+      this.logger.warn(
+        { operation, stderr: result.stderr.slice(-2000) },
+        'bridge reported diagnostics on a successful run',
+      );
+    }
     let payload: unknown;
     try {
       payload = JSON.parse(result.stdout);

--- a/packages/importer/src/adapters/beets/bridge/bridge.py
+++ b/packages/importer/src/adapters/beets/bridge/bridge.py
@@ -143,6 +143,7 @@ def collect_items(directory):
     if not os.path.isdir(directory):
         raise BridgeRefusal("directory-not-found", f"not a directory: {directory}")
     items = []
+    skipped = 0
     for root, _dirs, files in os.walk(directory):
         for name in sorted(files):
             path = os.path.join(root, name)
@@ -154,7 +155,13 @@ def collect_items(directory):
                 # dropping a file that beets could have read once the fault clears.
                 raise
             except Exception:
+                skipped += 1
                 continue  # not an audio file beets can read (unreadable/unsupported format)
+    if skipped:
+        # Skipping is by design (album folders carry covers and logs), but the COUNT must be
+        # visible: a proposal built on 9 of 12 tracks otherwise reads as silent corruption. The
+        # diagnostic stream only — the stdout JSON contract is unchanged.
+        print(f"collect: skipped {skipped} unreadable file(s) under {directory}", file=sys.stderr)
     if not items:
         raise BridgeRefusal("no-audio-files", f"no readable audio files under: {directory}")
     return items

--- a/packages/importer/src/adapters/beets/runner.test.ts
+++ b/packages/importer/src/adapters/beets/runner.test.ts
@@ -21,6 +21,19 @@ describe('nodeCommandRunner', () => {
     expect(result.code).toBeNull();
   });
 
+  it('decodes multi-byte UTF-8 split across chunk boundaries intact', async () => {
+    // A per-chunk `Buffer#toString` corrupts a code point whose bytes straddle two chunks — the
+    // bridge's stdout is JSON.parsed, so a split non-ASCII artist name would read as a crash.
+    const script =
+      "const b = Buffer.from('✓', 'utf8');" +
+      'process.stdout.write(b.subarray(0, 2));' +
+      'setTimeout(() => { process.stdout.write(b.subarray(2)); }, 20);';
+
+    const result = await nodeCommandRunner.run(process.execPath, ['-e', script], 5000);
+
+    expect(result.stdout).toBe('✓');
+  });
+
   it('rejects when the binary cannot be spawned at all', async () => {
     await expect(nodeCommandRunner.run('/nonexistent/interpreter', [], 1000)).rejects.toMatchObject(
       { code: 'ENOENT' },

--- a/packages/importer/src/adapters/beets/runner.ts
+++ b/packages/importer/src/adapters/beets/runner.ts
@@ -29,8 +29,13 @@ export const nodeCommandRunner: CommandRunner = {
         isTimedOut = true;
         child.kill('SIGKILL');
       }, timeoutMs);
-      child.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()));
-      child.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()));
+      // Decode the stream, not the chunks: a multi-byte code point split across two chunks
+      // corrupts under a per-chunk `Buffer#toString` — and this stdout is `JSON.parse`d, so a
+      // split non-ASCII artist name would read back as a bridge crash.
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', (chunk: string) => (stdout += chunk));
+      child.stderr.on('data', (chunk: string) => (stderr += chunk));
       child.on('error', (cause) => {
         clearTimeout(timer);
         reject(cause);

--- a/packages/importer/src/application/events/catch-up-subscription.test.ts
+++ b/packages/importer/src/application/events/catch-up-subscription.test.ts
@@ -2,6 +2,7 @@ import { err, ok } from 'neverthrow';
 import type { Result } from 'neverthrow';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FakeCheckpointStore, FakeDeadLetterStore, silentLogger } from '../__fixtures__/fakes.js';
+import { createLogger } from '../logging/logger.js';
 import { infraError } from '../ports/errors.js';
 import { CatchUpSubscription } from './catch-up-subscription.js';
 import type {
@@ -382,6 +383,42 @@ describe('CatchUpSubscription', () => {
 
     expect(wakeListeners).toHaveLength(0);
     expect(intervals[0]!.stopped).toBe(true);
+  });
+
+  it('catches and logs an unexpected throw from a fire-and-forget poll, surviving the cycle', async () => {
+    // A defective feed/handler that THROWS (rather than returning a modeled failure) is a bug; a
+    // wakeup- or timer-driven poll must not let it escape as an unhandled process rejection — in
+    // the composed monolith that rejection would terminate the one process serving the web UI and
+    // both modules. It is caught at the boundary, logged, and the loop lives on.
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: 'error',
+      destination: { write: (line: string) => void lines.push(line) },
+    });
+    let isBoom = false;
+    const throwingFeed = {
+      read: (from: number, limit: number) => {
+        if (isBoom) throw new Error('feed adapter bug');
+        return feed.read(from, limit);
+      },
+    };
+    const sub = subscription({ feed: throwingFeed, logger });
+    await sub.start(); // the initial (awaited) poll drains cleanly
+
+    isBoom = true;
+    for (const listener of wakeListeners) {
+      listener(); // fires the fire-and-forget poll under the hood — the throw must be contained
+    }
+    await vi.waitFor(() => {
+      expect(lines.join('')).toContain('seam subscription poll failed unexpectedly');
+    });
+
+    // The subscription survived: a later healthy poll still delivers.
+    isBoom = false;
+    feed.events = [seamEvent(1)];
+    await sub.poll();
+    expect(handled).toEqual([1]);
+    sub.stop();
   });
 
   it('uses a real interval by default and stops it cleanly', async () => {

--- a/packages/importer/src/application/events/catch-up-subscription.ts
+++ b/packages/importer/src/application/events/catch-up-subscription.ts
@@ -107,11 +107,26 @@ export class CatchUpSubscription {
     this.cursor = checkpoint.unwrapOr(0);
     await this.poll();
     this.stopWakeups = this.dependencies.wakeups?.subscribe(() => {
-      void this.poll();
+      this.schedulePoll();
     });
     this.stopInterval = (this.dependencies.interval ?? defaultInterval)(() => {
-      void this.poll();
+      this.schedulePoll();
     }, this.dependencies.pollIntervalMs);
+  }
+
+  /**
+   * Fire-and-forget a poll from a wakeup or the fallback timer. `poll` handles modeled failures as
+   * values; an actual throw (a defect in the feed or handler) is a bug, caught and logged here so a
+   * lone bad cycle can never surface as an unhandled process rejection — in the composed monolith
+   * that rejection would take down the one process serving both modules and the web UI.
+   */
+  private schedulePoll(): void {
+    void this.poll().catch((error: unknown) => {
+      this.dependencies.logger.error(
+        { subscription: this.dependencies.name, err: error },
+        'seam subscription poll failed unexpectedly',
+      );
+    });
   }
 
   stop(): void {

--- a/packages/importer/src/application/import/reactor.test.ts
+++ b/packages/importer/src/application/import/reactor.test.ts
@@ -1,5 +1,6 @@
-import { errAsync, okAsync } from 'neverthrow';
+import { ResultAsync, errAsync, okAsync } from 'neverthrow';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Import } from '../../domain/import/import.js';
 import {
   DIRECTORY,
   POLICY,
@@ -9,6 +10,9 @@ import {
 import { asDistance } from '../../domain/shared/__fixtures__/distance.js';
 import type { ImportEvent } from '../../domain/import/events.js';
 import { infraError } from '../ports/errors.js';
+import type { CheckpointStore } from '../ports/event-store-port.js';
+import { createLogger } from '../logging/logger.js';
+import type { Logger } from '../logging/logger.js';
 import {
   FakeCheckpointStore,
   FakeDeadLetterStore,
@@ -53,6 +57,7 @@ function reactor(
   overrides: {
     interval?: (function_: () => void, ms: number) => () => void;
     retryBudget?: number;
+    logger?: Logger;
   } = {},
 ): Reactor {
   return new Reactor({
@@ -63,7 +68,7 @@ function reactor(
     parked,
     stalled,
     clock: fixedClock(),
-    logger: silentLogger(),
+    logger: overrides.logger ?? silentLogger(),
     interpret,
     // Tests drive drains explicitly; the default real interval is covered by its own test below.
     interval: overrides.interval ?? (() => () => {}),
@@ -562,5 +567,129 @@ describe('Reactor — durable retry budget & stalled exposure', () => {
 
     expect(stalled.isStalled('imp-1')).toBe(true); // stays marked — the letters still exist
     expect(checkpoints.peek(REACTOR_CONSUMER)).toBe(1); // but the stream still advances
+  });
+});
+
+describe('Reactor — defect containment', () => {
+  it('catches and logs an unexpected throw from a fire-and-forget drain, surviving the pass', async () => {
+    // Failures inside a pass are values (neverthrow) — an actual throw (a defect in an interpreter
+    // closure, or a corrupt event breaking the fold) is a bug. A wakeup-driven `void this.drain()`
+    // must contain it: in the composed monolith an unhandled rejection from this durable loop
+    // would terminate the one process serving the web UI and both modules.
+    const lines: string[] = [];
+    const logger = createLogger({
+      level: 'error',
+      destination: { write: (line: string) => void lines.push(line) },
+    });
+    let isBoom = true;
+    const interpret: EffectInterpreter = (_importId, _effect) => {
+      if (isBoom) throw new Error('interpreter defect');
+      return okAsync([]);
+    };
+    const r = reactor(interpret, { logger });
+    await r.start(); // empty log: the startup drain is clean
+
+    // A live append publishes on the bus, so this wakeup alone fires the throwing drain.
+    await store.append('imp-1', 0, [requested()], { importId: 'imp-1', occurredAt: 't' });
+    await vi.waitFor(() => {
+      expect(lines.join('')).toContain('reactor pass failed unexpectedly');
+    });
+    expect(checkpoints.peek(REACTOR_CONSUMER)).toBeUndefined(); // held: nothing was settled
+
+    // The reactor survived: a later healthy pass drains the same backlog.
+    isBoom = false;
+    await r.drain();
+    expect(checkpoints.peek(REACTOR_CONSUMER)).toBe(1);
+    r.stop();
+  });
+
+  it('does not attach the live loop when stop() lands during the startup checkpoint load', async () => {
+    await seed([requested()]);
+    const interpret = vi.fn(() => okAsync([]));
+    const { promise: gate, resolve: releaseLoad } = Promise.withResolvers<void>();
+    const gated: CheckpointStore = {
+      load: (name) => ResultAsync.fromSafePromise(gate).andThen(() => checkpoints.load(name)),
+      save: (name, globalSeq) => checkpoints.save(name, globalSeq),
+    };
+    const intervals: (() => void)[] = [];
+    const r = new Reactor({
+      store,
+      checkpoints: gated,
+      bus,
+      deadLetters,
+      parked,
+      stalled,
+      clock: fixedClock(),
+      logger: silentLogger(),
+      interpret,
+      interval: (function_) => {
+        intervals.push(function_);
+        return () => {};
+      },
+    });
+
+    const started = r.start();
+    r.stop(); // a backgrounded boot torn down before the checkpoint read resolves
+    releaseLoad();
+    await started;
+
+    // Nothing attached and nothing drained: no subscription, no fallback poll, no dispatch.
+    expect(bus.subscriberCount()).toBe(0);
+    expect(intervals).toHaveLength(0);
+    expect(interpret).not.toHaveBeenCalled();
+  });
+});
+
+describe('Reactor — sibling effects of one event', () => {
+  // The real `react()` currently yields at most one effect per event, so the multi-effect protocol
+  // is pinned with a widened double on a genuine aggregate: the loop's contract — each sibling
+  // settles independently — must already hold when a future reaction yields more than one.
+  function twoEffectAggregate(): void {
+    const aggregate = Import.fromHistory([requested()]);
+    vi.spyOn(aggregate, 'reactTo').mockReturnValue([
+      { type: 'Propose', directory: DIRECTORY },
+      { type: 'DeleteIntake', directory: DIRECTORY },
+    ]);
+    vi.spyOn(Import, 'fromHistory').mockReturnValue(aggregate);
+  }
+
+  it('a stale rejection of one sibling does not silently drop the effects behind it', async () => {
+    await seed([requested()]);
+    twoEffectAggregate();
+    const interpret = vi
+      .fn<EffectInterpreter>()
+      .mockReturnValueOnce(errAsync({ kind: 'NoOpenReview' }))
+      .mockReturnValue(okAsync([]));
+
+    await reactor(interpret).start();
+
+    // Both siblings were interpreted — the settled rejection of the first is not a verdict on the
+    // second — and the event as a whole advances.
+    expect(interpret).toHaveBeenCalledTimes(2);
+    expect(interpret).toHaveBeenLastCalledWith(
+      'imp-1',
+      expect.objectContaining({ type: 'DeleteIntake' }),
+    );
+    expect(checkpoints.peek(REACTOR_CONSUMER)).toBe(1);
+  });
+
+  it('a dead-lettered sibling settles alone: the effects behind it still dispatch', async () => {
+    await seed([requested()]);
+    twoEffectAggregate();
+    const interpret = vi
+      .fn<EffectInterpreter>()
+      .mockReturnValueOnce(errAsync(infraError('bridge.propose', 'beets always fails')))
+      .mockReturnValue(okAsync([]));
+
+    await reactor(interpret, { retryBudget: 1 }).start(); // budget 1: first sibling dead-letters now
+
+    expect(interpret).toHaveBeenCalledTimes(2);
+    expect(interpret).toHaveBeenLastCalledWith(
+      'imp-1',
+      expect.objectContaining({ type: 'DeleteIntake' }),
+    );
+    expect(deadLetters.letters).toHaveLength(1);
+    expect(stalled.isStalled('imp-1')).toBe(true);
+    expect(checkpoints.peek(REACTOR_CONSUMER)).toBe(1);
   });
 });

--- a/packages/importer/src/application/import/reactor.test.ts
+++ b/packages/importer/src/application/import/reactor.test.ts
@@ -38,6 +38,9 @@ let parked: FakeParkedEffectStore;
 let stalled: StalledReadModel;
 
 beforeEach(() => {
+  // The sibling-effect suite stubs the STATIC `Import.fromHistory` — without a restore, that
+  // module-level mock would leak into every test that runs after it in this file.
+  vi.restoreAllMocks();
   store = new FakeEventStore();
   checkpoints = new FakeCheckpointStore();
   bus = new FakeEventBus();
@@ -644,6 +647,10 @@ describe('Reactor — sibling effects of one event', () => {
   // The real `react()` currently yields at most one effect per event, so the multi-effect protocol
   // is pinned with a widened double on a genuine aggregate: the loop's contract — each sibling
   // settles independently — must already hold when a future reaction yields more than one.
+  // (The domain stub is the design feedback here: the settlement loop has no seam of its own yet.
+  // Known latent interaction, unpinned until a real two-effect reaction exists: the durable retry
+  // tally is keyed per globalSeq, so siblings SHARE one budget — a sibling dead-lettering on a
+  // spent tally leaves the next sibling's first retryable failure reading the same spent count.)
   function twoEffectAggregate(): void {
     const aggregate = Import.fromHistory([requested()]);
     vi.spyOn(aggregate, 'reactTo').mockReturnValue([

--- a/packages/importer/src/application/import/reactor.ts
+++ b/packages/importer/src/application/import/reactor.ts
@@ -107,6 +107,7 @@ export class Reactor {
   private stopInterval: (() => void) | undefined;
   private running = false;
   private pending = false;
+  private stopped = false;
 
   constructor(private readonly dependencies: ReactorDependencies) {}
 
@@ -124,6 +125,7 @@ export class Reactor {
    */
   async start(): Promise<void> {
     const checkpoint = await this.dependencies.checkpoints.load(REACTOR_CONSUMER);
+    if (this.stopped) return; // stopped while loading (a backgrounded boot torn down early)
     if (checkpoint.isErr()) {
       // Replaying from the log start is safe (idempotent effects + decide's stale guards) but noisy
       // and slow — the operator must be able to tell it apart from a genuinely fresh consumer.
@@ -145,6 +147,7 @@ export class Reactor {
   }
 
   stop(): void {
+    this.stopped = true;
     this.unsubscribe?.();
     this.unsubscribe = undefined;
     this.stopInterval?.();
@@ -175,6 +178,14 @@ export class Reactor {
           }
         }
       } while (this.pending);
+    } catch (error: unknown) {
+      // Failures inside a pass are values (neverthrow) — an actual throw (a defect in an
+      // interpreter closure, or a corrupt event breaking the fold) is a bug. It is contained here
+      // so a wakeup-driven `void this.drain()` can never surface as an unhandled process rejection
+      // from the durable reactor — in the composed monolith that rejection would terminate the one
+      // process serving both modules and the web UI. The checkpoint is untouched, so the pass
+      // simply redelivers on the next wakeup or fallback poll.
+      this.dependencies.logger.error({ err: error }, 'reactor pass failed unexpectedly');
     } finally {
       this.running = false;
     }
@@ -208,16 +219,19 @@ export class Reactor {
       if (result.isErr()) {
         if (isRetryable(result.error)) {
           if (!(await this.handleRetryable(stored, effect.type, result.error))) return; // held
-          isDeadLettered = true; // budget spent: dead-lettered — fall through to advance past it
-          break;
+          // Budget spent: this sibling is dead-lettered — a settled outcome, not a verdict on the
+          // effects behind it, which still dispatch before the event advances.
+          isDeadLettered = true;
+          continue;
         }
-        // Stale/illegal outcome — the stream has already settled it. Record and advance past
-        // it; retrying would only re-fire the same rejection forever.
+        // Stale/illegal outcome — the stream has already settled this sibling; retrying would only
+        // re-fire the same rejection forever. Record it and carry on: dropping the effects behind
+        // it would silently lose work the event still owes.
         this.dependencies.logger.warn(
           { importId: stored.streamId, effect: effect.type, err: result.error },
-          'effect follow-on rejected as stale; advancing past it',
+          'effect follow-on rejected as stale; continuing past it',
         );
-        break;
+        continue;
       }
       this.dependencies.logger.debug(
         { importId: stored.streamId, effect: effect.type },

--- a/packages/importer/src/composition/runtime.ts
+++ b/packages/importer/src/composition/runtime.ts
@@ -32,6 +32,11 @@ import { intakeEventConsumer } from '../interfaces/events/intake-consumer.js';
 import { createImporterFacade } from '../facade/index.js';
 import type { ImporterFacade } from '../facade/index.js';
 
+// The module's log-redaction defaults, exposed on the runtime surface: the composed process
+// constructs the ONE pino root both runtimes share, so redaction must be composed there — a
+// module-internal default the composition root cannot see would never apply to a shipped line.
+export { DEFAULT_REDACT_PATHS } from '../application/logging/logger.js';
+
 /**
  * The importer module's runtime factory (merge-modular-monolith D8): everything the module runs
  * in a composed process — store, bus, projection, reactor, the validated beets bridge — behind

--- a/packages/importer/test/bridge/test_bridge.py
+++ b/packages/importer/test/bridge/test_bridge.py
@@ -13,6 +13,8 @@ A regression that reordered those handlers or widened the bare `except` would si
 beets could have read once the fault cleared — the exact class of bug this bridge change fixed.
 """
 
+import contextlib
+import io
 import os
 import sys
 import tempfile
@@ -84,6 +86,26 @@ class CollectItemsTest(unittest.TestCase):
         sentinel = object()
         _install_fake_beets(lambda _path: sentinel)
         self.assertEqual(bridge.collect_items(self._dir.name), [sentinel])
+
+    def test_skipped_unreadable_files_are_counted_on_stderr(self):
+        """A partially unreadable directory proposes on what it can read, but says how much it
+        dropped: a proposal built on 9 of 12 tracks otherwise reads as silent corruption, hinted
+        at only by an indirect missing-tracks penalty. The count goes to the diagnostic stream —
+        the stdout JSON contract is unchanged."""
+        with open(os.path.join(self._dir.name, "cover.jpg"), "wb") as handle:
+            handle.write(b"\0")
+
+        def read_only_flac(path):
+            if os.fsdecode(path).endswith(".flac"):
+                return "item"
+            raise ValueError("not an audio file beets can read")
+
+        _install_fake_beets(read_only_flac)
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            items = bridge.collect_items(self._dir.name)
+        self.assertEqual(items, ["item"])
+        self.assertIn("skipped 1", stderr.getvalue())
 
     def test_a_missing_directory_is_refused(self):
         """A path that is not a directory is a modeled refusal, before any file is read."""

--- a/packages/web/src/lib/server/config.test.ts
+++ b/packages/web/src/lib/server/config.test.ts
@@ -18,6 +18,7 @@ describe('loadComposedConfig', () => {
     expect(config.downloader.stagingRoot).toBe('/staging');
     expect(config.importer.intakeRoot).toBe('/intake');
     expect(config.importer.bridgeTimeoutMs).toBe(600_000);
+    expect(config.downloader.ffmpeg).toEqual({ timeoutMs: 120_000 });
     expect(config.importer.autoApplyThreshold).toBe(0.04);
     expect(config.logLevel).toBe('info');
   });
@@ -65,9 +66,11 @@ describe('loadComposedConfig', () => {
       BRIDGE_PYTHON: '/venv/bin/python',
       BRIDGE_SCRIPT: '/app/bridge.py',
       BRIDGE_TIMEOUT_MS: '1000',
+      FFMPEG_TIMEOUT_MS: '30000',
       AUTO_APPLY_THRESHOLD: '0.1',
     })._unsafeUnwrap();
     expect(config.downloader.slskd).toEqual({ baseUrl: 'http://slskd:5030', apiKey: 'key' });
+    expect(config.downloader.ffmpeg).toEqual({ timeoutMs: 30_000 });
     expect(config.downloader.musicbrainz).toEqual({ baseUrl: 'http://mb', userAgent: 'ua' });
     expect(config.downloader.databaseFile).toBe('/data/d.db');
     expect(config.importer.databaseFile).toBe('/data/i.db');

--- a/packages/web/src/lib/server/config.ts
+++ b/packages/web/src/lib/server/config.ts
@@ -29,6 +29,8 @@ const environmentSchema = z.object({
   REACTOR_RETRY_MAX_DELAY_MS: z.coerce.number().int().positive().optional(),
   REACTOR_RETRY_BUDGET_MS: z.coerce.number().int().nonnegative().optional(),
   REACTOR_STALLED_RETENTION_MS: z.coerce.number().int().positive().optional(),
+  /** Per-file kill budget for the ffprobe/decode passes — a hung run must never wedge dispatch. */
+  FFMPEG_TIMEOUT_MS: z.coerce.number().int().positive().default(120_000),
 
   // --- importer --------------------------------------------------------------------------------
   IMPORTER_DATABASE_FILE: z.string().min(1).default('data/importer/events.db'),
@@ -100,6 +102,7 @@ export function loadComposedConfig(
       stagingRoot: v.STAGING_ROOT,
       musicbrainz: { baseUrl: v.MUSICBRAINZ_BASE_URL, userAgent: v.MUSICBRAINZ_USER_AGENT },
       slskd: { baseUrl: v.SLSKD_BASE_URL, apiKey: v.SLSKD_API_KEY },
+      ffmpeg: { timeoutMs: v.FFMPEG_TIMEOUT_MS },
       reactor: {
         retry: {
           ...(v.REACTOR_RETRY_INITIAL_DELAY_MS !== undefined && {

--- a/packages/web/src/lib/server/logger.test.ts
+++ b/packages/web/src/lib/server/logger.test.ts
@@ -6,4 +6,26 @@ describe('createLogger', () => {
     const logger = createLogger('silent');
     expect(logger.level).toBe('silent');
   });
+
+  it('redacts both modules’ credential and PII paths from the composed root', () => {
+    // This is the ONLY logger production constructs — the module runtimes receive this root, so
+    // their own createLogger defaults never apply to a shipped line. A root without the composed
+    // redaction union ships credentials and peer usernames verbatim; this test goes through the
+    // production logger, not a module-tier one.
+    const lines: string[] = [];
+    const logger = createLogger('info', { write: (line: string) => void lines.push(line) });
+
+    logger.info(
+      { username: 'peer-42', slskd: { apiKey: 'sk-secret' }, fileContents: 'blob' },
+      'composed line',
+    );
+    logger.warn({ transfer: { username: 'peer-42' } }, 'nested peer field');
+
+    expect(lines).toHaveLength(2);
+    const joined = lines.join('');
+    expect(joined).toContain('[REDACTED]');
+    expect(joined).not.toContain('peer-42');
+    expect(joined).not.toContain('sk-secret');
+    expect(joined).not.toContain('blob');
+  });
 });

--- a/packages/web/src/lib/server/logger.ts
+++ b/packages/web/src/lib/server/logger.ts
@@ -1,7 +1,16 @@
 import { pino } from 'pino';
-import type { Logger } from 'pino';
+import type { DestinationStream, Logger } from 'pino';
+import { DEFAULT_REDACT_PATHS as DOWNLOADER_REDACT_PATHS } from '@music/downloader/runtime';
+import { DEFAULT_REDACT_PATHS as IMPORTER_REDACT_PATHS } from '@music/importer/runtime';
 
-/** The composed process's structured logger — one pino root shared by both module runtimes. */
-export function createLogger(level: string): Logger {
-  return pino({ level });
+/**
+ * The composed process's structured logger — one pino root shared by both module runtimes. It is
+ * the ONLY logger production constructs (each module's own `createLogger` exists for its test
+ * tiers), so the modules' redaction defaults MUST be composed here: a root without the union
+ * would ship every line unredacted — credentials, peer usernames, file contents.
+ */
+export function createLogger(level: string, destination?: DestinationStream): Logger {
+  const paths = [...new Set([...DOWNLOADER_REDACT_PATHS, ...IMPORTER_REDACT_PATHS])];
+  const options = { level, redact: { paths, censor: '[REDACTED]' } };
+  return destination ? pino(options, destination) : pino(options);
 }

--- a/packages/web/src/lib/server/runtime.test.ts
+++ b/packages/web/src/lib/server/runtime.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { err, ok } from 'neverthrow';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { DownloaderRuntime } from '@music/downloader/runtime';
+import type { createDownloaderRuntime, DownloaderRuntime } from '@music/downloader/runtime';
 import type { createImporterRuntime, ImporterRuntime } from '@music/importer/runtime';
 import { PlexTvAccess } from './plex/adapter.js';
 import {
@@ -53,6 +53,7 @@ function fakeSubscription(log: string[], name: string) {
 function fakeRuntimes(
   log: string[],
   statuses: { downloader?: 'up' | 'down'; importer?: 'up' | 'down' } = {},
+  failures: { acquisitionsStart?: boolean } = {},
 ) {
   // Each seam must be wired to the OTHER module's feed and wakeups; capturing what each connect call
   // received lets a test catch a cross-wiring (e.g. handing the verdict seam the downloader's own
@@ -83,7 +84,14 @@ function fakeRuntimes(
     connectAcquisitionFeed: (feed: unknown, options: { sourceRoot: string }, wakeups: unknown) => {
       log.push(`acquisitions:connect:${options.sourceRoot}`);
       captured.acquisition = { feed, wakeups };
-      return fakeSubscription(log, 'acquisitions');
+      return failures.acquisitionsStart
+        ? {
+            start: () => Promise.reject(new Error('subscription start defect')),
+            stop: () => {
+              log.push('acquisitions:stop');
+            },
+          }
+        : fakeSubscription(log, 'acquisitions');
     },
     readiness: () => ({ status: statuses.importer ?? 'up' }),
     stop: () => {
@@ -97,7 +105,7 @@ function fakeRuntimes(
     captured,
     createDownloader: vi.fn(() => {
       log.push('downloader:create');
-      return Promise.resolve(downloader);
+      return Promise.resolve(ok(downloader));
     }),
     createImporter: vi.fn(() => {
       log.push('importer:create');
@@ -198,6 +206,64 @@ describe('bootRuntimes', () => {
       }),
     ).rejects.toThrow(/bad yaml/);
     expect(log).toContain('downloader:stop');
+  });
+
+  it('fails when the downloader cannot start, before the importer ever boots', async () => {
+    const log: string[] = [];
+    const fakes = fakeRuntimes(log);
+    const failingDownloader = vi.fn((() =>
+      Promise.resolve(
+        err({ kind: 'ProjectionRebuildFailed', detail: 'backlog unreadable' }),
+      )) as unknown as typeof createDownloaderRuntime);
+
+    await expect(
+      bootRuntimes(VALID_ENV, {
+        createDownloader: failingDownloader,
+        createImporter: fakes.createImporter,
+        onShutdownSignal: vi.fn(),
+      }),
+    ).rejects.toThrow(/downloader startup failed: backlog unreadable/);
+    expect(log).not.toContain('importer:create'); // nothing else booted, nothing to stop
+  });
+
+  it('tears both runtimes down when a seam subscription fails to start', async () => {
+    // A subscription whose start() THROWS (a defect, not a modeled failure) must not strand two
+    // booted runtimes with live pollers behind a rejected boot — everything already started stops.
+    const log: string[] = [];
+    const fakes = fakeRuntimes(log, {}, { acquisitionsStart: true });
+
+    await expect(
+      bootRuntimes(VALID_ENV, {
+        createDownloader: fakes.createDownloader,
+        createImporter: fakes.createImporter,
+        onShutdownSignal: vi.fn(),
+      }),
+    ).rejects.toThrow(/subscription start defect/);
+    expect(log).toContain('acquisitions:stop');
+    expect(log).toContain('verdicts:stop');
+    expect(log).toContain('downloader:stop');
+    expect(log).toContain('importer:stop');
+  });
+
+  it('logs, rather than loses, a rejection from the signal-driven shutdown', async () => {
+    // The default registration fires `void shutdown()` from a process event: a rejection there
+    // has no awaiting caller, so unobserved it would be an unhandled rejection at teardown.
+    const log: string[] = [];
+    const fakes = fakeRuntimes(log);
+    await bootRuntimes(VALID_ENV, {
+      createDownloader: fakes.createDownloader,
+      createImporter: fakes.createImporter,
+    });
+    const errorSpy = vi.spyOn(loggerOf(), 'error');
+    fakes.downloader.stop = () => Promise.reject(new Error('close raced'));
+
+    (process.emit as (event: string) => boolean)('sveltekit:shutdown');
+
+    await vi.waitFor(() => {
+      const messages = errorSpy.mock.calls.map((call) => String(call.at(-1)));
+      expect(messages).toContain('shutdown failed');
+    });
+    fakes.downloader.stop = () => Promise.resolve(); // let afterEach tear down cleanly
   });
 
   it('composes the access surface: the configured session secret and the real plex.tv adapter', async () => {

--- a/packages/web/src/lib/server/runtime.test.ts
+++ b/packages/web/src/lib/server/runtime.test.ts
@@ -53,7 +53,7 @@ function fakeSubscription(log: string[], name: string) {
 function fakeRuntimes(
   log: string[],
   statuses: { downloader?: 'up' | 'down'; importer?: 'up' | 'down' } = {},
-  failures: { acquisitionsStart?: boolean } = {},
+  failures: { acquisitionsStart?: boolean; acquisitionsStopThrows?: boolean } = {},
 ) {
   // Each seam must be wired to the OTHER module's feed and wakeups; capturing what each connect call
   // received lets a test catch a cross-wiring (e.g. handing the verdict seam the downloader's own
@@ -84,14 +84,27 @@ function fakeRuntimes(
     connectAcquisitionFeed: (feed: unknown, options: { sourceRoot: string }, wakeups: unknown) => {
       log.push(`acquisitions:connect:${options.sourceRoot}`);
       captured.acquisition = { feed, wakeups };
-      return failures.acquisitionsStart
-        ? {
-            start: () => Promise.reject(new Error('subscription start defect')),
-            stop: () => {
-              log.push('acquisitions:stop');
-            },
-          }
-        : fakeSubscription(log, 'acquisitions');
+      if (failures.acquisitionsStart) {
+        return {
+          start: () => Promise.reject(new Error('subscription start defect')),
+          stop: () => {
+            log.push('acquisitions:stop');
+          },
+        };
+      }
+      if (failures.acquisitionsStopThrows) {
+        let hasThrown = false;
+        return {
+          start: () => Promise.resolve(),
+          stop: () => {
+            // Throw once (the scenario under test); settle quietly for the afterEach reset.
+            if (hasThrown) return;
+            hasThrown = true;
+            throw new Error('sync stop defect');
+          },
+        };
+      }
+      return fakeSubscription(log, 'acquisitions');
     },
     readiness: () => ({ status: statuses.importer ?? 'up' }),
     stop: () => {
@@ -245,25 +258,101 @@ describe('bootRuntimes', () => {
     expect(log).toContain('importer:stop');
   });
 
-  it('logs, rather than loses, a rejection from the signal-driven shutdown', async () => {
-    // The default registration fires `void shutdown()` from a process event: a rejection there
-    // has no awaiting caller, so unobserved it would be an unhandled rejection at teardown.
+  it('a failing stop during signal-driven shutdown is isolated, logged, and dirties the exit code', async () => {
+    // One runtime's failed stop must not skip the other's — its pollers would keep the event
+    // loop alive until SIGKILL while the exit reads clean. Each stop settles independently, the
+    // rejection is logged (never an unhandled rejection at teardown), and the exit code says so.
     const log: string[] = [];
+    const lines: string[] = [];
     const fakes = fakeRuntimes(log);
     await bootRuntimes(VALID_ENV, {
       createDownloader: fakes.createDownloader,
       createImporter: fakes.createImporter,
+      logDestination: { write: (line: string) => void lines.push(line) },
     });
-    const errorSpy = vi.spyOn(loggerOf(), 'error');
-    fakes.downloader.stop = () => Promise.reject(new Error('close raced'));
+    fakes.downloader.stop = () => {
+      log.push('downloader:stop:rejected');
+      return Promise.reject(new Error('close raced'));
+    };
+    const priorExitCode = process.exitCode;
+
+    (process.emit as (event: string) => boolean)('sveltekit:shutdown');
+
+    try {
+      await vi.waitFor(() => {
+        expect(lines.join('')).toContain('runtime stop failed during shutdown');
+      });
+      expect(log).toContain('importer:stop'); // the sibling stop still ran
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = priorExitCode; // never let this spec dirty the test process's own exit
+      fakes.downloader.stop = () => Promise.resolve(); // let afterEach tear down cleanly
+    }
+  });
+
+  it('a defect thrown inside shutdown itself is logged, never an unhandled rejection', async () => {
+    // stopSettled absorbs runtime-stop failures, but shutdown still calls the seam
+    // subscriptions' sync stop()s directly — a defect thrown there rejects the fire-and-forget
+    // shutdown call, which has no awaiting caller. The last-resort catch must observe it.
+    const log: string[] = [];
+    const lines: string[] = [];
+    const fakes = fakeRuntimes(log, {}, { acquisitionsStopThrows: true });
+    await bootRuntimes(VALID_ENV, {
+      createDownloader: fakes.createDownloader,
+      createImporter: fakes.createImporter,
+      logDestination: { write: (line: string) => void lines.push(line) },
+    });
 
     (process.emit as (event: string) => boolean)('sveltekit:shutdown');
 
     await vi.waitFor(() => {
-      const messages = errorSpy.mock.calls.map((call) => String(call.at(-1)));
-      expect(messages).toContain('shutdown failed');
+      expect(lines.join('')).toContain('shutdown failed');
     });
-    fakes.downloader.stop = () => Promise.resolve(); // let afterEach tear down cleanly
+  });
+
+  it('the original boot fatal wins over a failing stop during teardown', async () => {
+    // The seam subscription's start throws AND the downloader's stop rejects during cleanup:
+    // the caller must still see the subscription defect (the actual fatal), with the cleanup
+    // rejection logged — never thrown over it — and the importer's stop still runs.
+    const log: string[] = [];
+    const lines: string[] = [];
+    const fakes = fakeRuntimes(log, {}, { acquisitionsStart: true });
+    fakes.downloader.stop = () => {
+      log.push('downloader:stop:rejected');
+      return Promise.reject(new Error('close raced'));
+    };
+
+    await expect(
+      bootRuntimes(VALID_ENV, {
+        createDownloader: fakes.createDownloader,
+        createImporter: fakes.createImporter,
+        onShutdownSignal: vi.fn(),
+        logDestination: { write: (line: string) => void lines.push(line) },
+      }),
+    ).rejects.toThrow(/subscription start defect/);
+    expect(log).toContain('importer:stop');
+    expect(lines.join('')).toContain('runtime stop failed during boot teardown');
+  });
+
+  it('the importer startup error wins over a failing downloader stop', async () => {
+    const log: string[] = [];
+    const lines: string[] = [];
+    const fakes = fakeRuntimes(log);
+    fakes.downloader.stop = () => Promise.reject(new Error('close raced'));
+    const failingImporter = vi.fn((() =>
+      Promise.resolve(
+        err({ kind: 'BeetsConfigUnusable', detail: 'bad yaml' }),
+      )) as unknown as typeof createImporterRuntime);
+
+    await expect(
+      bootRuntimes(VALID_ENV, {
+        createDownloader: fakes.createDownloader,
+        createImporter: failingImporter,
+        onShutdownSignal: vi.fn(),
+        logDestination: { write: (line: string) => void lines.push(line) },
+      }),
+    ).rejects.toThrow(/importer startup failed: bad yaml/);
+    expect(lines.join('')).toContain('runtime stop failed during boot teardown');
   });
 
   it('composes the access surface: the configured session secret and the real plex.tv adapter', async () => {

--- a/packages/web/src/lib/server/runtime.ts
+++ b/packages/web/src/lib/server/runtime.ts
@@ -6,7 +6,7 @@ import type { DownloaderFacade } from '@music/downloader';
 import type { ImporterFacade } from '@music/importer';
 import type { DownloaderReadiness } from '@music/downloader/runtime';
 import type { ImporterReadiness } from '@music/importer/runtime';
-import type { Logger } from 'pino';
+import type { DestinationStream, Logger } from 'pino';
 import { loadComposedConfig } from './config.js';
 import { createLogger } from './logger.js';
 import { PlexTvAccess } from './plex/adapter.js';
@@ -77,6 +77,28 @@ export interface BootOverrides {
   readonly createImporter?: typeof createImporterRuntime;
   /** Shutdown-signal registration seam; production wires adapter-node's `sveltekit:shutdown`. */
   readonly onShutdownSignal?: (shutdown: () => Promise<void>) => void;
+  /** Log-capture seam for boot/teardown specs; production writes to stdout. */
+  readonly logDestination?: DestinationStream;
+}
+
+/**
+ * Settle every stop and log the failures: a teardown must never mask the error that caused it,
+ * and one runtime's failed stop must never skip the other's (its pollers would keep the event
+ * loop alive until SIGKILL). Returns whether every stop settled cleanly.
+ */
+async function stopSettled(
+  logger: Logger,
+  message: string,
+  stops: readonly Promise<void>[],
+): Promise<boolean> {
+  const settled = await Promise.allSettled(stops);
+  const failed = settled.filter(
+    (outcome): outcome is PromiseRejectedResult => outcome.status === 'rejected',
+  );
+  for (const failure of failed) {
+    logger.error({ err: failure.reason }, message);
+  }
+  return failed.length === 0;
 }
 
 // Boot-once singleton state held on one object so the memoization writes are property
@@ -105,7 +127,7 @@ async function boot(
   const config = loadComposedConfig(environment);
   if (config.isErr()) throw new Error(config.error);
 
-  const logger = createLogger(config.value.logLevel);
+  const logger = createLogger(config.value.logLevel, overrides.logDestination);
 
   const downloaderResult = await (overrides.createDownloader ?? createDownloaderRuntime)(
     config.value.downloader,
@@ -121,7 +143,8 @@ async function boot(
     logger,
   );
   if (importerResult.isErr()) {
-    await downloader.stop();
+    // Settled, never bare-awaited: a failing downloader stop must not mask the startup error.
+    await stopSettled(logger, 'runtime stop failed during boot teardown', [downloader.stop()]);
     throw new Error(`importer startup failed: ${importerResult.error.detail}`);
   }
   const importer: ImporterRuntime = importerResult.value;
@@ -137,21 +160,28 @@ async function boot(
     await verdicts.start();
   } catch (error) {
     // A subscription whose start throws must not strand two booted runtimes with live pollers
-    // behind a rejected boot: stop everything already started, then surface the fatal.
+    // behind a rejected boot: stop everything already started, then surface the ORIGINAL fatal —
+    // cleanup rejections are logged by stopSettled, never thrown over it.
     acquisitions.stop();
     verdicts.stop();
-    await downloader.stop();
-    await importer.stop();
+    await stopSettled(logger, 'runtime stop failed during boot teardown', [
+      downloader.stop(),
+      importer.stop(),
+    ]);
     throw error;
   }
 
   const shutdown = async (): Promise<void> => {
     acquisitions.stop();
     verdicts.stop();
-    await downloader.stop();
-    await importer.stop();
+    const isClean = await stopSettled(logger, 'runtime stop failed during shutdown', [
+      downloader.stop(),
+      importer.stop(),
+    ]);
     runtime.booted = undefined;
     runtime.booting = undefined;
+    // A dirty teardown must not report a clean exit: pollers may be alive until SIGKILL.
+    if (!isClean) process.exitCode = 1;
   };
   (overrides.onShutdownSignal ?? ((handler) => registerProcessShutdown(handler, logger)))(shutdown);
 

--- a/packages/web/src/lib/server/runtime.ts
+++ b/packages/web/src/lib/server/runtime.ts
@@ -84,9 +84,18 @@ export interface BootOverrides {
 // module-scoped binding from inside a function.
 const runtime: { booted?: Booted; booting?: Promise<Booted> } = {};
 
-function registerProcessShutdown(shutdown: () => Promise<void>): void {
-  // adapter-node stops accepting connections on SIGINT/SIGTERM, then emits this event.
-  process.once('sveltekit:shutdown', () => void shutdown());
+function registerProcessShutdown(shutdown: () => Promise<void>, logger: Logger): void {
+  // adapter-node stops accepting connections on SIGINT/SIGTERM, then emits this event. The
+  // fire-and-forget call has no awaiting caller, so a rejection (e.g. a close racing an in-flight
+  // pass) must be observed and logged here — never dropped, never an unhandled rejection.
+  const runShutdown = async (): Promise<void> => {
+    try {
+      await shutdown();
+    } catch (error) {
+      logger.error({ err: error }, 'shutdown failed');
+    }
+  };
+  process.once('sveltekit:shutdown', () => void runShutdown());
 }
 
 async function boot(
@@ -98,9 +107,14 @@ async function boot(
 
   const logger = createLogger(config.value.logLevel);
 
-  const downloader: DownloaderRuntime = await (
-    overrides.createDownloader ?? createDownloaderRuntime
-  )(config.value.downloader, logger);
+  const downloaderResult = await (overrides.createDownloader ?? createDownloaderRuntime)(
+    config.value.downloader,
+    logger,
+  );
+  if (downloaderResult.isErr()) {
+    throw new Error(`downloader startup failed: ${downloaderResult.error.detail}`);
+  }
+  const downloader: DownloaderRuntime = downloaderResult.value;
 
   const importerResult = await (overrides.createImporter ?? createImporterRuntime)(
     config.value.importer,
@@ -118,8 +132,18 @@ async function boot(
     downloader.wakeups,
   );
   const verdicts: Stoppable = downloader.connectVerdictFeed(importer.feed, importer.wakeups);
-  await acquisitions.start();
-  await verdicts.start();
+  try {
+    await acquisitions.start();
+    await verdicts.start();
+  } catch (error) {
+    // A subscription whose start throws must not strand two booted runtimes with live pollers
+    // behind a rejected boot: stop everything already started, then surface the fatal.
+    acquisitions.stop();
+    verdicts.stop();
+    await downloader.stop();
+    await importer.stop();
+    throw error;
+  }
 
   const shutdown = async (): Promise<void> => {
     acquisitions.stop();
@@ -129,7 +153,7 @@ async function boot(
     runtime.booted = undefined;
     runtime.booting = undefined;
   };
-  (overrides.onShutdownSignal ?? registerProcessShutdown)(shutdown);
+  (overrides.onShutdownSignal ?? ((handler) => registerProcessShutdown(handler, logger)))(shutdown);
 
   return {
     facades: { downloader: downloader.facade, importer: importer.facade },


### PR DESCRIPTION
Hardening batch from the 2026-08-05 ten-agent whole-project review — the S1 lane: every finding where a fault could take the process down, wedge dispatch, or vanish silently. Releases as **v3.16.1** (patch).

## What's fixed

**Importer process safety (the whole-monolith crash risk)**
- The reactor drain and seam-subscription poll now contain a thrown defect (parity with the downloader's `withMutex`/`schedulePoll` guards): a fire-and-forget pass can no longer surface as an unhandled rejection that terminates the one process serving both modules and the web UI.
- `stop()` during the startup checkpoint load no longer attaches the live loop of a torn-down boot.
- Sibling effects of one event now settle independently — a stale-rejected or dead-lettered first effect no longer silently drops the effects behind it (latent while `react()` yields ≤1 effect; pinned with a widened double).

**Downloader dispatch & boot**
- The ffmpeg/ffprobe runner has a kill-on-timeout (beets-runner pattern, `FFMPEG_TIMEOUT_MS`, default 120s/file): a hung decode can no longer wedge the reactor's dispatch forever. A timeout is an InfraError, never a bad-file verdict.
- Decode/probe stderr is logged when folding to `decodedCleanly: false` — systematic environmental faults (permissions, missing codec) are now diagnosable.
- A failed landing after budget exhaustion re-parks at the policy cap instead of re-firing the live effect on every ~5s tick unboundedly.
- `createDownloaderRuntime` returns a Result and refuses to boot on a failed projection rebuild (`ProjectionRebuildFailed`), mirroring the importer — no more empty lists with a green `/health`.

**Composed web runtime**
- A seam subscription whose `start()` throws stops both runtimes instead of stranding live pollers behind a rejected boot; the signal-driven shutdown logs a rejection instead of losing it.

**Adapters & hygiene**
- slskd adapters require their client injected (no more silent `localhost:5030`/empty-key fallback on a wiring slip).
- Both subprocess runners decode UTF-8 as a stream, not per chunk (split multi-byte code points corrupted; bridge stdout is JSON.parsed).
- Soulseek peer usernames (third-party PII) join the default log-redaction paths, and the one error message interpolating one was rewritten.
- `bridge.py` reports the count of files it skips as unreadable on stderr (stdout JSON contract unchanged).

## Verification
- TDD red-first per item; `pnpm check` (format, lint, typecheck, build, 100%-coverage tests, contract, release, bridge tiers) green on every commit.
- Local out-of-process e2e (`pnpm test:e2e`): **green**, all phases 0–4.
- Review pass: direct whole-diff self-review (the sandbox could not spawn the review-agent roster; flagged for the coordinator, who may run `/review-all` on this branch). Notable checks: err-path construction order, at-least-once semantics of the sibling-continue loop, no classifier keyed on the changed error message.

One deliberate scope note: the S1 item "require injection" was applied at the adapter constructors only; `SLSKD_BASE_URL`/`SLSKD_API_KEY` remain optional env vars (changing that is a deploy-contract decision, out of S1 scope).

## Review-pass amendments (2026-08-05)

A three-agent review (code quality, silent-failure hunt, test quality) of the original six commits produced a consolidated fix list, applied as five amendment commits before the release commit:

- **Critical — redaction was inert in production**: the web layer's `createLogger` was a bare `pino({level})`, so neither module's `DEFAULT_REDACT_PATHS` (peer usernames, and the pre-existing apiKey/authorization/fileContents) ever applied to a shipped line. The composed root now unions both modules' paths (`censor: '[REDACTED]'`), pinned by a web-tier test through the production logger.
- **Shutdown/boot teardown failure-isolated**: one runtime's failed `stop()` no longer skips the other's (Promise.allSettled shape), the original boot fatal always wins over cleanup rejections, and a dirty signal-driven teardown sets `process.exitCode = 1`; a defect thrown inside shutdown itself is logged, never an unhandled rejection.
- **Bridge stderr on success is now read**: the adapter logs non-empty stderr at warn on code-0 runs — the skipped-unreadable-files count was previously written to a stream nothing read.
- **Peer-username scrub completed**: the client's GET/DELETE throw messages embedded `downloadsPath(username)` (dead-letter-bound, unreachable by structured redaction); all throw sites now carry the route shape with the peer segment redacted, pinned message-side in the enqueue and client tests.
- **ffmpeg runner residual hang closed**: post-SIGKILL 1s grace resolves `{timedOut: true}` without awaiting `'close'` (a D-state child cannot wedge the reactor), and a decode finishing at ~the deadline is never stamped a false timeout.
- **Test precision**: static `Import.fromHistory` stub restored per-test (mock-leak trap), exact policy-cap re-park timestamp asserted, re-park comment corrected (the live effect re-fires idempotently before the landing is re-attempted; no landing-only mode exists).

**Recorded follow-ups (out of scope, same bug classes)**:
- `CatchUpSubscription.start()` in BOTH modules has an attach-after-teardown window: a `stop()` landing during the awaited checkpoint load still attaches wakeups and a live interval. Needs a concurrent stop no current call path produces.
- Sibling effects of one event share a single durable retry tally (keyed per `globalSeq`): once a real reaction yields two effects, a sibling dead-lettering on a spent tally leaves the next sibling's first failure reading the same spent count. Latent — `react()` yields ≤1 effect today; named in the sibling-effect suite's comment.
- The beets runner shares the ffmpeg runner's former resolve-only-on-'close' shape after its (pre-existing) timeout kill; the same post-kill grace could be ported for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
