### PR TITLE
build: parallelize the pnpm check gate and cache its tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ __pycache__/
 *.pyc
 .coverage
 packages/importer/test/bridge/.venv/
+
+# TypeScript incremental-build state
+*.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Hard rules. A change that violates one is wrong regardless of anything else:
 
 ## Commands
 
-- `pnpm check` — the full gate: format → lint → typecheck → build → test w/ coverage. Every commit must pass it.
+- `pnpm check` — the full gate: format, lint, typecheck, build, and all test tiers, fanned out as parallel fail-fast lanes (`scripts/check.sh`; `pnpm check:serial` runs the same lanes one at a time). Every commit must pass it.
 - `pnpm test` / `pnpm test:watch` / `pnpm test:cov` — unit + integration (vitest).
 - `pnpm test:e2e` — out-of-process E2E against a live slskd (`test/e2e/run.sh`).
 - `pnpm format:write` — apply prettier fixes.

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "node": ">=24.0.0"
   },
   "scripts": {
-    "build": "tsc -p packages/downloader/tsconfig.build.json && tsc -p packages/importer/tsconfig.build.json && pnpm --dir packages/web run build",
+    "build": "tsc --noCheck -p packages/downloader/tsconfig.build.json && tsc --noCheck -p packages/importer/tsconfig.build.json && pnpm --dir packages/web run build",
     "typecheck": "tsc --noEmit -p packages/downloader/tsconfig.json && tsc --noEmit -p packages/importer/tsconfig.json && pnpm --dir packages/web run check:svelte",
-    "lint": "eslint .",
-    "format": "prettier --check .",
+    "lint": "eslint --cache --cache-location node_modules/.cache/eslint/ --cache-strategy content .",
+    "format": "prettier --check --cache .",
     "format:write": "prettier --write .",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -23,7 +23,8 @@
     "test:e2e": "bash test/e2e/run.sh",
     "contracts:events": "tsx packages/downloader/scripts/contracts/generate-event-schemas.ts && tsx packages/importer/scripts/contracts/generate-event-schemas.ts",
     "version:prep": "tsx scripts/release/version-prep.ts",
-    "check": "pnpm run format && pnpm run lint && pnpm run typecheck && pnpm run build && pnpm run test:cov && pnpm run test:contract && pnpm run test:release && pnpm run test:bridge",
+    "check": "bash scripts/check.sh",
+    "check:serial": "bash scripts/check.sh --serial",
     "test:e2e:web": "pnpm --dir packages/web exec playwright test",
     "dev": "pnpm --dir packages/web dev"
   },

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# The commit gate (`pnpm check`). One lane list, two modes:
+#   default   — all lanes fan out in parallel; every lane must pass, first failure kills the
+#               rest (fail-fast) and prints its buffered output.
+#   --serial  — the same lanes one at a time in display order, output streamed live. This is
+#               the debugging/CI-reproduction mode; the lane list is defined only here.
+#
+# Lane independence notes (parallel mode):
+#   • Package exports point at `src/`, so no lane consumes another lane's build output.
+#   • `check:svelte` and the web vite build both (re)generate `.svelte-kit/` — they share the
+#     single `web` lane so nothing races on that directory. The web vitest projects use the
+#     plain svelte plugin (no svelte-kit sync), so the test lane never touches it.
+#   • The two tsc typecheck lanes and two tsc build lanes use distinct tsconfigs and therefore
+#     distinct .tsbuildinfo files; they never contend.
+#
+# CI (`pipeline.yml`) runs the underlying pnpm scripts individually and cold — this script is
+# the local loop's ergonomics, not a change to what the gate means.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+MODE=parallel
+if [[ "${1:-}" == "--serial" ]]; then
+  MODE=serial
+elif [[ $# -gt 0 ]]; then
+  echo "usage: check.sh [--serial]" >&2
+  exit 2
+fi
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[0;33m'
+BOLD=$'\033[1m'
+RESET=$'\033[0m'
+
+# Lane order here is display order (and execution order in --serial mode). Commands mirror
+# package.json scripts; typecheck/build are split per package so the slowest compiler doesn't
+# gate the others.
+NAMES=(
+  format
+  lint
+  typecheck:downloader
+  typecheck:importer
+  build:downloader
+  build:importer
+  web
+  test
+  contract
+  release
+  bridge
+)
+declare -A COMMANDS=(
+  ["format"]="pnpm run format"
+  ["lint"]="pnpm run lint"
+  ["typecheck:downloader"]="pnpm exec tsc --noEmit -p packages/downloader/tsconfig.json"
+  ["typecheck:importer"]="pnpm exec tsc --noEmit -p packages/importer/tsconfig.json"
+  ["build:downloader"]="pnpm exec tsc --noCheck -p packages/downloader/tsconfig.build.json"
+  ["build:importer"]="pnpm exec tsc --noCheck -p packages/importer/tsconfig.build.json"
+  ["web"]="pnpm --dir packages/web run check:svelte && pnpm --dir packages/web run build"
+  ["test"]="pnpm run test:cov"
+  ["contract"]="pnpm run test:contract"
+  ["release"]="pnpm run test:release"
+  ["bridge"]="pnpm run test:bridge"
+)
+
+if [[ "$MODE" == "serial" ]]; then
+  echo -e "${BOLD}pnpm check — ${#NAMES[@]} lanes, serial${RESET}\n"
+  for name in "${NAMES[@]}"; do
+    echo -e "${BOLD}=== $name ===${RESET}"
+    started=$EPOCHREALTIME
+    if ! bash -c "${COMMANDS[$name]}"; then
+      echo -e "\n${RED}${BOLD}✗ ${name} failed${RESET}"
+      exit 1
+    fi
+    duration=$(awk -v a="$started" -v b="$EPOCHREALTIME" 'BEGIN { printf "%.1f", b - a }')
+    echo -e "  ${GREEN}✓${RESET} $name (${duration}s)\n"
+  done
+  echo -e "${GREEN}${BOLD}All checks passed${RESET}"
+  exit 0
+fi
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+declare -A PIDS
+declare -A STARTED
+
+echo -e "${BOLD}pnpm check — ${#NAMES[@]} lanes in parallel${RESET}\n"
+
+for name in "${NAMES[@]}"; do
+  # Own session per lane so a failure can kill the lane's whole process tree.
+  setsid bash -c "${COMMANDS[$name]}" > "$TEMP_DIR/$name.out" 2>&1 &
+  PIDS[$name]=$!
+  STARTED[$name]=$EPOCHREALTIME
+  echo -e "  ${YELLOW}⏳${RESET} $name"
+done
+echo ""
+
+declare -A DURATION
+failed_name=""
+
+while [[ ${#PIDS[@]} -gt 0 ]]; do
+  wait -n -p finished_pid "${PIDS[@]}" && status=0 || status=$?
+  for name in "${!PIDS[@]}"; do
+    [[ "${PIDS[$name]}" == "$finished_pid" ]] || continue
+    DURATION[$name]=$(awk -v a="${STARTED[$name]}" -v b="$EPOCHREALTIME" 'BEGIN { printf "%.1f", b - a }')
+    unset "PIDS[$name]"
+    if [[ $status -ne 0 ]]; then
+      failed_name=$name
+      for other in "${!PIDS[@]}"; do
+        kill -TERM -- "-${PIDS[$other]}" 2>/dev/null || true
+      done
+      wait 2>/dev/null || true
+      break 2
+    fi
+    echo -e "  ${GREEN}✓${RESET} $name (${DURATION[$name]}s)"
+    break
+  done
+done
+
+if [[ -n "$failed_name" ]]; then
+  echo -e "\n${RED}${BOLD}✗ ${failed_name} failed (${DURATION[$failed_name]}s)${RESET}\n"
+  cat "$TEMP_DIR/$failed_name.out" 2>/dev/null || echo "(no output captured)"
+  exit 1
+fi
+
+echo -e "\n${GREEN}${BOLD}All checks passed${RESET}"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,6 +21,7 @@
 
     "declaration": true,
     "sourceMap": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "incremental": true
   }
 }


### PR DESCRIPTION
## What

The commit gate (`pnpm check`) ran its eight steps serially (~56s on a warm 24-core box). This PR makes the gate parallel and cached without changing what it checks:

- **`scripts/check.sh` owns the lane list once.** `pnpm check` fans 11 lanes out in parallel (fail-fast: first failure kills the rest and prints its buffered output, with per-lane timings); `pnpm check:serial` runs the same lanes one at a time with live output for debugging/CI reproduction.
- **Finer lanes than the old steps:** typecheck and build split per package; `check:svelte` + the web vite build share one lane because both regenerate `.svelte-kit/` (the only ordering hazard — package exports point at `src/`, so no lane consumes another's build output; the web vitest projects use the plain svelte plugin and never touch `.svelte-kit/`).
- **Warm-loop caches:** `prettier --cache`, `eslint --cache --cache-strategy content` (lint 22.3s → 3.0s warm), `incremental: true` in tsconfig.base (buildinfo lands in gitignored `dist/`; `*.tsbuildinfo` ignored for safety).
- **Emit-only tsc build (`--noCheck`)** — sound because the typecheck config is a strict superset (it includes tests) and CI's quality job always runs both; the dist emit is a compile artifact only (the image bundles from `src`).

## Measured

| Run | Before | After |
|---|---|---|
| Cold | ~56s | 22.7s |
| Warm | ~56s | 12.0s |

Failure path verified: injected type error → failing lane reported at 2.0s with the tsc output, remaining lanes killed, exit 1 (caches don't swallow new errors).

## Caveat

ESLint's cache is per-file, but type-aware rules can depend on other files' types — a cross-file type change could leave a stale clean verdict locally. CI's cold lint is the backstop.

CI itself is unchanged: `pipeline.yml` runs the underlying scripts individually and cold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)