### PR TITLE
fix: type-seam & upcaster integrity batch (S2) — v3.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.16.2](https://github.com/jgchk/music-downloader/compare/v3.16.1...v3.16.2) (2026-08-06)
+
+### Bug Fixes
+
+* **downloader:** default the event store to the populated upcaster registry ([0f7fdbd](https://github.com/jgchk/music-downloader/commit/0f7fdbdd9446ce02233bfecdef7b14894e010c85))
+* **downloader:** encode the stalled flag tag-or-omit on the wire ([5de2876](https://github.com/jgchk/music-downloader/commit/5de2876a1a1f354f37159607815f4d5f832d562e))
+* **importer:** project history onto the wire per kind, never by spread ([1f98ad3](https://github.com/jgchk/music-downloader/commit/1f98ad3db34914c4f2275bfd2a737296419759b0))
+* **importer:** replay legacy events through the production upcaster registry ([0fbbb9e](https://github.com/jgchk/music-downloader/commit/0fbbb9e60982e8887020b24ecafa5cac9fa0222c))
+* **web:** honest degrade arms and one-voice register at the wire lookups ([e69a6b3](https://github.com/jgchk/music-downloader/commit/e69a6b34a2343006df5ac5b3bb2a1e8413f861a3))
+* **web:** restore compile pressure on the resolution-verb seams ([fd52753](https://github.com/jgchk/music-downloader/commit/fd52753d5a17ecd83a8c5e6f7f7856512ed155cd))
 ## [3.16.1](https://github.com/jgchk/music-downloader/compare/v3.16.0...v3.16.1) (2026-08-05)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "3.16.1",
+  "version": "3.16.2",
   "private": true,
   "description": "An extensible, event-sourced music downloader and importer — a modular monolith.",
   "type": "module",

--- a/packages/downloader/src/adapters/sqlite/event-store.test.ts
+++ b/packages/downloader/src/adapters/sqlite/event-store.test.ts
@@ -203,6 +203,22 @@ describe('SqliteEventStore', () => {
     });
   });
 
+  it('surfaces an upcaster registration gap as a modeled infra error on read', async () => {
+    // Steps {current→+1, current+2→+3} leave a hole: the walk stops with a step unapplied above
+    // it. The read must refuse as an InfraError — never hand evolve a stale shape.
+    const registry = new UpcasterRegistry()
+      .register('AcquisitionFulfilled', CURRENT_SCHEMA_VERSION, (data) => data)
+      .register('AcquisitionFulfilled', CURRENT_SCHEMA_VERSION + 2, (data) => data);
+    const store = new SqliteEventStore(freshDatabase(), registry);
+    await store.append('acq-1', 0, [FULFILLED], META);
+
+    const read = await store.readStream('acq-1');
+
+    expect(read.isErr()).toBe(true);
+    expect(read._unsafeUnwrapErr().kind).toBe('InfraError');
+    expect(read._unsafeUnwrapErr().message).toContain('upcast gap');
+  });
+
   it('upcasts stored events on read', async () => {
     const registry = new UpcasterRegistry().register(
       'AcquisitionFulfilled',

--- a/packages/downloader/src/adapters/sqlite/event-store.test.ts
+++ b/packages/downloader/src/adapters/sqlite/event-store.test.ts
@@ -174,6 +174,35 @@ describe('SqliteEventStore', () => {
     });
   });
 
+  it('upcasts by default: a store built without a registry still lifts legacy rows', async () => {
+    // The default registry is the populated one, so a wiring omission cannot silently serve
+    // un-upcast events; an empty `new UpcasterRegistry()` is an explicit, deliberate opt-out.
+    const database = freshDatabase();
+    const store = new SqliteEventStore(database);
+    database
+      .prepare(
+        `INSERT INTO events (stream_id, version, type, schema_version, data, metadata)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        'acq-1',
+        0,
+        'ManualSelectionRequested',
+        1,
+        JSON.stringify({
+          type: 'ManualSelectionRequested',
+          candidates: [{ releaseMbid: 'b', title: 'Unknown', trackCount: 0 }],
+        }),
+        '{}',
+      );
+
+    const read = (await store.readStream('acq-1'))._unsafeUnwrap();
+    expect(read[0]!.event).toEqual({
+      type: 'ManualSelectionRequested',
+      candidates: [{ releaseMbid: 'b', title: 'Unknown' }],
+    });
+  });
+
   it('upcasts stored events on read', async () => {
     const registry = new UpcasterRegistry().register(
       'AcquisitionFulfilled',

--- a/packages/downloader/src/adapters/sqlite/event-store.test.ts
+++ b/packages/downloader/src/adapters/sqlite/event-store.test.ts
@@ -204,22 +204,6 @@ describe('SqliteEventStore', () => {
     });
   });
 
-  it('surfaces an upcaster registration gap as a modeled infra error on read', async () => {
-    // Steps {current→+1, current+2→+3} leave a hole: the walk stops with a step unapplied above
-    // it. The read must refuse as an InfraError — never hand evolve a stale shape.
-    const registry = new UpcasterRegistry()
-      .register('AcquisitionFulfilled', CURRENT_SCHEMA_VERSION, (data) => data)
-      .register('AcquisitionFulfilled', CURRENT_SCHEMA_VERSION + 2, (data) => data);
-    const store = new SqliteEventStore(freshDatabase(), registry);
-    await store.append('acq-1', 0, [FULFILLED], META);
-
-    const read = await store.readStream('acq-1');
-
-    expect(read.isErr()).toBe(true);
-    expect(read._unsafeUnwrapErr().kind).toBe('InfraError');
-    expect(read._unsafeUnwrapErr().message).toContain('upcast gap');
-  });
-
   it('upcasts stored events on read', async () => {
     const registry = new UpcasterRegistry().register(
       'AcquisitionFulfilled',

--- a/packages/downloader/src/adapters/sqlite/event-store.test.ts
+++ b/packages/downloader/src/adapters/sqlite/event-store.test.ts
@@ -196,7 +196,8 @@ describe('SqliteEventStore', () => {
         '{}',
       );
 
-    const read = (await store.readStream('acq-1'))._unsafeUnwrap();
+    const readResult = await store.readStream('acq-1');
+    const read = readResult._unsafeUnwrap();
     expect(read[0]!.event).toEqual({
       type: 'ManualSelectionRequested',
       candidates: [{ releaseMbid: 'b', title: 'Unknown' }],

--- a/packages/downloader/src/adapters/sqlite/event-store.ts
+++ b/packages/downloader/src/adapters/sqlite/event-store.ts
@@ -13,7 +13,8 @@ import type {
   StoredEvent,
 } from '../../application/ports/event-store-port.js';
 import type { EventDatabase } from './schema.js';
-import { buildUpcasterRegistry, CURRENT_SCHEMA_VERSION, UpcasterRegistry } from './upcaster.js';
+import { buildUpcasterRegistry, CURRENT_SCHEMA_VERSION } from './upcaster.js';
+import type { UpcasterRegistry } from './upcaster.js';
 
 /**
  * The SQLite `EventStorePort` adapter (D7). Optimistic concurrency is enforced twice: `append`

--- a/packages/downloader/src/adapters/sqlite/event-store.ts
+++ b/packages/downloader/src/adapters/sqlite/event-store.ts
@@ -36,6 +36,17 @@ interface EventRow {
 /** Thrown inside the append transaction to roll it back on a version mismatch. */
 class ConcurrencyBreak extends Error {}
 
+/** Thrown inside a read's row mapping to surface an upcaster registration gap as the read's
+ * modeled InfraError (the registry itself refuses as a value; no throw escapes the port). */
+class UpcastGapBreak extends Error {
+  constructor(gap: { type: string; arrivedAt: number; unappliedFrom: number }) {
+    super(
+      `upcast gap for ${gap.type}: chain arrived at v${gap.arrivedAt} with a step still ` +
+        `registered from v${gap.unappliedFrom} — refusing to serve a stale shape`,
+    );
+  }
+}
+
 function isUniqueViolation(error: unknown): boolean {
   return (error as { code?: string }).code === 'SQLITE_CONSTRAINT_UNIQUE';
 }
@@ -155,11 +166,14 @@ export class SqliteEventStore implements EventStorePort {
       streamId: row.stream_id,
       version: row.version,
       type: row.type as AcquisitionEventType,
-      event: this.upcasters.upcast(
-        row.type,
-        row.schema_version,
-        JSON.parse(row.data) as Record<string, unknown>,
-      ),
+      event: this.upcasters
+        .upcast(row.type, row.schema_version, JSON.parse(row.data) as Record<string, unknown>)
+        .match(
+          (event) => event,
+          (gap) => {
+            throw new UpcastGapBreak(gap);
+          },
+        ),
       metadata: JSON.parse(row.metadata) as EventMetadata,
     };
   }

--- a/packages/downloader/src/adapters/sqlite/event-store.ts
+++ b/packages/downloader/src/adapters/sqlite/event-store.ts
@@ -37,16 +37,6 @@ interface EventRow {
 /** Thrown inside the append transaction to roll it back on a version mismatch. */
 class ConcurrencyBreak extends Error {}
 
-/** Thrown inside a read's row mapping to surface an upcaster registration gap as the read's
- * modeled InfraError (the registry itself refuses as a value; no throw escapes the port). */
-class UpcastGapBreak extends Error {
-  constructor(gap: { type: string; arrivedAt: number; unappliedFrom: number }) {
-    super(
-      `upcast gap for ${gap.type}: chain arrived at v${gap.arrivedAt} with a step still ` +
-        `registered from v${gap.unappliedFrom} — refusing to serve a stale shape`,
-    );
-  }
-}
 
 function isUniqueViolation(error: unknown): boolean {
   return (error as { code?: string }).code === 'SQLITE_CONSTRAINT_UNIQUE';
@@ -167,14 +157,11 @@ export class SqliteEventStore implements EventStorePort {
       streamId: row.stream_id,
       version: row.version,
       type: row.type as AcquisitionEventType,
-      event: this.upcasters
-        .upcast(row.type, row.schema_version, JSON.parse(row.data) as Record<string, unknown>)
-        .match(
-          (event) => event,
-          (gap) => {
-            throw new UpcastGapBreak(gap);
-          },
-        ),
+      event: this.upcasters.upcast(
+        row.type,
+        row.schema_version,
+        JSON.parse(row.data) as Record<string, unknown>,
+      ),
       metadata: JSON.parse(row.metadata) as EventMetadata,
     };
   }

--- a/packages/downloader/src/adapters/sqlite/event-store.ts
+++ b/packages/downloader/src/adapters/sqlite/event-store.ts
@@ -13,7 +13,7 @@ import type {
   StoredEvent,
 } from '../../application/ports/event-store-port.js';
 import type { EventDatabase } from './schema.js';
-import { CURRENT_SCHEMA_VERSION, UpcasterRegistry } from './upcaster.js';
+import { buildUpcasterRegistry, CURRENT_SCHEMA_VERSION, UpcasterRegistry } from './upcaster.js';
 
 /**
  * The SQLite `EventStorePort` adapter (D7). Optimistic concurrency is enforced twice: `append`
@@ -54,7 +54,11 @@ export class SqliteEventStore implements EventStorePort {
 
   constructor(
     database: EventDatabase,
-    private readonly upcasters: UpcasterRegistry = new UpcasterRegistry(),
+    // Default to the populated registry so legacy on-disk shapes are lifted even when a caller
+    // omits the argument: a store built without one still upcasts. Passing an empty
+    // `new UpcasterRegistry()` is an explicit, deliberate opt-out (only tests that assert raw
+    // pass-through do so).
+    private readonly upcasters: UpcasterRegistry = buildUpcasterRegistry(),
     private readonly bus?: EventBus,
   ) {
     this.insertStmt = database.prepare(

--- a/packages/downloader/src/adapters/sqlite/event-store.ts
+++ b/packages/downloader/src/adapters/sqlite/event-store.ts
@@ -37,7 +37,6 @@ interface EventRow {
 /** Thrown inside the append transaction to roll it back on a version mismatch. */
 class ConcurrencyBreak extends Error {}
 
-
 function isUniqueViolation(error: unknown): boolean {
   return (error as { code?: string }).code === 'SQLITE_CONSTRAINT_UNIQUE';
 }

--- a/packages/downloader/src/adapters/sqlite/upcaster.test.ts
+++ b/packages/downloader/src/adapters/sqlite/upcaster.test.ts
@@ -2,25 +2,48 @@ import { describe, expect, it } from 'vitest';
 import { UpcasterRegistry, buildUpcasterRegistry } from './upcaster.js';
 
 describe('UpcasterRegistry', () => {
-  it('refuses a gapped chain as a value instead of serving a stale shape', () => {
-    // Steps {1→2, 3→4} with no 2→3: a v1 row walks to 2 and stops while a step from 3 remains
-    // unapplied above it — a registration gap. Serving the v2 shape to evolve would be silent
-    // corruption; the registry surfaces it as a value for the store's modeled error channel.
-    // Two unapplied steps (3 and 5) pin that the reported gap is the LOWEST unapplied step —
-    // the first hole an operator must fill.
+  it('continues across absent versions: every step at or above the stored version applies', () => {
+    // The schema version is a store-wide counter, so a type's chain is EXPECTED non-contiguous —
+    // it skips the versions it did not participate in, and the absence of a step at a version IS
+    // the declaration that the type's shape did not change there. Steps {1→2, 3→4, 5→6} with a
+    // v1 row therefore apply ALL THREE, in ascending order (registration order must not matter).
     const registry = new UpcasterRegistry()
       .register('Widened', 1, (data) => ({ ...data, two: true }))
       .register('Widened', 5, (data) => ({ ...data, six: true }))
       .register('Widened', 3, (data) => ({ ...data, four: true }));
 
-    const result = registry.upcast('Widened', 1, { type: 'Widened', one: true });
-
-    expect(result.isErr()).toBe(true);
-    expect(result._unsafeUnwrapErr()).toEqual({
-      kind: 'UpcastGap',
+    expect(registry.upcast('Widened', 1, { type: 'Widened', one: true })).toEqual({
       type: 'Widened',
-      arrivedAt: 2,
-      unappliedFrom: 3,
+      one: true,
+      two: true,
+      four: true,
+      six: true,
+    });
+  });
+
+  it('passes a future/unknown schema version through untouched (forward compatibility)', () => {
+    // A newer writer stamped v5; this reader knows only a v1→v2 step. With no step at or above
+    // v5, the payload is already at-or-beyond the reader's latest shape and flows through.
+    const registry = new UpcasterRegistry().register('Widened', 1, (data) => ({
+      ...data,
+      two: true,
+    }));
+
+    expect(registry.upcast('Widened', 5, { type: 'Widened', future: true })).toEqual({
+      type: 'Widened',
+      future: true,
+    });
+  });
+
+  it('starts a non-contiguous chain at the stored version, not below it', () => {
+    // A row stored at v4 (after the 3→4 change) must not re-apply the earlier steps.
+    const registry = new UpcasterRegistry()
+      .register('Widened', 1, (data) => ({ ...data, two: true }))
+      .register('Widened', 3, (data) => ({ ...data, four: true }));
+
+    expect(registry.upcast('Widened', 4, { type: 'Widened', four: true })).toEqual({
+      type: 'Widened',
+      four: true,
     });
   });
 
@@ -28,7 +51,7 @@ describe('UpcasterRegistry', () => {
     const registry = new UpcasterRegistry();
     const data = { type: 'AcquisitionExhausted' };
 
-    expect(registry.upcast('AcquisitionExhausted', 1, data)._unsafeUnwrap()).toEqual({
+    expect(registry.upcast('AcquisitionExhausted', 1, data)).toEqual({
       type: 'AcquisitionExhausted',
     });
   });
@@ -39,8 +62,7 @@ describe('UpcasterRegistry', () => {
       .register('Widened', 2, (data) => ({ ...data, three: true }));
 
     const result = registry
-      .upcast('Widened', 1, { type: 'Widened', one: true })
-      ._unsafeUnwrap() as Record<string, unknown>;
+      .upcast('Widened', 1, { type: 'Widened', one: true }) as Record<string, unknown>;
 
     expect(result).toEqual({ type: 'Widened', one: true, two: true, three: true });
   });
@@ -53,8 +75,7 @@ describe('UpcasterRegistry', () => {
 
     // Stored at version 2: no upcaster registered for v2, so it is already current.
     const result = registry
-      .upcast('Widened', 2, { type: 'Widened', two: true })
-      ._unsafeUnwrap() as Record<string, unknown>;
+      .upcast('Widened', 2, { type: 'Widened', two: true }) as Record<string, unknown>;
 
     expect(result).toEqual({ type: 'Widened', two: true });
   });
@@ -64,7 +85,7 @@ describe('buildUpcasterRegistry — ManualSelectionRequested v1 → v2', () => {
   const registry = buildUpcasterRegistry();
 
   function upcast(data: Record<string, unknown>): Record<string, unknown> {
-    return registry.upcast('ManualSelectionRequested', 1, data)._unsafeUnwrap();
+    return registry.upcast('ManualSelectionRequested', 1, data);
   }
 
   it('drops a v1 trackCount: 0 sentinel to absent and passes a real count through', () => {
@@ -94,6 +115,6 @@ describe('buildUpcasterRegistry — ManualSelectionRequested v1 → v2', () => {
       type: 'ManualSelectionRequested',
       candidates: [{ releaseMbid: 'b', title: 'Unknown' }],
     };
-    expect(registry.upcast('ManualSelectionRequested', 2, v2)._unsafeUnwrap()).toEqual(v2);
+    expect(registry.upcast('ManualSelectionRequested', 2, v2)).toEqual(v2);
   });
 });

--- a/packages/downloader/src/adapters/sqlite/upcaster.test.ts
+++ b/packages/downloader/src/adapters/sqlite/upcaster.test.ts
@@ -6,8 +6,11 @@ describe('UpcasterRegistry', () => {
     // Steps {1→2, 3→4} with no 2→3: a v1 row walks to 2 and stops while a step from 3 remains
     // unapplied above it — a registration gap. Serving the v2 shape to evolve would be silent
     // corruption; the registry surfaces it as a value for the store's modeled error channel.
+    // Two unapplied steps (3 and 5) pin that the reported gap is the LOWEST unapplied step —
+    // the first hole an operator must fill.
     const registry = new UpcasterRegistry()
       .register('Widened', 1, (data) => ({ ...data, two: true }))
+      .register('Widened', 5, (data) => ({ ...data, six: true }))
       .register('Widened', 3, (data) => ({ ...data, four: true }));
 
     const result = registry.upcast('Widened', 1, { type: 'Widened', one: true });
@@ -35,10 +38,9 @@ describe('UpcasterRegistry', () => {
       .register('Widened', 1, (data) => ({ ...data, two: true }))
       .register('Widened', 2, (data) => ({ ...data, three: true }));
 
-    const result = registry.upcast('Widened', 1, { type: 'Widened', one: true })._unsafeUnwrap() as Record<
-      string,
-      unknown
-    >;
+    const result = registry
+      .upcast('Widened', 1, { type: 'Widened', one: true })
+      ._unsafeUnwrap() as Record<string, unknown>;
 
     expect(result).toEqual({ type: 'Widened', one: true, two: true, three: true });
   });
@@ -50,10 +52,9 @@ describe('UpcasterRegistry', () => {
     }));
 
     // Stored at version 2: no upcaster registered for v2, so it is already current.
-    const result = registry.upcast('Widened', 2, { type: 'Widened', two: true })._unsafeUnwrap() as Record<
-      string,
-      unknown
-    >;
+    const result = registry
+      .upcast('Widened', 2, { type: 'Widened', two: true })
+      ._unsafeUnwrap() as Record<string, unknown>;
 
     expect(result).toEqual({ type: 'Widened', two: true });
   });

--- a/packages/downloader/src/adapters/sqlite/upcaster.test.ts
+++ b/packages/downloader/src/adapters/sqlite/upcaster.test.ts
@@ -61,8 +61,10 @@ describe('UpcasterRegistry', () => {
       .register('Widened', 1, (data) => ({ ...data, two: true }))
       .register('Widened', 2, (data) => ({ ...data, three: true }));
 
-    const result = registry
-      .upcast('Widened', 1, { type: 'Widened', one: true }) as Record<string, unknown>;
+    const result = registry.upcast('Widened', 1, { type: 'Widened', one: true }) as Record<
+      string,
+      unknown
+    >;
 
     expect(result).toEqual({ type: 'Widened', one: true, two: true, three: true });
   });
@@ -74,8 +76,10 @@ describe('UpcasterRegistry', () => {
     }));
 
     // Stored at version 2: no upcaster registered for v2, so it is already current.
-    const result = registry
-      .upcast('Widened', 2, { type: 'Widened', two: true }) as Record<string, unknown>;
+    const result = registry.upcast('Widened', 2, { type: 'Widened', two: true }) as Record<
+      string,
+      unknown
+    >;
 
     expect(result).toEqual({ type: 'Widened', two: true });
   });

--- a/packages/downloader/src/adapters/sqlite/upcaster.test.ts
+++ b/packages/downloader/src/adapters/sqlite/upcaster.test.ts
@@ -2,11 +2,30 @@ import { describe, expect, it } from 'vitest';
 import { UpcasterRegistry, buildUpcasterRegistry } from './upcaster.js';
 
 describe('UpcasterRegistry', () => {
+  it('refuses a gapped chain as a value instead of serving a stale shape', () => {
+    // Steps {1→2, 3→4} with no 2→3: a v1 row walks to 2 and stops while a step from 3 remains
+    // unapplied above it — a registration gap. Serving the v2 shape to evolve would be silent
+    // corruption; the registry surfaces it as a value for the store's modeled error channel.
+    const registry = new UpcasterRegistry()
+      .register('Widened', 1, (data) => ({ ...data, two: true }))
+      .register('Widened', 3, (data) => ({ ...data, four: true }));
+
+    const result = registry.upcast('Widened', 1, { type: 'Widened', one: true });
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toEqual({
+      kind: 'UpcastGap',
+      type: 'Widened',
+      arrivedAt: 2,
+      unappliedFrom: 3,
+    });
+  });
+
   it('is pass-through when nothing is registered (the MVP)', () => {
     const registry = new UpcasterRegistry();
     const data = { type: 'AcquisitionExhausted' };
 
-    expect(registry.upcast('AcquisitionExhausted', 1, data)).toEqual({
+    expect(registry.upcast('AcquisitionExhausted', 1, data)._unsafeUnwrap()).toEqual({
       type: 'AcquisitionExhausted',
     });
   });
@@ -16,7 +35,7 @@ describe('UpcasterRegistry', () => {
       .register('Widened', 1, (data) => ({ ...data, two: true }))
       .register('Widened', 2, (data) => ({ ...data, three: true }));
 
-    const result = registry.upcast('Widened', 1, { type: 'Widened', one: true }) as Record<
+    const result = registry.upcast('Widened', 1, { type: 'Widened', one: true })._unsafeUnwrap() as Record<
       string,
       unknown
     >;
@@ -31,7 +50,7 @@ describe('UpcasterRegistry', () => {
     }));
 
     // Stored at version 2: no upcaster registered for v2, so it is already current.
-    const result = registry.upcast('Widened', 2, { type: 'Widened', two: true }) as Record<
+    const result = registry.upcast('Widened', 2, { type: 'Widened', two: true })._unsafeUnwrap() as Record<
       string,
       unknown
     >;
@@ -44,7 +63,7 @@ describe('buildUpcasterRegistry — ManualSelectionRequested v1 → v2', () => {
   const registry = buildUpcasterRegistry();
 
   function upcast(data: Record<string, unknown>): Record<string, unknown> {
-    return registry.upcast('ManualSelectionRequested', 1, data);
+    return registry.upcast('ManualSelectionRequested', 1, data)._unsafeUnwrap();
   }
 
   it('drops a v1 trackCount: 0 sentinel to absent and passes a real count through', () => {
@@ -74,6 +93,6 @@ describe('buildUpcasterRegistry — ManualSelectionRequested v1 → v2', () => {
       type: 'ManualSelectionRequested',
       candidates: [{ releaseMbid: 'b', title: 'Unknown' }],
     };
-    expect(registry.upcast('ManualSelectionRequested', 2, v2)).toEqual(v2);
+    expect(registry.upcast('ManualSelectionRequested', 2, v2)._unsafeUnwrap()).toEqual(v2);
   });
 });

--- a/packages/downloader/src/adapters/sqlite/upcaster.ts
+++ b/packages/downloader/src/adapters/sqlite/upcaster.ts
@@ -1,3 +1,5 @@
+import { err, ok } from 'neverthrow';
+import type { Result } from 'neverthrow';
 import type { AcquisitionEvent } from '../../domain/acquisition/events.js';
 
 /**
@@ -21,6 +23,18 @@ export const CURRENT_SCHEMA_VERSION = 2;
 /** Transforms one on-disk event payload from version N to version N+1. */
 export type Upcaster = (data: Record<string, unknown>) => Record<string, unknown>;
 
+/**
+ * A registration gap: the chain walk stopped at `arrivedAt` while a step registered from
+ * `unappliedFrom` (above it) could never apply. Serving the arrived shape to `evolve` would be
+ * silent corruption, so the walk refuses as a value instead.
+ */
+export interface UpcastGap {
+  readonly kind: 'UpcastGap';
+  readonly type: string;
+  readonly arrivedAt: number;
+  readonly unappliedFrom: number;
+}
+
 export class UpcasterRegistry {
   // event type -> (fromVersion -> upcaster that produces fromVersion + 1)
   private readonly upcasters = new Map<string, Map<number, Upcaster>>();
@@ -35,12 +49,19 @@ export class UpcasterRegistry {
 
   /**
    * Apply the chain of registered upcasters from `schemaVersion` up to the latest known shape.
-   * With no upcaster registered for the type, this is a pass-through: the stored payload is already
-   * current and is returned untouched.
+   * With no upcaster registered for the type, this is a pass-through: the stored payload is
+   * declared already-current and is returned untouched. A walk that stops below a still-registered
+   * step is a registration gap — refused as a value, never served stale (absence of a step from
+   * the arrival version upward is the declaration that no shape change exists there, so a
+   * remaining higher step can only mean a hole in the chain).
    */
-  upcast(type: string, schemaVersion: number, data: Record<string, unknown>): AcquisitionEvent {
+  upcast(
+    type: string,
+    schemaVersion: number,
+    data: Record<string, unknown>,
+  ): Result<AcquisitionEvent, UpcastGap> {
     const forType = this.upcasters.get(type);
-    if (forType === undefined) return data as unknown as AcquisitionEvent;
+    if (forType === undefined) return ok(data as unknown as AcquisitionEvent);
 
     let version = schemaVersion;
     let current = data;
@@ -48,7 +69,11 @@ export class UpcasterRegistry {
       current = step(current);
       version += 1;
     }
-    return current as unknown as AcquisitionEvent;
+    const unapplied = [...forType.keys()].filter((from) => from > version).sort((a, b) => a - b);
+    if (unapplied.length > 0) {
+      return err({ kind: 'UpcastGap', type, arrivedAt: version, unappliedFrom: unapplied[0]! });
+    }
+    return ok(current as unknown as AcquisitionEvent);
   }
 }
 

--- a/packages/downloader/src/adapters/sqlite/upcaster.ts
+++ b/packages/downloader/src/adapters/sqlite/upcaster.ts
@@ -21,7 +21,6 @@ export const CURRENT_SCHEMA_VERSION = 2;
 /** Transforms one on-disk event payload from version N to version N+1. */
 export type Upcaster = (data: Record<string, unknown>) => Record<string, unknown>;
 
-
 export class UpcasterRegistry {
   // event type -> (fromVersion -> upcaster that produces fromVersion + 1)
   private readonly upcasters = new Map<string, Map<number, Upcaster>>();

--- a/packages/downloader/src/adapters/sqlite/upcaster.ts
+++ b/packages/downloader/src/adapters/sqlite/upcaster.ts
@@ -1,5 +1,3 @@
-import { err, ok } from 'neverthrow';
-import type { Result } from 'neverthrow';
 import type { AcquisitionEvent } from '../../domain/acquisition/events.js';
 
 /**
@@ -23,17 +21,6 @@ export const CURRENT_SCHEMA_VERSION = 2;
 /** Transforms one on-disk event payload from version N to version N+1. */
 export type Upcaster = (data: Record<string, unknown>) => Record<string, unknown>;
 
-/**
- * A registration gap: the chain walk stopped at `arrivedAt` while a step registered from
- * `unappliedFrom` (above it) could never apply. Serving the arrived shape to `evolve` would be
- * silent corruption, so the walk refuses as a value instead.
- */
-export interface UpcastGap {
-  readonly kind: 'UpcastGap';
-  readonly type: string;
-  readonly arrivedAt: number;
-  readonly unappliedFrom: number;
-}
 
 export class UpcasterRegistry {
   // event type -> (fromVersion -> upcaster that produces fromVersion + 1)
@@ -48,36 +35,28 @@ export class UpcasterRegistry {
   }
 
   /**
-   * Apply the chain of registered upcasters from `schemaVersion` up to the latest known shape.
-   * With no upcaster registered for the type, this is a pass-through: the stored payload is
-   * declared already-current and is returned untouched. A walk that stops below a still-registered
-   * step is a registration gap — refused as a value, never served stale (absence of a step from
-   * the arrival version upward is the declaration that no shape change exists there, so a
-   * remaining higher step can only mean a hole in the chain).
+   * Apply every registered step at or above the stored version, in ascending order. The schema
+   * version is a STORE-WIDE counter, so a type's chain is expected non-contiguous — it skips the
+   * versions it did not participate in, and the absence of a step at a version IS the declaration
+   * that the type's shape did not change there. That makes this walk total: with no steps
+   * registered for the type (or none at/above the stored version — including a future writer's
+   * stamp), the payload is declared already-current and passes through untouched. The remaining
+   * authoring risk — a shape change nobody wrote a step for — is indistinguishable from
+   * no-change-by-declaration at read time; it is guarded where it can be: the contract tier
+   * replays frozen legacy fixtures through the production registry.
    */
-  upcast(
-    type: string,
-    schemaVersion: number,
-    data: Record<string, unknown>,
-  ): Result<AcquisitionEvent, UpcastGap> {
+  upcast(type: string, schemaVersion: number, data: Record<string, unknown>): AcquisitionEvent {
     const forType = this.upcasters.get(type);
-    if (forType === undefined) return ok(data as unknown as AcquisitionEvent);
+    if (forType === undefined) return data as unknown as AcquisitionEvent;
 
-    let version = schemaVersion;
-    let current = data;
-    for (let step = forType.get(version); step !== undefined; step = forType.get(version)) {
-      current = step(current);
-      version += 1;
-    }
-    const unapplied = forType
-      .keys()
-      .filter((from) => from > version)
+    const steps = forType
+      .entries()
+      .filter(([from]) => from >= schemaVersion)
       .toArray()
-      .toSorted((a, b) => a - b);
-    if (unapplied.length > 0) {
-      return err({ kind: 'UpcastGap', type, arrivedAt: version, unappliedFrom: unapplied[0]! });
-    }
-    return ok(current as unknown as AcquisitionEvent);
+      .toSorted(([a], [b]) => a - b);
+    let current = data;
+    for (const [, step] of steps) current = step(current);
+    return current as unknown as AcquisitionEvent;
   }
 }
 

--- a/packages/downloader/src/adapters/sqlite/upcaster.ts
+++ b/packages/downloader/src/adapters/sqlite/upcaster.ts
@@ -69,7 +69,11 @@ export class UpcasterRegistry {
       current = step(current);
       version += 1;
     }
-    const unapplied = [...forType.keys()].filter((from) => from > version).sort((a, b) => a - b);
+    const unapplied = forType
+      .keys()
+      .filter((from) => from > version)
+      .toArray()
+      .toSorted((a, b) => a - b);
     if (unapplied.length > 0) {
       return err({ kind: 'UpcastGap', type, arrivedAt: version, unappliedFrom: unapplied[0]! });
     }

--- a/packages/downloader/src/application/projections/read-models.ts
+++ b/packages/downloader/src/application/projections/read-models.ts
@@ -109,9 +109,10 @@ export interface AcquisitionStatusView {
   /**
    * Present (true) when the acquisition's current effect dead-lettered — its retry budget spent,
    * or a permanent fault, with no modeled failure to degrade to — awaiting an operator
-   * (reactor-durability D2). Additive: absent for every acquisition progressing normally.
+   * (reactor-durability D2). Tag-or-omit like the importer's: `true` or absent, never `false` —
+   * the join in the use-cases layer only ever adds the tag.
    */
-  readonly stalled?: boolean;
+  readonly stalled?: true;
 }
 
 /**

--- a/packages/downloader/src/composition/runtime.test.ts
+++ b/packages/downloader/src/composition/runtime.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../domain/acquisition/__fixtures__/acquisition-fixtures.js';
 import type { ProbedAudio } from '../domain/validation/validators.js';
 import type { SeamEvent, SeamFeed } from '../application/events/catch-up-subscription.js';
+import { defaultPolicies } from '../domain/acquisition/__fixtures__/acquisition-fixtures.js';
 import { createDownloaderRuntime } from './runtime.js';
 import type { DownloaderRuntime } from './runtime.js';
 
@@ -322,6 +323,53 @@ describe('createDownloaderRuntime', () => {
     const second = await testRuntime(file);
     const listed = second.facade.listAcquisitions().acquisitions;
     expect(listed.map((entry) => entry.acquisitionId)).toContain(submitted.value.acquisitionId);
+  });
+
+  it('serves a legacy v1 row upcast through the composed runtime path', async () => {
+    // The regression this pins: composition (or the store default) silently dropping the populated
+    // upcaster registry would serve raw v1 payloads at 100% unit coverage — only a boot over a
+    // legacy file proves the composed read path lifts them.
+    const directory = mkdtempSync(path.join(tmpdir(), 'runtime-'));
+    cleanups.push(() => rmSync(directory, { recursive: true, force: true }));
+    const file = path.join(directory, 'events.db');
+
+    const seeded = openEventDatabase(file);
+    const insert = seeded.prepare(
+      `INSERT INTO events (stream_id, version, type, schema_version, data, metadata)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    );
+    insert.run(
+      'acq-legacy',
+      0,
+      'AcquisitionRequested',
+      1,
+      JSON.stringify({
+        type: 'AcquisitionRequested',
+        request: SUBMIT.request,
+        policies: defaultPolicies(),
+      }),
+      JSON.stringify({ acquisitionId: 'acq-legacy', occurredAt: '2026-01-01T00:00:00.000Z' }),
+    );
+    // A v1 ManualSelectionRequested: the unknown track count stored as the sentinel 0, which the
+    // registered upcaster folds to absent before evolve ever sees it.
+    insert.run(
+      'acq-legacy',
+      1,
+      'ManualSelectionRequested',
+      1,
+      JSON.stringify({
+        type: 'ManualSelectionRequested',
+        candidates: [{ releaseMbid: 'r-1', title: 'Unknown Edition', trackCount: 0 }],
+      }),
+      JSON.stringify({ acquisitionId: 'acq-legacy', occurredAt: '2026-01-01T00:00:01.000Z' }),
+    );
+    seeded.close();
+
+    const runtime = await testRuntime(file);
+    const status = runtime.facade.getAcquisition({ id: 'acq-legacy' });
+    if (!status.ok) throw new Error('legacy acquisition not served');
+    expect(status.value.status).toBe('AwaitingManualSelection');
+    expect(status.value.candidates).toEqual([{ releaseMbid: 'r-1', title: 'Unknown Edition' }]);
   });
 
   it('constructs real adapters when no overrides are given', async () => {

--- a/packages/downloader/src/composition/runtime.test.ts
+++ b/packages/downloader/src/composition/runtime.test.ts
@@ -15,13 +15,13 @@ import { FakeDeadLetterStore, silentLogger } from '../application/__fixtures__/f
 import { createLogger } from '../application/logging/logger.js';
 import type { DownloadObserverPort, DownloadResult } from '../application/ports/outbound-ports.js';
 import {
+  defaultPolicies,
   matchingCandidate,
   requestedHistory,
   sampleTarget,
 } from '../domain/acquisition/__fixtures__/acquisition-fixtures.js';
 import type { ProbedAudio } from '../domain/validation/validators.js';
 import type { SeamEvent, SeamFeed } from '../application/events/catch-up-subscription.js';
-import { defaultPolicies } from '../domain/acquisition/__fixtures__/acquisition-fixtures.js';
 import { createDownloaderRuntime } from './runtime.js';
 import type { DownloaderRuntime } from './runtime.js';
 

--- a/packages/downloader/src/facade/schemas.test.ts
+++ b/packages/downloader/src/facade/schemas.test.ts
@@ -158,6 +158,19 @@ describe('acquisitionStatusResponseSchema', () => {
     expect(acquisitionStatusResponseSchema.parse({ ...base, stalled: true }).stalled).toBe(true);
   });
 
+  it('rejects a stalled: false the producer never emits (tag-or-omit)', () => {
+    const base = {
+      acquisitionId: 'acq-1',
+      status: 'Downloading',
+      attempts: 0,
+      rejectedCount: 0,
+      history: [],
+    };
+    expect(acquisitionStatusResponseSchema.safeParse({ ...base, stalled: false }).success).toBe(
+      false,
+    );
+  });
+
   it('accepts the additive lifecycle flags present (true/false) and absent', () => {
     const base = {
       acquisitionId: 'acq-1',

--- a/packages/downloader/src/facade/schemas.ts
+++ b/packages/downloader/src/facade/schemas.ts
@@ -269,8 +269,9 @@ export const acquisitionStatusResponseSchema = z.object({
   transferStarted: z.boolean().optional(),
   cancellable: z.boolean().optional(),
   awaitingSelection: z.boolean().optional(),
-  // Present (true) only when the acquisition dead-lettered awaiting an operator (additive).
-  stalled: z.boolean().optional(),
+  // Present (true) only when the acquisition dead-lettered awaiting an operator (additive,
+  // tag-or-omit: only ever `true` or absent — the producer joins it, never writes `false`).
+  stalled: z.literal(true).optional(),
 });
 
 export const acquisitionListResponseSchema = z.object({

--- a/packages/downloader/test/contract/events-upcast.contract.test.ts
+++ b/packages/downloader/test/contract/events-upcast.contract.test.ts
@@ -29,10 +29,9 @@ describe('ManualSelectionRequested v1 → v2 upcast (EditionCandidate.trackCount
   };
 
   function upcastFixture(): AcquisitionEvent {
-    return buildUpcasterRegistry()
-      .upcast('ManualSelectionRequested', 1, {
-        ...fixture.event,
-      });
+    return buildUpcasterRegistry().upcast('ManualSelectionRequested', 1, {
+      ...fixture.event,
+    });
   }
 
   it('drops the legacy trackCount: 0 sentinel to absent, and passes a real count through', () => {
@@ -79,10 +78,9 @@ describe('ManualSelectionRequested v1 → v2 upcast (EditionCandidate.trackCount
 
     const folded = foldEvents([
       { type: 'AcquisitionRequested', request: sampleGroupRequest, policies: defaultPolicies() },
-      buildUpcasterRegistry()
-        .upcast('ManualSelectionRequested', 2, {
-          ...v2Event,
-        } as unknown as Record<string, unknown>),
+      buildUpcasterRegistry().upcast('ManualSelectionRequested', 2, {
+        ...v2Event,
+      } as unknown as Record<string, unknown>),
     ]);
 
     expect(folded.phase).toBe('AwaitingManualSelection');

--- a/packages/downloader/test/contract/events-upcast.contract.test.ts
+++ b/packages/downloader/test/contract/events-upcast.contract.test.ts
@@ -32,8 +32,7 @@ describe('ManualSelectionRequested v1 → v2 upcast (EditionCandidate.trackCount
     return buildUpcasterRegistry()
       .upcast('ManualSelectionRequested', 1, {
         ...fixture.event,
-      })
-      ._unsafeUnwrap();
+      });
   }
 
   it('drops the legacy trackCount: 0 sentinel to absent, and passes a real count through', () => {
@@ -83,8 +82,7 @@ describe('ManualSelectionRequested v1 → v2 upcast (EditionCandidate.trackCount
       buildUpcasterRegistry()
         .upcast('ManualSelectionRequested', 2, {
           ...v2Event,
-        } as unknown as Record<string, unknown>)
-        ._unsafeUnwrap(),
+        } as unknown as Record<string, unknown>),
     ]);
 
     expect(folded.phase).toBe('AwaitingManualSelection');

--- a/packages/downloader/test/contract/events-upcast.contract.test.ts
+++ b/packages/downloader/test/contract/events-upcast.contract.test.ts
@@ -31,7 +31,7 @@ describe('ManualSelectionRequested v1 → v2 upcast (EditionCandidate.trackCount
   function upcastFixture(): AcquisitionEvent {
     return buildUpcasterRegistry().upcast('ManualSelectionRequested', 1, {
       ...fixture.event,
-    });
+    })._unsafeUnwrap();
   }
 
   it('drops the legacy trackCount: 0 sentinel to absent, and passes a real count through', () => {
@@ -80,7 +80,7 @@ describe('ManualSelectionRequested v1 → v2 upcast (EditionCandidate.trackCount
       { type: 'AcquisitionRequested', request: sampleGroupRequest, policies: defaultPolicies() },
       buildUpcasterRegistry().upcast('ManualSelectionRequested', 2, {
         ...v2Event,
-      } as unknown as Record<string, unknown>),
+      } as unknown as Record<string, unknown>)._unsafeUnwrap(),
     ]);
 
     expect(folded.phase).toBe('AwaitingManualSelection');

--- a/packages/downloader/test/contract/events-upcast.contract.test.ts
+++ b/packages/downloader/test/contract/events-upcast.contract.test.ts
@@ -29,9 +29,11 @@ describe('ManualSelectionRequested v1 → v2 upcast (EditionCandidate.trackCount
   };
 
   function upcastFixture(): AcquisitionEvent {
-    return buildUpcasterRegistry().upcast('ManualSelectionRequested', 1, {
-      ...fixture.event,
-    })._unsafeUnwrap();
+    return buildUpcasterRegistry()
+      .upcast('ManualSelectionRequested', 1, {
+        ...fixture.event,
+      })
+      ._unsafeUnwrap();
   }
 
   it('drops the legacy trackCount: 0 sentinel to absent, and passes a real count through', () => {
@@ -78,9 +80,11 @@ describe('ManualSelectionRequested v1 → v2 upcast (EditionCandidate.trackCount
 
     const folded = foldEvents([
       { type: 'AcquisitionRequested', request: sampleGroupRequest, policies: defaultPolicies() },
-      buildUpcasterRegistry().upcast('ManualSelectionRequested', 2, {
-        ...v2Event,
-      } as unknown as Record<string, unknown>)._unsafeUnwrap(),
+      buildUpcasterRegistry()
+        .upcast('ManualSelectionRequested', 2, {
+          ...v2Event,
+        } as unknown as Record<string, unknown>)
+        ._unsafeUnwrap(),
     ]);
 
     expect(folded.phase).toBe('AwaitingManualSelection');

--- a/packages/importer/src/adapters/sqlite/event-store.test.ts
+++ b/packages/importer/src/adapters/sqlite/event-store.test.ts
@@ -180,6 +180,22 @@ describe('SqliteEventStore', () => {
     expect(row.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
   });
 
+  it('surfaces an upcaster registration gap as a modeled infra error on read', async () => {
+    // Steps {current→+1, current+2→+3} leave a hole: the walk stops with a step unapplied above
+    // it. The read must refuse as an InfraError — never hand evolve a stale shape.
+    const registry = new UpcasterRegistry()
+      .register('ImportApplied', CURRENT_SCHEMA_VERSION, (data) => data)
+      .register('ImportApplied', CURRENT_SCHEMA_VERSION + 2, (data) => data);
+    const store = new SqliteEventStore(freshDatabase(), registry);
+    await store.append('imp-1', 0, [APPLIED], META);
+
+    const read = await store.readStream('imp-1');
+
+    expect(read.isErr()).toBe(true);
+    expect(read._unsafeUnwrapErr().kind).toBe('InfraError');
+    expect(read._unsafeUnwrapErr().message).toContain('upcast gap');
+  });
+
   it('upcasts stored events on read', async () => {
     // Registered at the version `append` stamps, so a freshly-stored row is lifted on read-back.
     const registry = new UpcasterRegistry().register(

--- a/packages/importer/src/adapters/sqlite/event-store.test.ts
+++ b/packages/importer/src/adapters/sqlite/event-store.test.ts
@@ -180,22 +180,6 @@ describe('SqliteEventStore', () => {
     expect(row.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
   });
 
-  it('surfaces an upcaster registration gap as a modeled infra error on read', async () => {
-    // Steps {current→+1, current+2→+3} leave a hole: the walk stops with a step unapplied above
-    // it. The read must refuse as an InfraError — never hand evolve a stale shape.
-    const registry = new UpcasterRegistry()
-      .register('ImportApplied', CURRENT_SCHEMA_VERSION, (data) => data)
-      .register('ImportApplied', CURRENT_SCHEMA_VERSION + 2, (data) => data);
-    const store = new SqliteEventStore(freshDatabase(), registry);
-    await store.append('imp-1', 0, [APPLIED], META);
-
-    const read = await store.readStream('imp-1');
-
-    expect(read.isErr()).toBe(true);
-    expect(read._unsafeUnwrapErr().kind).toBe('InfraError');
-    expect(read._unsafeUnwrapErr().message).toContain('upcast gap');
-  });
-
   it('upcasts stored events on read', async () => {
     // Registered at the version `append` stamps, so a freshly-stored row is lifted on read-back.
     const registry = new UpcasterRegistry().register(

--- a/packages/importer/src/adapters/sqlite/event-store.ts
+++ b/packages/importer/src/adapters/sqlite/event-store.ts
@@ -37,6 +37,17 @@ interface EventRow {
 /** Thrown inside the append transaction to roll it back on a version mismatch. */
 class ConcurrencyBreak extends Error {}
 
+/** Thrown inside a read's row mapping to surface an upcaster registration gap as the read's
+ * modeled InfraError (the registry itself refuses as a value; no throw escapes the port). */
+class UpcastGapBreak extends Error {
+  constructor(gap: { type: string; arrivedAt: number; unappliedFrom: number }) {
+    super(
+      `upcast gap for ${gap.type}: chain arrived at v${gap.arrivedAt} with a step still ` +
+        `registered from v${gap.unappliedFrom} — refusing to serve a stale shape`,
+    );
+  }
+}
+
 function isUniqueViolation(error: unknown): boolean {
   return (error as { code?: string }).code === 'SQLITE_CONSTRAINT_UNIQUE';
 }
@@ -155,11 +166,14 @@ export class SqliteEventStore implements EventStorePort {
       streamId: row.stream_id,
       version: row.version,
       type: row.type as ImportEventType,
-      event: this.upcasters.upcast(
-        row.type,
-        row.schema_version,
-        JSON.parse(row.data) as Record<string, unknown>,
-      ),
+      event: this.upcasters
+        .upcast(row.type, row.schema_version, JSON.parse(row.data) as Record<string, unknown>)
+        .match(
+          (event) => event,
+          (gap) => {
+            throw new UpcastGapBreak(gap);
+          },
+        ),
       metadata: JSON.parse(row.metadata) as EventMetadata,
     };
   }

--- a/packages/importer/src/adapters/sqlite/event-store.ts
+++ b/packages/importer/src/adapters/sqlite/event-store.ts
@@ -37,7 +37,6 @@ interface EventRow {
 /** Thrown inside the append transaction to roll it back on a version mismatch. */
 class ConcurrencyBreak extends Error {}
 
-
 function isUniqueViolation(error: unknown): boolean {
   return (error as { code?: string }).code === 'SQLITE_CONSTRAINT_UNIQUE';
 }

--- a/packages/importer/src/adapters/sqlite/event-store.ts
+++ b/packages/importer/src/adapters/sqlite/event-store.ts
@@ -37,16 +37,6 @@ interface EventRow {
 /** Thrown inside the append transaction to roll it back on a version mismatch. */
 class ConcurrencyBreak extends Error {}
 
-/** Thrown inside a read's row mapping to surface an upcaster registration gap as the read's
- * modeled InfraError (the registry itself refuses as a value; no throw escapes the port). */
-class UpcastGapBreak extends Error {
-  constructor(gap: { type: string; arrivedAt: number; unappliedFrom: number }) {
-    super(
-      `upcast gap for ${gap.type}: chain arrived at v${gap.arrivedAt} with a step still ` +
-        `registered from v${gap.unappliedFrom} — refusing to serve a stale shape`,
-    );
-  }
-}
 
 function isUniqueViolation(error: unknown): boolean {
   return (error as { code?: string }).code === 'SQLITE_CONSTRAINT_UNIQUE';
@@ -166,14 +156,11 @@ export class SqliteEventStore implements EventStorePort {
       streamId: row.stream_id,
       version: row.version,
       type: row.type as ImportEventType,
-      event: this.upcasters
-        .upcast(row.type, row.schema_version, JSON.parse(row.data) as Record<string, unknown>)
-        .match(
-          (event) => event,
-          (gap) => {
-            throw new UpcastGapBreak(gap);
-          },
-        ),
+      event: this.upcasters.upcast(
+        row.type,
+        row.schema_version,
+        JSON.parse(row.data) as Record<string, unknown>,
+      ),
       metadata: JSON.parse(row.metadata) as EventMetadata,
     };
   }

--- a/packages/importer/src/adapters/sqlite/upcaster.test.ts
+++ b/packages/importer/src/adapters/sqlite/upcaster.test.ts
@@ -27,12 +27,14 @@ describe('buildUpcasterRegistry', () => {
   it('lifts a v1 ReviewResolved rejection and leaves a v2 one alone', () => {
     const registry = buildUpcasterRegistry();
 
-    expect(registry.upcast('ReviewResolved', 1, legacyRejectResolvedData(['corrupt rip']))._unsafeUnwrap()).toEqual(
-      {
-        type: 'ReviewResolved',
-        resolution: { kind: 'reject-unusable-delivery', reasons: ['corrupt rip'] },
-      },
-    );
+    expect(
+      registry
+        .upcast('ReviewResolved', 1, legacyRejectResolvedData(['corrupt rip']))
+        ._unsafeUnwrap(),
+    ).toEqual({
+      type: 'ReviewResolved',
+      resolution: { kind: 'reject-unusable-delivery', reasons: ['corrupt rip'] },
+    });
 
     const v2 = {
       type: 'ReviewResolved',
@@ -74,10 +76,9 @@ describe('UpcasterRegistry', () => {
       .register('Widened', 1, (data) => ({ ...data, two: true }))
       .register('Widened', 2, (data) => ({ ...data, three: true }));
 
-    const result = registry.upcast('Widened', 1, { type: 'Widened', one: true })._unsafeUnwrap() as Record<
-      string,
-      unknown
-    >;
+    const result = registry
+      .upcast('Widened', 1, { type: 'Widened', one: true })
+      ._unsafeUnwrap() as Record<string, unknown>;
 
     expect(result).toEqual({ type: 'Widened', one: true, two: true, three: true });
   });
@@ -89,10 +90,9 @@ describe('UpcasterRegistry', () => {
     }));
 
     // Stored at version 2: no upcaster registered for v2, so it is already current.
-    const result = registry.upcast('Widened', 2, { type: 'Widened', two: true })._unsafeUnwrap() as Record<
-      string,
-      unknown
-    >;
+    const result = registry
+      .upcast('Widened', 2, { type: 'Widened', two: true })
+      ._unsafeUnwrap() as Record<string, unknown>;
 
     expect(result).toEqual({ type: 'Widened', two: true });
   });
@@ -101,8 +101,11 @@ describe('UpcasterRegistry', () => {
     // Steps {1→2, 3→4} with no 2→3: a v1 row walks to 2 and stops while a step from 3 remains
     // unapplied above it — a registration gap. Serving the v2 shape to evolve would be silent
     // corruption; the registry surfaces it as a value for the store's modeled error channel.
+    // Two unapplied steps (3 and 5) pin that the reported gap is the LOWEST unapplied step —
+    // the first hole an operator must fill.
     const registry = new UpcasterRegistry()
       .register('Widened', 1, (data) => ({ ...data, two: true }))
+      .register('Widened', 5, (data) => ({ ...data, six: true }))
       .register('Widened', 3, (data) => ({ ...data, four: true }));
 
     const result = registry.upcast('Widened', 1, { type: 'Widened', one: true });
@@ -124,10 +127,9 @@ describe('UpcasterRegistry', () => {
 
     // A newer writer stamped v5; this reader knows only a v1→v2 step. With no upcaster registered at
     // or above v5, the payload is already at-or-beyond the reader's latest shape and flows through.
-    const result = registry.upcast('Widened', 5, { type: 'Widened', future: true })._unsafeUnwrap() as Record<
-      string,
-      unknown
-    >;
+    const result = registry
+      .upcast('Widened', 5, { type: 'Widened', future: true })
+      ._unsafeUnwrap() as Record<string, unknown>;
 
     expect(result).toEqual({ type: 'Widened', future: true });
   });

--- a/packages/importer/src/adapters/sqlite/upcaster.test.ts
+++ b/packages/importer/src/adapters/sqlite/upcaster.test.ts
@@ -27,13 +27,12 @@ describe('buildUpcasterRegistry', () => {
   it('lifts a v1 ReviewResolved rejection and leaves a v2 one alone', () => {
     const registry = buildUpcasterRegistry();
 
-    expect(
-      registry
-        .upcast('ReviewResolved', 1, legacyRejectResolvedData(['corrupt rip'])),
-    ).toEqual({
-      type: 'ReviewResolved',
-      resolution: { kind: 'reject-unusable-delivery', reasons: ['corrupt rip'] },
-    });
+    expect(registry.upcast('ReviewResolved', 1, legacyRejectResolvedData(['corrupt rip']))).toEqual(
+      {
+        type: 'ReviewResolved',
+        resolution: { kind: 'reject-unusable-delivery', reasons: ['corrupt rip'] },
+      },
+    );
 
     const v2 = {
       type: 'ReviewResolved',
@@ -75,8 +74,10 @@ describe('UpcasterRegistry', () => {
       .register('Widened', 1, (data) => ({ ...data, two: true }))
       .register('Widened', 2, (data) => ({ ...data, three: true }));
 
-    const result = registry
-      .upcast('Widened', 1, { type: 'Widened', one: true }) as Record<string, unknown>;
+    const result = registry.upcast('Widened', 1, { type: 'Widened', one: true }) as Record<
+      string,
+      unknown
+    >;
 
     expect(result).toEqual({ type: 'Widened', one: true, two: true, three: true });
   });
@@ -88,8 +89,10 @@ describe('UpcasterRegistry', () => {
     }));
 
     // Stored at version 2: no upcaster registered for v2, so it is already current.
-    const result = registry
-      .upcast('Widened', 2, { type: 'Widened', two: true }) as Record<string, unknown>;
+    const result = registry.upcast('Widened', 2, { type: 'Widened', two: true }) as Record<
+      string,
+      unknown
+    >;
 
     expect(result).toEqual({ type: 'Widened', two: true });
   });
@@ -133,8 +136,10 @@ describe('UpcasterRegistry', () => {
 
     // A newer writer stamped v5; this reader knows only a v1→v2 step. With no upcaster registered at
     // or above v5, the payload is already at-or-beyond the reader's latest shape and flows through.
-    const result = registry
-      .upcast('Widened', 5, { type: 'Widened', future: true }) as Record<string, unknown>;
+    const result = registry.upcast('Widened', 5, { type: 'Widened', future: true }) as Record<
+      string,
+      unknown
+    >;
 
     expect(result).toEqual({ type: 'Widened', future: true });
   });

--- a/packages/importer/src/adapters/sqlite/upcaster.test.ts
+++ b/packages/importer/src/adapters/sqlite/upcaster.test.ts
@@ -29,8 +29,7 @@ describe('buildUpcasterRegistry', () => {
 
     expect(
       registry
-        .upcast('ReviewResolved', 1, legacyRejectResolvedData(['corrupt rip']))
-        ._unsafeUnwrap(),
+        .upcast('ReviewResolved', 1, legacyRejectResolvedData(['corrupt rip'])),
     ).toEqual({
       type: 'ReviewResolved',
       resolution: { kind: 'reject-unusable-delivery', reasons: ['corrupt rip'] },
@@ -41,7 +40,7 @@ describe('buildUpcasterRegistry', () => {
       resolution: { kind: 'reject-unusable-delivery', reasons: ['corrupt rip'] },
     };
     // Already current: returned by reference, not needlessly cloned.
-    expect(registry.upcast('ReviewResolved', CURRENT_SCHEMA_VERSION, v2)._unsafeUnwrap()).toBe(v2);
+    expect(registry.upcast('ReviewResolved', CURRENT_SCHEMA_VERSION, v2)).toBe(v2);
   });
 
   it('lifts a v1 ReviewResolved of a non-rejection kind through the wired path untouched', () => {
@@ -49,14 +48,14 @@ describe('buildUpcasterRegistry', () => {
     const v1 = { type: 'ReviewResolved', resolution: { kind: 'accept' } };
 
     // The rename only touches the rejection verb; other v1 resolutions flow through the registry.
-    expect(registry.upcast('ReviewResolved', 1, v1)._unsafeUnwrap()).toBe(v1);
+    expect(registry.upcast('ReviewResolved', 1, v1)).toBe(v1);
   });
 
   it('leaves a non-ReviewResolved type untouched', () => {
     const registry = buildUpcasterRegistry();
     const data = { type: 'ImportApplied', location: '/library/album' };
 
-    expect(registry.upcast('ImportApplied', 1, data)._unsafeUnwrap()).toBe(data);
+    expect(registry.upcast('ImportApplied', 1, data)).toBe(data);
   });
 });
 
@@ -65,7 +64,7 @@ describe('UpcasterRegistry', () => {
     const registry = new UpcasterRegistry();
     const data = { type: 'ImportApplied', location: '/library/album' };
 
-    expect(registry.upcast('ImportApplied', 1, data)._unsafeUnwrap()).toEqual({
+    expect(registry.upcast('ImportApplied', 1, data)).toEqual({
       type: 'ImportApplied',
       location: '/library/album',
     });
@@ -77,8 +76,7 @@ describe('UpcasterRegistry', () => {
       .register('Widened', 2, (data) => ({ ...data, three: true }));
 
     const result = registry
-      .upcast('Widened', 1, { type: 'Widened', one: true })
-      ._unsafeUnwrap() as Record<string, unknown>;
+      .upcast('Widened', 1, { type: 'Widened', one: true }) as Record<string, unknown>;
 
     expect(result).toEqual({ type: 'Widened', one: true, two: true, three: true });
   });
@@ -91,31 +89,39 @@ describe('UpcasterRegistry', () => {
 
     // Stored at version 2: no upcaster registered for v2, so it is already current.
     const result = registry
-      .upcast('Widened', 2, { type: 'Widened', two: true })
-      ._unsafeUnwrap() as Record<string, unknown>;
+      .upcast('Widened', 2, { type: 'Widened', two: true }) as Record<string, unknown>;
 
     expect(result).toEqual({ type: 'Widened', two: true });
   });
 
-  it('refuses a gapped chain as a value instead of serving a stale shape', () => {
-    // Steps {1→2, 3→4} with no 2→3: a v1 row walks to 2 and stops while a step from 3 remains
-    // unapplied above it — a registration gap. Serving the v2 shape to evolve would be silent
-    // corruption; the registry surfaces it as a value for the store's modeled error channel.
-    // Two unapplied steps (3 and 5) pin that the reported gap is the LOWEST unapplied step —
-    // the first hole an operator must fill.
+  it('continues across absent versions: every step at or above the stored version applies', () => {
+    // The schema version is a store-wide counter, so a type's chain is EXPECTED non-contiguous —
+    // it skips the versions it did not participate in, and the absence of a step at a version IS
+    // the declaration that the type's shape did not change there. Steps {1→2, 3→4, 5→6} with a
+    // v1 row therefore apply ALL THREE, in ascending order (registration order must not matter).
     const registry = new UpcasterRegistry()
       .register('Widened', 1, (data) => ({ ...data, two: true }))
       .register('Widened', 5, (data) => ({ ...data, six: true }))
       .register('Widened', 3, (data) => ({ ...data, four: true }));
 
-    const result = registry.upcast('Widened', 1, { type: 'Widened', one: true });
-
-    expect(result.isErr()).toBe(true);
-    expect(result._unsafeUnwrapErr()).toEqual({
-      kind: 'UpcastGap',
+    expect(registry.upcast('Widened', 1, { type: 'Widened', one: true })).toEqual({
       type: 'Widened',
-      arrivedAt: 2,
-      unappliedFrom: 3,
+      one: true,
+      two: true,
+      four: true,
+      six: true,
+    });
+  });
+
+  it('starts a non-contiguous chain at the stored version, not below it', () => {
+    // A row stored at v4 (after the 3→4 change) must not re-apply the earlier steps.
+    const registry = new UpcasterRegistry()
+      .register('Widened', 1, (data) => ({ ...data, two: true }))
+      .register('Widened', 3, (data) => ({ ...data, four: true }));
+
+    expect(registry.upcast('Widened', 4, { type: 'Widened', four: true })).toEqual({
+      type: 'Widened',
+      four: true,
     });
   });
 
@@ -128,8 +134,7 @@ describe('UpcasterRegistry', () => {
     // A newer writer stamped v5; this reader knows only a v1→v2 step. With no upcaster registered at
     // or above v5, the payload is already at-or-beyond the reader's latest shape and flows through.
     const result = registry
-      .upcast('Widened', 5, { type: 'Widened', future: true })
-      ._unsafeUnwrap() as Record<string, unknown>;
+      .upcast('Widened', 5, { type: 'Widened', future: true }) as Record<string, unknown>;
 
     expect(result).toEqual({ type: 'Widened', future: true });
   });

--- a/packages/importer/src/adapters/sqlite/upcaster.test.ts
+++ b/packages/importer/src/adapters/sqlite/upcaster.test.ts
@@ -27,7 +27,7 @@ describe('buildUpcasterRegistry', () => {
   it('lifts a v1 ReviewResolved rejection and leaves a v2 one alone', () => {
     const registry = buildUpcasterRegistry();
 
-    expect(registry.upcast('ReviewResolved', 1, legacyRejectResolvedData(['corrupt rip']))).toEqual(
+    expect(registry.upcast('ReviewResolved', 1, legacyRejectResolvedData(['corrupt rip']))._unsafeUnwrap()).toEqual(
       {
         type: 'ReviewResolved',
         resolution: { kind: 'reject-unusable-delivery', reasons: ['corrupt rip'] },
@@ -39,7 +39,7 @@ describe('buildUpcasterRegistry', () => {
       resolution: { kind: 'reject-unusable-delivery', reasons: ['corrupt rip'] },
     };
     // Already current: returned by reference, not needlessly cloned.
-    expect(registry.upcast('ReviewResolved', CURRENT_SCHEMA_VERSION, v2)).toBe(v2);
+    expect(registry.upcast('ReviewResolved', CURRENT_SCHEMA_VERSION, v2)._unsafeUnwrap()).toBe(v2);
   });
 
   it('lifts a v1 ReviewResolved of a non-rejection kind through the wired path untouched', () => {
@@ -47,14 +47,14 @@ describe('buildUpcasterRegistry', () => {
     const v1 = { type: 'ReviewResolved', resolution: { kind: 'accept' } };
 
     // The rename only touches the rejection verb; other v1 resolutions flow through the registry.
-    expect(registry.upcast('ReviewResolved', 1, v1)).toBe(v1);
+    expect(registry.upcast('ReviewResolved', 1, v1)._unsafeUnwrap()).toBe(v1);
   });
 
   it('leaves a non-ReviewResolved type untouched', () => {
     const registry = buildUpcasterRegistry();
     const data = { type: 'ImportApplied', location: '/library/album' };
 
-    expect(registry.upcast('ImportApplied', 1, data)).toBe(data);
+    expect(registry.upcast('ImportApplied', 1, data)._unsafeUnwrap()).toBe(data);
   });
 });
 
@@ -63,7 +63,7 @@ describe('UpcasterRegistry', () => {
     const registry = new UpcasterRegistry();
     const data = { type: 'ImportApplied', location: '/library/album' };
 
-    expect(registry.upcast('ImportApplied', 1, data)).toEqual({
+    expect(registry.upcast('ImportApplied', 1, data)._unsafeUnwrap()).toEqual({
       type: 'ImportApplied',
       location: '/library/album',
     });
@@ -74,7 +74,7 @@ describe('UpcasterRegistry', () => {
       .register('Widened', 1, (data) => ({ ...data, two: true }))
       .register('Widened', 2, (data) => ({ ...data, three: true }));
 
-    const result = registry.upcast('Widened', 1, { type: 'Widened', one: true }) as Record<
+    const result = registry.upcast('Widened', 1, { type: 'Widened', one: true })._unsafeUnwrap() as Record<
       string,
       unknown
     >;
@@ -89,12 +89,31 @@ describe('UpcasterRegistry', () => {
     }));
 
     // Stored at version 2: no upcaster registered for v2, so it is already current.
-    const result = registry.upcast('Widened', 2, { type: 'Widened', two: true }) as Record<
+    const result = registry.upcast('Widened', 2, { type: 'Widened', two: true })._unsafeUnwrap() as Record<
       string,
       unknown
     >;
 
     expect(result).toEqual({ type: 'Widened', two: true });
+  });
+
+  it('refuses a gapped chain as a value instead of serving a stale shape', () => {
+    // Steps {1→2, 3→4} with no 2→3: a v1 row walks to 2 and stops while a step from 3 remains
+    // unapplied above it — a registration gap. Serving the v2 shape to evolve would be silent
+    // corruption; the registry surfaces it as a value for the store's modeled error channel.
+    const registry = new UpcasterRegistry()
+      .register('Widened', 1, (data) => ({ ...data, two: true }))
+      .register('Widened', 3, (data) => ({ ...data, four: true }));
+
+    const result = registry.upcast('Widened', 1, { type: 'Widened', one: true });
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toEqual({
+      kind: 'UpcastGap',
+      type: 'Widened',
+      arrivedAt: 2,
+      unappliedFrom: 3,
+    });
   });
 
   it('passes a future/unknown schema version through untouched (forward compatibility)', () => {
@@ -105,7 +124,7 @@ describe('UpcasterRegistry', () => {
 
     // A newer writer stamped v5; this reader knows only a v1→v2 step. With no upcaster registered at
     // or above v5, the payload is already at-or-beyond the reader's latest shape and flows through.
-    const result = registry.upcast('Widened', 5, { type: 'Widened', future: true }) as Record<
+    const result = registry.upcast('Widened', 5, { type: 'Widened', future: true })._unsafeUnwrap() as Record<
       string,
       unknown
     >;

--- a/packages/importer/src/adapters/sqlite/upcaster.ts
+++ b/packages/importer/src/adapters/sqlite/upcaster.ts
@@ -1,3 +1,5 @@
+import { err, ok } from 'neverthrow';
+import type { Result } from 'neverthrow';
 import type { ImportEvent } from '../../domain/import/events.js';
 
 /**
@@ -14,6 +16,18 @@ export const CURRENT_SCHEMA_VERSION = 2;
 /** Transforms one on-disk event payload from version N to version N+1. */
 export type Upcaster = (data: Record<string, unknown>) => Record<string, unknown>;
 
+/**
+ * A registration gap: the chain walk stopped at `arrivedAt` while a step registered from
+ * `unappliedFrom` (above it) could never apply. Serving the arrived shape to `evolve` would be
+ * silent corruption, so the walk refuses as a value instead.
+ */
+export interface UpcastGap {
+  readonly kind: 'UpcastGap';
+  readonly type: string;
+  readonly arrivedAt: number;
+  readonly unappliedFrom: number;
+}
+
 export class UpcasterRegistry {
   // event type -> (fromVersion -> upcaster that produces fromVersion + 1)
   private readonly upcasters = new Map<string, Map<number, Upcaster>>();
@@ -28,12 +42,19 @@ export class UpcasterRegistry {
 
   /**
    * Apply the chain of registered upcasters from `schemaVersion` up to the latest known shape.
-   * With nothing registered (the MVP), this is a pass-through: the stored payload is already
-   * current and is returned untouched.
+   * With nothing registered for the type, this is a pass-through: the stored payload is declared
+   * already-current and is returned untouched. A walk that stops below a still-registered step is
+   * a registration gap — refused as a value, never served stale (absence of a step from the
+   * arrival version upward is the declaration that no shape change exists there, so a remaining
+   * higher step can only mean a hole in the chain).
    */
-  upcast(type: string, schemaVersion: number, data: Record<string, unknown>): ImportEvent {
+  upcast(
+    type: string,
+    schemaVersion: number,
+    data: Record<string, unknown>,
+  ): Result<ImportEvent, UpcastGap> {
     const forType = this.upcasters.get(type);
-    if (forType === undefined) return data as unknown as ImportEvent;
+    if (forType === undefined) return ok(data as unknown as ImportEvent);
 
     let version = schemaVersion;
     let current = data;
@@ -41,7 +62,11 @@ export class UpcasterRegistry {
       current = step(current);
       version += 1;
     }
-    return current as unknown as ImportEvent;
+    const unapplied = [...forType.keys()].filter((from) => from > version).sort((a, b) => a - b);
+    if (unapplied.length > 0) {
+      return err({ kind: 'UpcastGap', type, arrivedAt: version, unappliedFrom: unapplied[0]! });
+    }
+    return ok(current as unknown as ImportEvent);
   }
 }
 

--- a/packages/importer/src/adapters/sqlite/upcaster.ts
+++ b/packages/importer/src/adapters/sqlite/upcaster.ts
@@ -62,7 +62,11 @@ export class UpcasterRegistry {
       current = step(current);
       version += 1;
     }
-    const unapplied = [...forType.keys()].filter((from) => from > version).sort((a, b) => a - b);
+    const unapplied = forType
+      .keys()
+      .filter((from) => from > version)
+      .toArray()
+      .toSorted((a, b) => a - b);
     if (unapplied.length > 0) {
       return err({ kind: 'UpcastGap', type, arrivedAt: version, unappliedFrom: unapplied[0]! });
     }

--- a/packages/importer/src/adapters/sqlite/upcaster.ts
+++ b/packages/importer/src/adapters/sqlite/upcaster.ts
@@ -1,5 +1,3 @@
-import { err, ok } from 'neverthrow';
-import type { Result } from 'neverthrow';
 import type { ImportEvent } from '../../domain/import/events.js';
 
 /**
@@ -16,17 +14,6 @@ export const CURRENT_SCHEMA_VERSION = 2;
 /** Transforms one on-disk event payload from version N to version N+1. */
 export type Upcaster = (data: Record<string, unknown>) => Record<string, unknown>;
 
-/**
- * A registration gap: the chain walk stopped at `arrivedAt` while a step registered from
- * `unappliedFrom` (above it) could never apply. Serving the arrived shape to `evolve` would be
- * silent corruption, so the walk refuses as a value instead.
- */
-export interface UpcastGap {
-  readonly kind: 'UpcastGap';
-  readonly type: string;
-  readonly arrivedAt: number;
-  readonly unappliedFrom: number;
-}
 
 export class UpcasterRegistry {
   // event type -> (fromVersion -> upcaster that produces fromVersion + 1)
@@ -41,36 +28,28 @@ export class UpcasterRegistry {
   }
 
   /**
-   * Apply the chain of registered upcasters from `schemaVersion` up to the latest known shape.
-   * With nothing registered for the type, this is a pass-through: the stored payload is declared
-   * already-current and is returned untouched. A walk that stops below a still-registered step is
-   * a registration gap — refused as a value, never served stale (absence of a step from the
-   * arrival version upward is the declaration that no shape change exists there, so a remaining
-   * higher step can only mean a hole in the chain).
+   * Apply every registered step at or above the stored version, in ascending order. The schema
+   * version is a STORE-WIDE counter, so a type's chain is expected non-contiguous — it skips the
+   * versions it did not participate in, and the absence of a step at a version IS the declaration
+   * that the type's shape did not change there. That makes this walk total: with no steps
+   * registered for the type (or none at/above the stored version — including a future writer's
+   * stamp), the payload is declared already-current and passes through untouched. The remaining
+   * authoring risk — a shape change nobody wrote a step for — is indistinguishable from
+   * no-change-by-declaration at read time; it is guarded where it can be: the contract tier
+   * replays frozen legacy fixtures through the production registry.
    */
-  upcast(
-    type: string,
-    schemaVersion: number,
-    data: Record<string, unknown>,
-  ): Result<ImportEvent, UpcastGap> {
+  upcast(type: string, schemaVersion: number, data: Record<string, unknown>): ImportEvent {
     const forType = this.upcasters.get(type);
-    if (forType === undefined) return ok(data as unknown as ImportEvent);
+    if (forType === undefined) return data as unknown as ImportEvent;
 
-    let version = schemaVersion;
-    let current = data;
-    for (let step = forType.get(version); step !== undefined; step = forType.get(version)) {
-      current = step(current);
-      version += 1;
-    }
-    const unapplied = forType
-      .keys()
-      .filter((from) => from > version)
+    const steps = forType
+      .entries()
+      .filter(([from]) => from >= schemaVersion)
       .toArray()
-      .toSorted((a, b) => a - b);
-    if (unapplied.length > 0) {
-      return err({ kind: 'UpcastGap', type, arrivedAt: version, unappliedFrom: unapplied[0]! });
-    }
-    return ok(current as unknown as ImportEvent);
+      .toSorted(([a], [b]) => a - b);
+    let current = data;
+    for (const [, step] of steps) current = step(current);
+    return current as unknown as ImportEvent;
   }
 }
 

--- a/packages/importer/src/adapters/sqlite/upcaster.ts
+++ b/packages/importer/src/adapters/sqlite/upcaster.ts
@@ -14,7 +14,6 @@ export const CURRENT_SCHEMA_VERSION = 2;
 /** Transforms one on-disk event payload from version N to version N+1. */
 export type Upcaster = (data: Record<string, unknown>) => Record<string, unknown>;
 
-
 export class UpcasterRegistry {
   // event type -> (fromVersion -> upcaster that produces fromVersion + 1)
   private readonly upcasters = new Map<string, Map<number, Upcaster>>();

--- a/packages/importer/src/facade/mapping.test.ts
+++ b/packages/importer/src/facade/mapping.test.ts
@@ -242,8 +242,16 @@ describe('statusViewToDto / pendingReviewToDto', () => {
         reasons: ['unusable'],
       },
     ]);
-    // The wire copy is a fresh projection, never the projection's own objects.
-    expect(dto.history[7]).not.toBe(history[7]);
+  });
+
+  it('projects fresh wire objects, never the projection\u2019s own', () => {
+    const entry: ImportStatusView['history'][number] = {
+      kind: 'remediation-required',
+      at: 't',
+      failures: [FAILURE],
+    };
+    const dto = statusViewToDto({ ...view, history: [entry] });
+    expect(dto.history[0]).not.toBe(entry);
   });
 
   it('cannot leak a domain-only history field onto the wire', () => {

--- a/packages/importer/src/facade/mapping.test.ts
+++ b/packages/importer/src/facade/mapping.test.ts
@@ -244,7 +244,7 @@ describe('statusViewToDto / pendingReviewToDto', () => {
     ]);
   });
 
-  it('projects fresh wire objects, never the projection\u2019s own', () => {
+  it('projects fresh wire objects, never the projection\u{2019}s own', () => {
     const entry: ImportStatusView['history'][number] = {
       kind: 'remediation-required',
       at: 't',
@@ -284,14 +284,18 @@ describe('statusViewToDto / pendingReviewToDto', () => {
 
     const dto = statusViewToDto({ ...view, history: [hintsEntry, failuresEntry] });
 
-    expect(dto.history[0]).toEqual({ kind: 'requested', at: 't1', hints: { artist: 'a', album: 'b' } });
+    expect(dto.history[0]).toEqual({
+      kind: 'requested',
+      at: 't1',
+      hints: { artist: 'a', album: 'b' },
+    });
     expect((dto.history[0] as { hints?: object }).hints).not.toHaveProperty(
       'projectionOnlyHintField',
     );
     expect(dto.history[1]).toEqual({ kind: 'remediation-required', at: 't2', failures: [FAILURE] });
-    expect(
-      (dto.history[1] as { failures: object[] }).failures[0],
-    ).not.toHaveProperty('projectionOnlyFailureField');
+    expect((dto.history[1] as { failures: object[] }).failures[0]).not.toHaveProperty(
+      'projectionOnlyFailureField',
+    );
   });
 
   it('maps a status view carrying an open review', () => {

--- a/packages/importer/src/facade/mapping.test.ts
+++ b/packages/importer/src/facade/mapping.test.ts
@@ -260,6 +260,32 @@ describe('statusViewToDto / pendingReviewToDto', () => {
     expect(dto.history[0]).not.toHaveProperty('projectionOnlyDebugField');
   });
 
+  it('cannot leak a domain-only field from a nested history payload onto the wire', () => {
+    // The leaf level is pinned too: hints and failure elements are explicit field projections,
+    // not spreads, so a future projection-only field inside them cannot ship either.
+    const hintsEntry = {
+      kind: 'requested',
+      at: 't1',
+      hints: { artist: 'a', album: 'b', projectionOnlyHintField: 'must-not-ship' },
+    } as unknown as ImportStatusView['history'][number];
+    const failuresEntry = {
+      kind: 'remediation-required',
+      at: 't2',
+      failures: [{ ...FAILURE, projectionOnlyFailureField: 'must-not-ship' }],
+    } as unknown as ImportStatusView['history'][number];
+
+    const dto = statusViewToDto({ ...view, history: [hintsEntry, failuresEntry] });
+
+    expect(dto.history[0]).toEqual({ kind: 'requested', at: 't1', hints: { artist: 'a', album: 'b' } });
+    expect((dto.history[0] as { hints?: object }).hints).not.toHaveProperty(
+      'projectionOnlyHintField',
+    );
+    expect(dto.history[1]).toEqual({ kind: 'remediation-required', at: 't2', failures: [FAILURE] });
+    expect(
+      (dto.history[1] as { failures: object[] }).failures[0],
+    ).not.toHaveProperty('projectionOnlyFailureField');
+  });
+
   it('maps a status view carrying an open review', () => {
     const withReview: ImportStatusView = {
       importId: toImportId('imp-2'),

--- a/packages/importer/src/facade/mapping.test.ts
+++ b/packages/importer/src/facade/mapping.test.ts
@@ -10,6 +10,7 @@ import type {
   PendingReviewView,
 } from '../application/projections/read-models.js';
 import { asDistance } from '../domain/shared/__fixtures__/distance.js';
+import { toAcquisitionId } from '../domain/shared/acquisition-id.js';
 import { toImportId } from '../domain/shared/import-id.js';
 import {
   hintsToDomain,
@@ -193,6 +194,70 @@ describe('statusViewToDto / pendingReviewToDto', () => {
 
   it('omits the acquisition id for a manually-submitted import', () => {
     expect(statusViewToDto({ ...view, acquisitionId: undefined }).acquisitionId).toBeUndefined();
+  });
+
+  it('projects every history kind onto the wire as its exact schema shape', () => {
+    const history: ImportStatusView['history'] = [
+      { kind: 'requested', at: 't1', hints: { artist: 'a', album: 'b' } },
+      { kind: 'requested', at: 't2' },
+      { kind: 'proposed', at: 't3', candidateCount: 2, pinnedId: 'mb-1' },
+      {
+        kind: 'auto-apply-selected',
+        at: 't4',
+        candidate: { dataSource: 'musicbrainz', albumId: 'alb-1' },
+        distance: 0.01,
+      },
+      { kind: 'review-required', at: 't5', reviewKind: 'match-review' },
+      { kind: 'review-resolved', at: 't6', resolution: 'apply-candidate' },
+      { kind: 'applied', at: 't7', location: '/library/x' },
+      { kind: 'remediation-required', at: 't8', failures: [FAILURE] },
+      { kind: 'rejected', at: 't9', reason: 'r', filesDeleted: false },
+      {
+        kind: 'release-verdict-recorded',
+        at: 't10',
+        acquisitionId: toAcquisitionId('acq-9'),
+        reasons: ['unusable'],
+      },
+    ];
+    const dto = statusViewToDto({ ...view, history });
+    expect(dto.history).toEqual([
+      { kind: 'requested', at: 't1', hints: { artist: 'a', album: 'b' } },
+      { kind: 'requested', at: 't2', hints: undefined },
+      { kind: 'proposed', at: 't3', candidateCount: 2, pinnedId: 'mb-1' },
+      {
+        kind: 'auto-apply-selected',
+        at: 't4',
+        candidate: { dataSource: 'musicbrainz', albumId: 'alb-1' },
+        distance: 0.01,
+      },
+      { kind: 'review-required', at: 't5', reviewKind: 'match-review' },
+      { kind: 'review-resolved', at: 't6', resolution: 'apply-candidate' },
+      { kind: 'applied', at: 't7', location: '/library/x' },
+      { kind: 'remediation-required', at: 't8', failures: [FAILURE] },
+      { kind: 'rejected', at: 't9', reason: 'r', filesDeleted: false },
+      {
+        kind: 'release-verdict-recorded',
+        at: 't10',
+        acquisitionId: 'acq-9',
+        reasons: ['unusable'],
+      },
+    ]);
+    // The wire copy is a fresh projection, never the projection's own objects.
+    expect(dto.history[7]).not.toBe(history[7]);
+  });
+
+  it('cannot leak a domain-only history field onto the wire', () => {
+    // Simulate a future projection-only field the wire schema does not know: an explicit per-kind
+    // projection must drop it, where a spread would leak it into every consumer's payload.
+    const entry = {
+      kind: 'applied',
+      at: 't',
+      location: '/library/x',
+      projectionOnlyDebugField: 'must-not-ship',
+    } as unknown as ImportStatusView['history'][number];
+    const dto = statusViewToDto({ ...view, history: [entry] });
+    expect(dto.history[0]).toEqual({ kind: 'applied', at: 't', location: '/library/x' });
+    expect(dto.history[0]).not.toHaveProperty('projectionOnlyDebugField');
   });
 
   it('maps a status view carrying an open review', () => {

--- a/packages/importer/src/facade/mapping.ts
+++ b/packages/importer/src/facade/mapping.ts
@@ -152,7 +152,12 @@ function historyEntryToDto(
       };
     }
     case 'proposed': {
-      return { kind: 'proposed', at, candidateCount: entry.candidateCount, pinnedId: entry.pinnedId };
+      return {
+        kind: 'proposed',
+        at,
+        candidateCount: entry.candidateCount,
+        pinnedId: entry.pinnedId,
+      };
     }
     case 'auto-apply-selected': {
       return {

--- a/packages/importer/src/facade/mapping.ts
+++ b/packages/importer/src/facade/mapping.ts
@@ -148,7 +148,14 @@ function historyEntryToDto(
       return {
         kind: 'requested',
         at,
-        hints: entry.hints === undefined ? undefined : { ...entry.hints },
+        hints:
+          entry.hints === undefined
+            ? undefined
+            : {
+                mbReleaseId: entry.hints.mbReleaseId,
+                artist: entry.hints.artist,
+                album: entry.hints.album,
+              },
       };
     }
     case 'proposed': {
@@ -180,7 +187,10 @@ function historyEntryToDto(
       return {
         kind: 'remediation-required',
         at,
-        failures: entry.failures.map((failure) => ({ ...failure })),
+        failures: entry.failures.map((failure) => ({
+          stage: failure.stage,
+          message: failure.message,
+        })),
       };
     }
     case 'rejected': {

--- a/packages/importer/src/facade/mapping.ts
+++ b/packages/importer/src/facade/mapping.ts
@@ -134,6 +134,64 @@ export function reviewToDto(review: OpenReview): ReviewDto {
   }
 }
 
+/**
+ * The history entry projected onto the wire as an explicit per-kind field projection — never a
+ * spread, so a future projection-only field cannot leak into a consumer's payload (the
+ * anti-corruption copy is real). The domain's branded acquisition id decays to its string here.
+ */
+function historyEntryToDto(
+  entry: ImportStatusView['history'][number],
+): ImportStatusResponseDto['history'][number] {
+  const at = entry.at;
+  switch (entry.kind) {
+    case 'requested': {
+      return {
+        kind: 'requested',
+        at,
+        hints: entry.hints === undefined ? undefined : { ...entry.hints },
+      };
+    }
+    case 'proposed': {
+      return { kind: 'proposed', at, candidateCount: entry.candidateCount, pinnedId: entry.pinnedId };
+    }
+    case 'auto-apply-selected': {
+      return {
+        kind: 'auto-apply-selected',
+        at,
+        candidate: { dataSource: entry.candidate.dataSource, albumId: entry.candidate.albumId },
+        distance: entry.distance,
+      };
+    }
+    case 'review-required': {
+      return { kind: 'review-required', at, reviewKind: entry.reviewKind };
+    }
+    case 'review-resolved': {
+      return { kind: 'review-resolved', at, resolution: entry.resolution };
+    }
+    case 'applied': {
+      return { kind: 'applied', at, location: entry.location };
+    }
+    case 'remediation-required': {
+      return {
+        kind: 'remediation-required',
+        at,
+        failures: entry.failures.map((failure) => ({ ...failure })),
+      };
+    }
+    case 'rejected': {
+      return { kind: 'rejected', at, reason: entry.reason, filesDeleted: entry.filesDeleted };
+    }
+    case 'release-verdict-recorded': {
+      return {
+        kind: 'release-verdict-recorded',
+        at,
+        acquisitionId: entry.acquisitionId,
+        reasons: [...entry.reasons],
+      };
+    }
+  }
+}
+
 export function statusViewToDto(view: ImportStatusView): ImportStatusResponseDto {
   return {
     importId: view.importId,
@@ -145,9 +203,7 @@ export function statusViewToDto(view: ImportStatusView): ImportStatusResponseDto
     rejection: view.rejection === undefined ? undefined : { ...view.rejection },
     settled: view.settled,
     stalled: view.stalled,
-    history: view.history.map(
-      (entry) => ({ ...entry }) as ImportStatusResponseDto['history'][number],
-    ),
+    history: view.history.map((entry) => historyEntryToDto(entry)),
   };
 }
 

--- a/packages/importer/test/contract/events-fold.contract.test.ts
+++ b/packages/importer/test/contract/events-fold.contract.test.ts
@@ -36,7 +36,7 @@ const FIXTURE_DIR = new URL('./fixtures/events/', import.meta.url).pathname;
 
 function upcastFixture(type: string, relative: string): ImportEvent {
   const fixture = readJson(join(FIXTURE_DIR, relative)) as { event: Record<string, unknown> };
-  return buildUpcasterRegistry().upcast(type, 1, fixture.event)._unsafeUnwrap();
+  return buildUpcasterRegistry().upcast(type, 1, fixture.event);
 }
 
 describe('ReviewRequired match-review legacy fold (best now required)', () => {

--- a/packages/importer/test/contract/events-fold.contract.test.ts
+++ b/packages/importer/test/contract/events-fold.contract.test.ts
@@ -4,19 +4,28 @@ import { describe, expect, it } from 'vitest';
 import type { ImportEvent } from '../../src/domain/import/events.js';
 import { foldEvents } from '../../src/domain/import/state.js';
 import {
+  MATCH_REVIEW,
   candidate,
   proposed,
   requested,
 } from '../../src/domain/import/__fixtures__/import-fixtures.js';
-import { UpcasterRegistry } from '../../src/adapters/sqlite/upcaster.js';
+import { buildUpcasterRegistry } from '../../src/adapters/sqlite/upcaster.js';
 
 /**
- * Schema-evolution contract: `ReviewCause` `match-review.best` was tightened from optional to
- * required. That is only safe because every stored `match-review` event has always carried `best`
- * (the decider reaches match-review solely for a non-empty candidate list; the empty case routes to
- * `no-match`). No upcaster/version bump is needed — the on-disk bytes are already valid under the
- * required type. This test proves the frozen v1 shape still folds through the (pass-through) read
- * path to the correct review state; if it fails, the tightening broke legacy history.
+ * Schema-evolution contracts, replayed through the PRODUCTION upcaster registry — the same
+ * `buildUpcasterRegistry()` composition wires into the store — so this tier fails if the
+ * registry ever stops lifting a frozen on-disk shape (an empty registry here would prove
+ * nothing: it would pass while production data rotted).
+ *
+ * Case 1 (`review.required/v1.json`): `ReviewCause` `match-review.best` was tightened from
+ * optional to required. That is only safe because every stored `match-review` event has always
+ * carried `best` (the decider reaches match-review solely for a non-empty candidate list; the
+ * empty case routes to `no-match`). No upcaster is registered for it — the registry must pass
+ * the frozen v1 bytes through as already-current, and they must fold to the correct state.
+ *
+ * Case 2 (`review.resolved/v1.json`): the resolution verb rename (`reject-and-retry-download`
+ * → `reject-unusable-delivery`). The frozen v1 bytes carry the old token; the registry's
+ * v1→v2 step must rewrite it before the pure domain ever sees it.
  */
 
 function readJson(path: string): unknown {
@@ -25,18 +34,14 @@ function readJson(path: string): unknown {
 
 const FIXTURE_DIR = new URL('./fixtures/events/', import.meta.url).pathname;
 
-describe('ReviewRequired match-review legacy fold (best now required)', () => {
-  const fixture = readJson(join(FIXTURE_DIR, 'review.required/v1.json')) as {
-    event: Record<string, unknown>;
-  };
+function upcastFixture(type: string, relative: string): ImportEvent {
+  const fixture = readJson(join(FIXTURE_DIR, relative)) as { event: Record<string, unknown> };
+  return buildUpcasterRegistry().upcast(type, 1, fixture.event)._unsafeUnwrap();
+}
 
+describe('ReviewRequired match-review legacy fold (best now required)', () => {
   it('folds a legacy stored match-review event to awaiting-review with best present', () => {
-    // The importer read path stamps no upcaster (MVP pass-through); the stored bytes are cast as-is.
-    const reviewEvent = new UpcasterRegistry().upcast(
-      'ReviewRequired',
-      1,
-      fixture.event,
-    ) as ImportEvent;
+    const reviewEvent = upcastFixture('ReviewRequired', 'review.required/v1.json');
 
     const history: readonly ImportEvent[] = [
       requested({ hints: { mbReleaseId: 'mb-release-1' } }),
@@ -51,5 +56,35 @@ describe('ReviewRequired match-review legacy fold (best now required)', () => {
     expect(state.cause.kind).toBe('match-review');
     if (state.cause.kind !== 'match-review') throw new Error('unreachable');
     expect(state.cause.best).toEqual({ dataSource: 'MusicBrainz', albumId: 'album-1' });
+  });
+});
+
+describe('ReviewResolved v1 → v2 upcast (resolution verb rename)', () => {
+  it('lifts the frozen pre-rename verb through the production registry before the fold', () => {
+    const resolvedEvent = upcastFixture('ReviewResolved', 'review.resolved/v1.json');
+
+    if (resolvedEvent.type !== 'ReviewResolved') throw new Error('wrong event type');
+    expect(resolvedEvent.resolution).toEqual({
+      kind: 'reject-unusable-delivery',
+      reasons: ['corrupt rip', 'wrong pressing'],
+    });
+  });
+
+  it('folds the upcast legacy resolution to a pending rejection in the importer language', () => {
+    const history: readonly ImportEvent[] = [
+      requested(),
+      proposed([candidate()]),
+      MATCH_REVIEW,
+      upcastFixture('ReviewResolved', 'review.resolved/v1.json'),
+    ];
+
+    const state = foldEvents(history);
+
+    expect(state.phase).toBe('awaiting-review');
+    if (state.phase !== 'awaiting-review') throw new Error('unreachable');
+    expect(state.settled).toEqual({
+      kind: 'reject-unusable-delivery',
+      reasons: ['corrupt rip', 'wrong pressing'],
+    });
   });
 });

--- a/packages/importer/test/contract/fixtures/events/review.resolved/v1.json
+++ b/packages/importer/test/contract/fixtures/events/review.resolved/v1.json
@@ -1,0 +1,14 @@
+{
+  "provenance": {
+    "recordedAt": "2026-07-23T00:00:00.000Z",
+    "schemaVersion": 1,
+    "note": "The v1 on-disk shape of an internal ReviewResolved event. Under v1 the rejection-of-a-bad-delivery resolution was stored under the downloader's action verb (reject-and-retry-download) before the importer's own-language rename to reject-unusable-delivery. FROZEN — never regenerate; the upcaster must fold this shape forever."
+  },
+  "event": {
+    "type": "ReviewResolved",
+    "resolution": {
+      "kind": "reject-and-retry-download",
+      "reasons": ["corrupt rip", "wrong pressing"]
+    }
+  }
+}

--- a/packages/web/src/lib/acquisitions.test.ts
+++ b/packages/web/src/lib/acquisitions.test.ts
@@ -33,6 +33,12 @@ describe('isTransferStarted', () => {
 });
 
 describe('statusTone', () => {
+  it('degrades an unknown future status to the neutral pending tone', () => {
+    // Simulates wire evolution ahead of this build (the copy layer's as-never idiom): the tone
+    // must degrade honestly, never render undefined into the badge channel.
+    expect(statusTone('BrandNewStatus' as never)).toBe('pending');
+  });
+
   // The tone table stays a presentation mapping the web layer owns — exhaustive on purpose.
   it.each([
     ['Empty', 'pending'],

--- a/packages/web/src/lib/acquisitions.test.ts
+++ b/packages/web/src/lib/acquisitions.test.ts
@@ -39,6 +39,12 @@ describe('statusTone', () => {
     expect(statusTone('BrandNewStatus' as never)).toBe('pending');
   });
 
+  it('degrades Object.prototype key names like any unknown status', () => {
+    // 'toString' would resolve an inherited function from a plain record lookup; the degrade arm
+    // must treat prototype keys as unknown data, not members.
+    expect(statusTone('toString' as never)).toBe('pending');
+  });
+
   // The tone table stays a presentation mapping the web layer owns — exhaustive on purpose.
   it.each([
     ['Empty', 'pending'],

--- a/packages/web/src/lib/acquisitions.ts
+++ b/packages/web/src/lib/acquisitions.ts
@@ -29,7 +29,9 @@ const TONE = {
 } as const satisfies Record<AcquisitionStatusResponseDto['status'], BadgePhase>;
 
 export function statusTone(status: AcquisitionStatusResponseDto['status']): BadgePhase {
-  return TONE[status];
+  // Dual regime: the table is compile-total above, and this lookup still degrades honestly to the
+  // neutral tone for a status this build cannot know (wire evolution ahead of the page).
+  return (TONE as Partial<Record<string, BadgePhase>>)[status] ?? 'pending';
 }
 
 /**

--- a/packages/web/src/lib/acquisitions.ts
+++ b/packages/web/src/lib/acquisitions.ts
@@ -31,7 +31,8 @@ const TONE = {
 export function statusTone(status: AcquisitionStatusResponseDto['status']): BadgePhase {
   // Dual regime: the table is compile-total above, and this lookup still degrades honestly to the
   // neutral tone for a status this build cannot know (wire evolution ahead of the page).
-  return (TONE as Partial<Record<string, BadgePhase>>)[status] ?? 'pending';
+  // Object.hasOwn: prototype key names are unknown data, never inherited members.
+  return Object.hasOwn(TONE, status) ? TONE[status] : 'pending';
 }
 
 /**

--- a/packages/web/src/lib/attention.test.ts
+++ b/packages/web/src/lib/attention.test.ts
@@ -37,6 +37,17 @@ function item(over: Partial<AttentionItem>): AttentionItem {
 }
 
 describe('attentionItems', () => {
+  it('keeps the module channel honest for an unknown future review kind', () => {
+    // A review kind this build does not know still came from the importer's pending-review read,
+    // so the machine-readable module attribute stays factual while the kind passes through raw.
+    const composed = attentionItems(
+      [review({ review: { kind: 'brand-new-review' as never } })],
+      [],
+    )[0]!;
+    expect(composed.module).toBe('importer');
+    expect(composed.kind).toBe('brand-new-review');
+  });
+
   it('maps a pending review to an item whose ask names the decision, titled by its basename', () => {
     expect(attentionItems([review({})], [])).toEqual([
       {

--- a/packages/web/src/lib/attention.test.ts
+++ b/packages/web/src/lib/attention.test.ts
@@ -48,6 +48,11 @@ describe('attentionItems', () => {
     expect(composed.kind).toBe('brand-new-review');
   });
 
+  it('treats an Object.prototype key name as an unknown review kind', () => {
+    const composed = attentionItems([review({ review: { kind: 'toString' as never } })], [])[0]!;
+    expect(composed.module).toBe('importer');
+  });
+
   it('maps a pending review to an item whose ask names the decision, titled by its basename', () => {
     expect(attentionItems([review({})], [])).toEqual([
       {

--- a/packages/web/src/lib/attention.ts
+++ b/packages/web/src/lib/attention.ts
@@ -57,9 +57,9 @@ function reviewItem(pending: PendingReviewDto, composedTitle: string | undefined
   return {
     // Structurally importer-owned: this item was composed from the importer's pending-review
     // read, so an unknown future kind keeps a factual module channel instead of breaking it.
-    module:
-      (MODULE_OF as Partial<Record<string, AttentionItem['module']>>)[pending.review.kind] ??
-      'importer',
+    module: Object.hasOwn(MODULE_OF, pending.review.kind)
+      ? MODULE_OF[pending.review.kind as keyof typeof MODULE_OF]
+      : 'importer',
     kind: pending.review.kind,
     id: pending.importId,
     // Musical intent first, then the staged basename, then the neutral phrase — sparse

--- a/packages/web/src/lib/attention.ts
+++ b/packages/web/src/lib/attention.ts
@@ -55,7 +55,9 @@ export function attentionItems(
 
 function reviewItem(pending: PendingReviewDto, composedTitle: string | undefined): AttentionItem {
   return {
-    module: MODULE_OF[pending.review.kind],
+    // Structurally importer-owned: this item was composed from the importer's pending-review
+    // read, so an unknown future kind keeps a factual module channel instead of breaking it.
+    module: (MODULE_OF as Partial<Record<string, AttentionItem['module']>>)[pending.review.kind] ?? 'importer',
     kind: pending.review.kind,
     id: pending.importId,
     // Musical intent first, then the staged basename, then the neutral phrase — sparse

--- a/packages/web/src/lib/attention.ts
+++ b/packages/web/src/lib/attention.ts
@@ -57,7 +57,9 @@ function reviewItem(pending: PendingReviewDto, composedTitle: string | undefined
   return {
     // Structurally importer-owned: this item was composed from the importer's pending-review
     // read, so an unknown future kind keeps a factual module channel instead of breaking it.
-    module: (MODULE_OF as Partial<Record<string, AttentionItem['module']>>)[pending.review.kind] ?? 'importer',
+    module:
+      (MODULE_OF as Partial<Record<string, AttentionItem['module']>>)[pending.review.kind] ??
+      'importer',
     kind: pending.review.kind,
     id: pending.importId,
     // Musical intent first, then the staged basename, then the neutral phrase — sparse

--- a/packages/web/src/lib/components/ResolveForms.ssr.test.ts
+++ b/packages/web/src/lib/components/ResolveForms.ssr.test.ts
@@ -3,18 +3,20 @@ import { describe, expect, it } from 'vitest';
 import ResolveForms from './ResolveForms.svelte';
 
 const ALL_ON = {
-  supplyId: true,
-  refresh: true,
-  importAsIs: true,
-  reject: true,
-  rejectUnusable: true,
-  accept: true,
-  retryEnrichment: true,
+  actions: new Set([
+    'supply-id',
+    'refresh-candidates',
+    'import-as-is',
+    'reject',
+    'reject-unusable-delivery',
+    'accept',
+    'retry-enrichment',
+  ]),
 };
 
 describe('ResolveForms (SSR)', () => {
   it('renders nothing when no verb is enabled', () => {
-    const { body } = render(ResolveForms, { props: {} });
+    const { body } = render(ResolveForms, { props: { actions: new Set<string>() } });
     for (const id of [
       'supply-id',
       'refresh',
@@ -70,7 +72,7 @@ describe('ResolveForms (SSR)', () => {
   });
 
   it('opens the release-ID form behind an ellipsis summary and never names the matcher', () => {
-    const { body } = render(ResolveForms, { props: { supplyId: true } });
+    const { body } = render(ResolveForms, { props: { actions: new Set(['supply-id']) } });
     expect(body).toContain('Supply a release ID…');
     expect(body).toContain('Search with this release ID');
     expect(body).toContain('from any connected source');

--- a/packages/web/src/lib/components/ResolveForms.ssr.test.ts
+++ b/packages/web/src/lib/components/ResolveForms.ssr.test.ts
@@ -1,18 +1,10 @@
 import { render } from 'svelte/server';
 import { describe, expect, it } from 'vitest';
+import { RESOLUTION_ACTIONS } from '$lib/resolution-actions.js';
 import ResolveForms from './ResolveForms.svelte';
 
-const ALL_ON = {
-  actions: new Set([
-    'supply-id',
-    'refresh-candidates',
-    'import-as-is',
-    'reject',
-    'reject-unusable-delivery',
-    'accept',
-    'retry-enrichment',
-  ]),
-};
+// Derived from the verb inventory, so a new verb exercises this suite without a hand-edit.
+const ALL_ON = { actions: new Set(Object.keys(RESOLUTION_ACTIONS)) };
 
 describe('ResolveForms (SSR)', () => {
   it('renders nothing when no verb is enabled', () => {

--- a/packages/web/src/lib/components/ResolveForms.svelte
+++ b/packages/web/src/lib/components/ResolveForms.svelte
@@ -23,14 +23,14 @@
     'manual-tags': 'ManualTagsForm',
   } as const satisfies Record<ResolutionVerb, string>;
 
-  const offered = (verb: keyof typeof VERB_HOME): boolean => actions.has(verb);
+  const isOffered = (verb: keyof typeof VERB_HOME): boolean => actions.has(verb);
 </script>
 
 <!-- Labels come from the verb inventory (reviews-register-alignment D1): imperative fragments, em-dash consequences
      stating the composed contract, no parenthesized asides. The two file-deleting verbs render
      low-emphasis danger — visible up front, confirmed in-page after submit (reviews-register-alignment D5). -->
 
-{#if offered('supply-id')}
+{#if isOffered('supply-id')}
   <details data-testid="supply-id">
     <summary>Supply a release ID…</summary>
     <form method="POST" action="?/resolve">
@@ -44,35 +44,35 @@
   </details>
 {/if}
 
-{#if offered('refresh-candidates')}
+{#if isOffered('refresh-candidates')}
   <form method="POST" action="?/resolve" data-testid="refresh">
     <input type="hidden" name="verb" value="refresh-candidates" />
     <button type="submit">{actionButtonText('refresh-candidates')}</button>
   </form>
 {/if}
 
-{#if offered('import-as-is')}
+{#if isOffered('import-as-is')}
   <form method="POST" action="?/resolve" data-testid="import-as-is">
     <input type="hidden" name="verb" value="import-as-is" />
     <button type="submit">{actionButtonText('import-as-is')}</button>
   </form>
 {/if}
 
-{#if offered('accept')}
+{#if isOffered('accept')}
   <form method="POST" action="?/resolve" data-testid="accept">
     <input type="hidden" name="verb" value="accept" />
     <button type="submit">{actionButtonText('accept')}</button>
   </form>
 {/if}
 
-{#if offered('retry-enrichment')}
+{#if isOffered('retry-enrichment')}
   <form method="POST" action="?/resolve" data-testid="retry-enrichment">
     <input type="hidden" name="verb" value="retry-enrichment" />
     <button type="submit">{actionButtonText('retry-enrichment')}</button>
   </form>
 {/if}
 
-{#if offered('reject')}
+{#if isOffered('reject')}
   <form method="POST" action="?/resolve" data-testid="reject">
     <input type="hidden" name="verb" value="reject" />
     <label>Reason (optional) <input name="reason" /></label>
@@ -80,7 +80,7 @@
   </form>
 {/if}
 
-{#if offered('reject-unusable-delivery')}
+{#if isOffered('reject-unusable-delivery')}
   <form method="POST" action="?/resolve" data-testid="reject-unusable">
     <input type="hidden" name="verb" value="reject-unusable-delivery" />
     <label>

--- a/packages/web/src/lib/components/ResolveForms.svelte
+++ b/packages/web/src/lib/components/ResolveForms.svelte
@@ -1,32 +1,36 @@
 <script lang="ts">
-  import { actionButtonText } from '$lib/resolution-actions.js';
+  import { actionButtonText, type ResolutionVerb } from '$lib/resolution-actions.js';
 
   interface Properties {
-    supplyId?: boolean;
-    refresh?: boolean;
-    importAsIs?: boolean;
-    reject?: boolean;
-    rejectUnusable?: boolean;
-    accept?: boolean;
-    retryEnrichment?: boolean;
+    /** The importer's decided verb set, passed through — membership is never re-derived here. */
+    actions: ReadonlySet<string>;
   }
 
-  let {
-    supplyId = false,
-    refresh = false,
-    importAsIs = false,
-    reject = false,
-    rejectUnusable = false,
-    accept = false,
-    retryEnrichment = false,
-  }: Properties = $props();
+  let { actions }: Properties = $props();
+
+  // Compile totality over the verb inventory's union: a new importer verb fails the build here
+  // until it is given a rendering home — either a form below, or one of the two components named
+  // for the verbs this one deliberately does not render.
+  const VERB_HOME = {
+    'supply-id': 'form below',
+    'refresh-candidates': 'form below',
+    'import-as-is': 'form below',
+    accept: 'form below',
+    'retry-enrichment': 'form below',
+    reject: 'form below',
+    'reject-unusable-delivery': 'form below',
+    'apply-candidate': 'CandidateTable',
+    'manual-tags': 'ManualTagsForm',
+  } as const satisfies Record<ResolutionVerb, string>;
+
+  const offered = (verb: keyof typeof VERB_HOME): boolean => actions.has(verb);
 </script>
 
 <!-- Labels come from the verb inventory (reviews-register-alignment D1): imperative fragments, em-dash consequences
      stating the composed contract, no parenthesized asides. The two file-deleting verbs render
      low-emphasis danger — visible up front, confirmed in-page after submit (reviews-register-alignment D5). -->
 
-{#if supplyId}
+{#if offered('supply-id')}
   <details data-testid="supply-id">
     <summary>Supply a release ID…</summary>
     <form method="POST" action="?/resolve">
@@ -40,35 +44,35 @@
   </details>
 {/if}
 
-{#if refresh}
+{#if offered('refresh-candidates')}
   <form method="POST" action="?/resolve" data-testid="refresh">
     <input type="hidden" name="verb" value="refresh-candidates" />
     <button type="submit">{actionButtonText('refresh-candidates')}</button>
   </form>
 {/if}
 
-{#if importAsIs}
+{#if offered('import-as-is')}
   <form method="POST" action="?/resolve" data-testid="import-as-is">
     <input type="hidden" name="verb" value="import-as-is" />
     <button type="submit">{actionButtonText('import-as-is')}</button>
   </form>
 {/if}
 
-{#if accept}
+{#if offered('accept')}
   <form method="POST" action="?/resolve" data-testid="accept">
     <input type="hidden" name="verb" value="accept" />
     <button type="submit">{actionButtonText('accept')}</button>
   </form>
 {/if}
 
-{#if retryEnrichment}
+{#if offered('retry-enrichment')}
   <form method="POST" action="?/resolve" data-testid="retry-enrichment">
     <input type="hidden" name="verb" value="retry-enrichment" />
     <button type="submit">{actionButtonText('retry-enrichment')}</button>
   </form>
 {/if}
 
-{#if reject}
+{#if offered('reject')}
   <form method="POST" action="?/resolve" data-testid="reject">
     <input type="hidden" name="verb" value="reject" />
     <label>Reason (optional) <input name="reason" /></label>
@@ -76,7 +80,7 @@
   </form>
 {/if}
 
-{#if rejectUnusable}
+{#if offered('reject-unusable-delivery')}
   <form method="POST" action="?/resolve" data-testid="reject-unusable">
     <input type="hidden" name="verb" value="reject-unusable-delivery" />
     <label>

--- a/packages/web/src/lib/components/ReviewDetail.svelte
+++ b/packages/web/src/lib/components/ReviewDetail.svelte
@@ -116,15 +116,7 @@
 {/if}
 
 {#if confirm === undefined}
-  <ResolveForms
-    supplyId={actions.has('supply-id')}
-    refresh={actions.has('refresh-candidates')}
-    importAsIs={actions.has('import-as-is')}
-    reject={actions.has('reject')}
-    rejectUnusable={actions.has('reject-unusable-delivery')}
-    accept={actions.has('accept')}
-    retryEnrichment={actions.has('retry-enrichment')}
-  />
+  <ResolveForms {actions} />
   {#if actions.has('manual-tags')}
     <ManualTagsForm />
   {/if}

--- a/packages/web/src/lib/copy.test.ts
+++ b/packages/web/src/lib/copy.test.ts
@@ -476,6 +476,12 @@ describe('metaSummary', () => {
 });
 
 describe('statusPhrase', () => {
+  it('degrades an unknown future status to an honest cannot-describe phrase', () => {
+    expect(statusPhrase('BrandNewStatus' as never)).toBe(
+      'This page can\u{2019}t describe this step yet',
+    );
+  });
+
   it('phrases every status humanly, with terminal failures free of enum identifiers', () => {
     expect(statusPhrase('Validating')).toBe('Checking quality');
     expect(statusPhrase('MetadataFailed')).toBe('Couldn’t identify the release');

--- a/packages/web/src/lib/copy.test.ts
+++ b/packages/web/src/lib/copy.test.ts
@@ -482,6 +482,10 @@ describe('statusPhrase', () => {
     );
   });
 
+  it('degrades Object.prototype key names like any unknown status', () => {
+    expect(statusPhrase('toString' as never)).toBe('This page can\u{2019}t describe this step yet');
+  });
+
   it('phrases every status humanly, with terminal failures free of enum identifiers', () => {
     expect(statusPhrase('Validating')).toBe('Checking quality');
     expect(statusPhrase('MetadataFailed')).toBe('Couldn’t identify the release');

--- a/packages/web/src/lib/copy.ts
+++ b/packages/web/src/lib/copy.ts
@@ -373,7 +373,12 @@ const STATUS_PHRASE: Readonly<Record<AcquisitionStatusResponseDto['status'], str
 
 /** The human phrase for a downloader status on its own (the queue list, which has no import read). */
 export function statusPhrase(status: AcquisitionStatusResponseDto['status']): string {
-  return STATUS_PHRASE[status];
+  // Dual regime: STATUS_PHRASE is compile-total, and the lookup still degrades honestly for a
+  // status this build cannot know — never the literal text "undefined" in the narrator's voice.
+  return (
+    (STATUS_PHRASE as Partial<Record<string, string>>)[status] ??
+    'This page can\u{2019}t describe this step yet'
+  );
 }
 
 /**
@@ -424,7 +429,7 @@ export function overallStatus(
       }
     }
   }
-  return { tone: statusTone(acquisition.status), phrase: STATUS_PHRASE[acquisition.status] };
+  return { tone: statusTone(acquisition.status), phrase: statusPhrase(acquisition.status) };
 }
 
 /** Correctly-pluralized counters with zero-count segments omitted (legible-acquisition-history D9). */

--- a/packages/web/src/lib/copy.ts
+++ b/packages/web/src/lib/copy.ts
@@ -79,7 +79,9 @@ const RESOLUTION_GLOSS: Record<string, string> = Object.fromEntries(
 );
 
 function glossOf(map: Record<string, string>, code: string): string | undefined {
-  return (map as Partial<Record<string, string>>)[code];
+  // Object.hasOwn: an unknown code degrades to undefined, and a prototype key name must not
+  // resolve an inherited member into visible copy.
+  return Object.hasOwn(map, code) ? map[code] : undefined;
 }
 
 /** The auto-apply distance inverted to a whole match percentage (extends the v3.8.0 gloss). */
@@ -375,10 +377,10 @@ const STATUS_PHRASE: Readonly<Record<AcquisitionStatusResponseDto['status'], str
 export function statusPhrase(status: AcquisitionStatusResponseDto['status']): string {
   // Dual regime: STATUS_PHRASE is compile-total, and the lookup still degrades honestly for a
   // status this build cannot know — never the literal text "undefined" in the narrator's voice.
-  return (
-    (STATUS_PHRASE as Partial<Record<string, string>>)[status] ??
-    'This page can\u{2019}t describe this step yet'
-  );
+  // Object.hasOwn: prototype key names are unknown data, never inherited members.
+  return Object.hasOwn(STATUS_PHRASE, status)
+    ? STATUS_PHRASE[status]
+    : 'This page can\u{2019}t describe this step yet';
 }
 
 /**

--- a/packages/web/src/lib/server/facade-errors.test.ts
+++ b/packages/web/src/lib/server/facade-errors.test.ts
@@ -76,13 +76,15 @@ describe('messageOf', () => {
     ['NoOpenReview', 'already been settled'],
     ['InvalidResolution', 'Invalid resolution'],
     ['UnknownCandidate', 'Unknown candidate'],
-    ['NoRetainedCandidate', 'retained candidate'],
+    ['NoRetainedCandidate', 'tracked download'],
     ['ConcurrencyConflict', 'reload'],
     ['InfraError', 'Something went wrong'],
   ] as const)('renders the importer %s error as a human message', (kind, needle) => {
     const message = messageOf(importerErrors.find((entry) => entry.kind === kind)!);
     expect(message).toMatch(/\S/);
     expect(message).toContain(needle);
+    // One-voice register: user-visible error copy never names a module or architecture noun.
+    expect(message).not.toMatch(/downloader|importer/i);
   });
 
   it('carries actionable detail through', () => {

--- a/packages/web/src/lib/server/facade-errors.ts
+++ b/packages/web/src/lib/server/facade-errors.ts
@@ -69,7 +69,9 @@ export function messageOf(error: FacadeError): string {
       return `Unknown edition: ${error.releaseMbid}. It is not among the offered candidates — reload and choose from the list.`;
     }
     case 'NoRetainedCandidate': {
-      return 'This import did not arrive from the downloader with a retained candidate, so a download retry cannot be requested. Plain reject is still available.';
+      // One-voice register: no module nouns in user-visible copy; the refusal is deterministic
+      // (no retained candidate ⇒ the verb is refused), so it is stated plainly, not hedged.
+      return 'These files didn\u{2019}t come from a tracked download, so rejecting them can\u{2019}t resume a search for a replacement. A plain reject is still available.';
     }
     case 'ConcurrencyConflict': {
       return 'The record changed while you were working - reload and try again.';

--- a/packages/web/src/lib/server/forms.test.ts
+++ b/packages/web/src/lib/server/forms.test.ts
@@ -76,6 +76,15 @@ describe('submitAcquisitionForm', () => {
 });
 
 describe('resolveReviewForm', () => {
+  it('passes hostile prototype-key verbs through untouched for the facade to refuse', () => {
+    // A hand-crafted POST can name any string as the verb. Keys inherited from Object.prototype
+    // must not resolve to functions (or throw, for __proto__) — they are unknown verbs like any
+    // other and fall through to the bare pass-through the facade's zod boundary refuses.
+    for (const hostile of ['__proto__', 'toString', 'constructor', 'hasOwnProperty']) {
+      expect(resolveReviewForm(form({ verb: hostile }))).toEqual({ verb: hostile });
+    }
+  });
+
   it('shapes apply-candidate with an optional duplicate action', () => {
     const dto = resolveReviewForm(
       form({

--- a/packages/web/src/lib/server/forms.ts
+++ b/packages/web/src/lib/server/forms.ts
@@ -1,4 +1,4 @@
-import type { SubmitAcquisitionRequestDto } from '@music/downloader';
+import type { ResolutionVerb } from '$lib/resolution-actions.js';
 
 /**
  * Form-data translation: flat HTML form fields into the facades' nested wire DTOs. Deliberately
@@ -45,9 +45,12 @@ export function submitAcquisitionForm(data: FormData): unknown {
     .map((s) => s.trim())
     .filter((s) => s !== '');
 
-  const dto: SubmitAcquisitionRequestDto = {
-    request: request as SubmitAcquisitionRequestDto['request'],
-    qualityPolicy: compact({ order, floor: text(data, 'qualityFloor') }) as never,
+  // Built as a plain unknown record (the resolveReviewForm shape): the facade's zod boundary is
+  // the validator, and impersonating the DTO type here would silence the compile pressure a DTO
+  // shape change should exert on this reshaper.
+  const dto: Record<string, unknown> = {
+    request,
+    qualityPolicy: compact({ order, floor: text(data, 'qualityFloor') }),
     matchPolicy: compact({ threshold: number_(data, 'matchThreshold') }),
     retryPolicy: compact({
       maxSearchRounds: number_(data, 'maxSearchRounds'),
@@ -71,46 +74,55 @@ export function submitFormValues(data: FormData): Record<string, string> {
   return values;
 }
 
+/** Reshapes one verb's per-verb form fields into its resolution payload. */
+type VerbReshaper = (verb: string, data: FormData) => unknown;
+
+const noPayload: VerbReshaper = (verb) => ({ verb });
+
+/**
+ * One reshaper per known verb, `satisfies`-proven total over the importer's verb union: a new
+ * wire verb without an entry here is a compile error, not a silently payload-less POST. Unknown
+ * verb strings (a stale form, a hand-crafted POST) fall through to a bare pass-through for the
+ * facade to refuse — the same dual regime as the copy layer's gloss maps.
+ */
+const VERB_RESHAPERS = {
+  'apply-candidate': (verb, data) =>
+    compactResolution({
+      verb,
+      candidate: { dataSource: text(data, 'dataSource'), albumId: text(data, 'albumId') },
+      duplicateAction: text(data, 'duplicateAction'),
+    }),
+  'supply-id': (verb, data) => compactResolution({ verb, mbReleaseId: text(data, 'mbReleaseId') }),
+  'manual-tags': (verb, data) =>
+    compactResolution({
+      verb,
+      tags: {
+        albumArtist: text(data, 'albumArtist'),
+        album: text(data, 'album'),
+        year: number_(data, 'year'),
+        tracks: manualTracks(data),
+      },
+    }),
+  reject: (verb, data) => compactResolution({ verb, reason: text(data, 'reason') }),
+  'reject-unusable-delivery': (verb, data) => {
+    const reasons = text(data, 'reasons')
+      ?.split('\n')
+      .map((s) => s.trim())
+      .filter((s) => s !== '');
+    return compactResolution({ verb, reasons });
+  },
+  'refresh-candidates': noPayload,
+  'import-as-is': noPayload,
+  accept: noPayload,
+  'retry-enrichment': noPayload,
+} satisfies Record<ResolutionVerb, VerbReshaper>;
+
 /** The review resolution form: a `verb` field plus per-verb fields, reshaped to the union. */
 export function resolveReviewForm(data: FormData): unknown {
   const verb = text(data, 'verb');
-  switch (verb) {
-    case 'apply-candidate': {
-      return compactResolution({
-        verb,
-        candidate: { dataSource: text(data, 'dataSource'), albumId: text(data, 'albumId') },
-        duplicateAction: text(data, 'duplicateAction'),
-      });
-    }
-    case 'supply-id': {
-      return compactResolution({ verb, mbReleaseId: text(data, 'mbReleaseId') });
-    }
-    case 'manual-tags': {
-      return compactResolution({
-        verb,
-        tags: {
-          albumArtist: text(data, 'albumArtist'),
-          album: text(data, 'album'),
-          year: number_(data, 'year'),
-          tracks: manualTracks(data),
-        },
-      });
-    }
-    case 'reject': {
-      return compactResolution({ verb, reason: text(data, 'reason') });
-    }
-    case 'reject-unusable-delivery': {
-      const reasons = text(data, 'reasons')
-        ?.split('\n')
-        .map((s) => s.trim())
-        .filter((s) => s !== '');
-      return compactResolution({ verb, reasons });
-    }
-    // The remaining verbs carry no payload; unknown verbs pass through for the facade to refuse.
-    default: {
-      return { verb };
-    }
-  }
+  if (verb === undefined) return { verb };
+  const reshape = (VERB_RESHAPERS as Partial<Record<string, VerbReshaper>>)[verb];
+  return reshape === undefined ? { verb } : reshape(verb, data);
 }
 
 function manualTracks(data: FormData): unknown[] {

--- a/packages/web/src/lib/server/forms.ts
+++ b/packages/web/src/lib/server/forms.ts
@@ -82,8 +82,9 @@ const noPayload: VerbReshaper = (verb) => ({ verb });
 /**
  * One reshaper per known verb, `satisfies`-proven total over the importer's verb union: a new
  * wire verb without an entry here is a compile error, not a silently payload-less POST. Unknown
- * verb strings (a stale form, a hand-crafted POST) fall through to a bare pass-through for the
- * facade to refuse — the same dual regime as the copy layer's gloss maps.
+ * verb strings (a stale form, a hand-crafted POST — including Object.prototype key names, which
+ * the `Object.hasOwn` guard keeps from resolving inherited members) fall through to a bare
+ * pass-through for the facade to refuse — the same dual regime as the copy layer's gloss maps.
  */
 const VERB_RESHAPERS = {
   'apply-candidate': (verb, data) =>
@@ -120,9 +121,8 @@ const VERB_RESHAPERS = {
 /** The review resolution form: a `verb` field plus per-verb fields, reshaped to the union. */
 export function resolveReviewForm(data: FormData): unknown {
   const verb = text(data, 'verb');
-  if (verb === undefined) return { verb };
-  const reshape = (VERB_RESHAPERS as Partial<Record<string, VerbReshaper>>)[verb];
-  return reshape === undefined ? { verb } : reshape(verb, data);
+  if (verb === undefined || !Object.hasOwn(VERB_RESHAPERS, verb)) return { verb };
+  return VERB_RESHAPERS[verb as keyof typeof VERB_RESHAPERS](verb, data);
 }
 
 function manualTracks(data: FormData): unknown[] {

--- a/packages/web/src/routes/reviews/[id]/page.server.test.ts
+++ b/packages/web/src/routes/reviews/[id]/page.server.test.ts
@@ -177,6 +177,6 @@ describe('resolve action', () => {
       eventFor({ resolveReview }, { verb: 'reject-unusable-delivery', confirmed: 'true' }),
     )) as { status: number; data: { message: string } };
     expect(result.status).toBe(409);
-    expect(result.data.message).toContain('Plain reject is still available');
+    expect(result.data.message).toContain('A plain reject is still available');
   });
 });

--- a/packages/web/src/routes/reviews/[id]/page.server.test.ts
+++ b/packages/web/src/routes/reviews/[id]/page.server.test.ts
@@ -138,6 +138,17 @@ describe('resolve action', () => {
     });
   });
 
+  it('refuses a __proto__ verb as a modeled 400, never a thrown 500', async () => {
+    // The hostile-POST shape: Object.prototype key names must behave exactly like any unknown
+    // verb — reshaped to a bare pass-through the facade refuses — not crash the action.
+    const resolveReview = vi
+      .fn()
+      .mockResolvedValue({ ok: false, error: { kind: 'ValidationFailed', detail: 'bad verb' } });
+    const result = await actions.resolve!(eventFor({ resolveReview }, { verb: '__proto__' }));
+    expect(resolveReview).toHaveBeenCalledWith({ id: 'imp-1', resolution: { verb: '__proto__' } });
+    expect(result).toMatchObject({ status: 400 });
+  });
+
   it('treats a missing verb as non-destructive and lets the facade refuse it', async () => {
     const resolveReview = vi.fn().mockResolvedValue({ ok: false, error: { kind: 'Validation' } });
     await actions.resolve!(eventFor({ resolveReview }, {}));


### PR DESCRIPTION
The S2 batch from the 2026-08-05 whole-project review sweep: every type-seam and upcaster-integrity finding, fixed red-first, plus the three-agent review pass over this PR itself. Releases as **3.16.2** (patch).

## Findings → fixes (original batch)

| # | Finding (review agent) | Fix |
|---|---|---|
| 1 | Importer facade history mapping was a spread + `as`-cast passthrough — the one type-level bypass on a DTO boundary (type-design + type-altitude, found independently) | Exhaustive per-kind `historyEntryToDto` mirroring the downloader's, down to the leaf level (hints, failure elements); leak-proof pinned at both levels; the branded `AcquisitionId` decays to its wire string implicitly via assignment (the same shape the `importId` field always used) |
| 2 | Downloader wire `stalled: z.boolean().optional()` admitted a never-emitted `false` | `z.literal(true).optional()` (importer parity); view type tightened to `?: true` |
| 3 | Downloader `SqliteEventStore` defaulted to an **empty** upcaster registry — a wiring slip silently skips every upcast (SOLID + test-coverage) | Defaults to `buildUpcasterRegistry()`; empty registry is now an explicit test-only opt-out |
| 4 | No runtime-level pin that legacy rows upcast through the composed path | Composed-runtime test boots over a file seeded with a v1 `ManualSelectionRequested` row |
| 5 | Importer contract tier replayed through an empty registry; v1 `ReviewResolved` existed only as a synthetic builder | Replays through the production `buildUpcasterRegistry()`; frozen `review.resolved/v1.json` fixture (downloader pattern) |
| 6 | Upcast chain integrity | The walk now applies every registered step at or above the stored version in ascending order — **sound under the store-wide version counter**, where per-type chains are expected non-contiguous (see review round below); guarded by the contract tier's production-registry replays |
| 7 | `forms.ts` impersonated the DTO with `as`/`as never`, silencing compile pressure | Plain unknown record, `resolveReviewForm`'s shape |
| 8 | A future importer verb compiled clean but silently shipped payload-less and never rendered an affordance (SOLID OCP) | Verb reshapers are a `satisfies Record<ResolutionVerb, …>` table; `ResolveForms` takes the decided `actions` set with a `VERB_HOME` totality witness. Known limitation, recorded: the `satisfies` pressure forces a new verb to be *named* with a home, but cannot force the corresponding `{#if}` block to exist — the SSR suite (now inventory-derived) is the runtime backstop |
| 9 | `MODULE_OF`/`TONE`/`STATUS_PHRASE` lookups rendered `undefined` for unknown wire values | Dual regime: compile-total tables + honest, prototype-safe runtime degrade arms |
| 10 | `NoRetainedCandidate` copy named a module in user-visible text (bounded-context) | Reworded in the one-voice register; register test bans module nouns across all importer error messages |

## Review round on this PR (three-agent pass)

- **Critical:** the verb-reshaper table resolved `Object.prototype` keys — `verb=__proto__` threw (uncaught 500), `verb=toString` handed the facade a function. `Object.hasOwn` guard; pinned at the reshaper and the route (modeled 400).
- **Important:** the first-shipped `UpcastGap` predicate was unsound under the store-wide version counter (a legitimate `{1→2, 3→4}` registry would false-positive on legacy rows and wedge the catch-up feed). Reworked to the total ascending walk; the never-err Result plumbing was reverted rather than kept as a lie; far-future forward-compat pin mirrored into the downloader.
- **Important:** the same prototype hole in the three new degrade arms + the pre-existing `glossOf` — `Object.hasOwn` at all four.
- **Important:** two leaf-level spreads survived in the exhaustive mapping — explicit field projection + leaf leak tests.
- Lows: inventory-derived SSR fixture, split identity assertion, folded duplicate import.

## Verification

- `pnpm check` green (parallelized gate, post-rebase onto current main; 100% coverage without waivers)
- Local out-of-process e2e: **green, all phases**, re-run after the review fixes and again after the trunk rebase
- TDD red-first per item, visible in commit order

🤖 Generated with [Claude Code](https://claude.com/claude-code)