### PR TITLE
docs: jj+gh PR mechanics in CLAUDE.md; local-gate latency budget in deterministic-floor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,22 @@ Hard rules. A change that violates one is wrong regardless of anything else:
 
 Runtime: Node ≥24, pnpm 11. After switching Node versions locally, run `pnpm rebuild better-sqlite3` (native module).
 
+## PRs with `jj` + `gh`
+
+jj keeps git's `HEAD` detached, so any `gh` subcommand that infers "the current branch" fails with `not on any branch` — and a `gh pr merge` printing that error has usually **still merged** (verify with `gh pr view <#> --json state`). Never let `gh` touch or infer local branch state, and never judge commit/push state from `git status`/`git log` (stale in colocated repos) — trust `jj st` and `jj bookmark list --all`. Run `gh` from the colocated main repo, not a bare workspace (`not a git repository`).
+
+The reliable flow:
+
+```sh
+jj git fetch && jj rebase -b <bookmark> -d 'main@origin'  # sync FIRST — concurrent sessions move main mid-ship (recurring collision)
+jj git push --bookmark <bookmark>
+gh pr create --head <bookmark> --base main …              # explicit --head; refer to the PR by number from here on
+gh pr checks <#> --watch
+gh pr merge <#> --rebase                                  # rebase-merge only; NO --delete-branch (remote auto-deletes; local: jj git fetch)
+```
+
+If checks took a while, fetch + rebase again before merging — "head branch is not up to date" means main moved underneath you.
+
 ## Stack
 
 Node · TypeScript (strict) · pnpm workspace · neverthrow · zod · pino · vitest · SQLite · ffmpeg (downloader) · beets via a stateless Python bridge CLI behind an outbound port (importer, the one non-TS component, pinned in the Docker image). VCS: jujutsu (`jj`), git-backed — see Non-negotiables.

--- a/openspec/changes/deterministic-floor/tasks.md
+++ b/openspec/changes/deterministic-floor/tasks.md
@@ -27,7 +27,9 @@ judgment commits. Red-first only where a triage uncovers a real defect (then `fi
 
 - [ ] 3.1 Write `docs/development/quality-gates.md`: admission contract (<10% effective FP,
       actionable-only, appeasement counts as false), four-rung promotion ladder with
-      when-to-stop guidance, waiver-doctrine cross-reference.
+      when-to-stop guidance, waiver-doctrine cross-reference, and the local-gate latency
+      budget (`pnpm check` stays seconds-order; minutes-order analysis lives in CI and is
+      locally runnable on demand, never in the commit gate).
 - [ ] 3.2 Link it from CLAUDE.md's constitution list and from `testing.md`/
       `coding-standards.md` where they touch gate membership.
 - [ ] 3.3 Sanity-check the contract text against the actual sonarjs triage experience


### PR DESCRIPTION
Retro outcomes from the quality-function proposal session:

- **CLAUDE.md gains a "PRs with jj + gh" section** — the detached-HEAD gh gotchas, the sync-before-create-and-before-merge rule (concurrent sessions move main mid-ship; this session hit the collision again), run-gh-from-the-colocated-repo, and the reliable push→create→checks→merge flow. Migrated from assistant memory into the repo, where it's version-controlled.
- **deterministic-floor task 3.1** now names the local-gate latency budget (`pnpm check` seconds-order; minutes-order analysis in CI, locally runnable on demand) as `quality-gates.md` content, so the implementing session writes the spoken rule into the constitution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)