### PR TITLE
docs: record bare-workspace mechanics in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,8 @@ Runtime: Node ≥24, pnpm 11. After switching Node versions locally, run `pnpm r
 
 jj keeps git's `HEAD` detached, so any `gh` subcommand that infers "the current branch" fails with `not on any branch` — and a `gh pr merge` printing that error has usually **still merged** (verify with `gh pr view <#> --json state`). Never let `gh` touch or infer local branch state, and never judge commit/push state from `git status`/`git log` (stale in colocated repos) — trust `jj st` and `jj bookmark list --all`. Run `gh` **and `jj git push`** from the colocated main repo, not a bare workspace: in a bare workspace `jj git push` can land the push on the remote and _then_ die with `not a git repository`, leaving local state claiming "already matches" — trust the PR head SHA (`gh pr view <#> --json headRefOid`), not the error.
 
+`jj workspace add` creates **bare** workspaces (this jj version has no colocate option): dev, `pnpm check`, and `pnpm version:prep` (jj-native) all work there after a `pnpm install --frozen-lockfile`, but `git` and `gh` do not (no `.git`) — run those from the main repo, pointing its working copy at the branch with `jj new <bookmark>` when something needs git `HEAD`.
+
 **The commit type is release semantics.** CI's `version-check` derives the expected version from conventional-commit types since the last release: a `feat`/`fix` on the PR demands the matching `version:prep` bump or the check fails. Tooling/docs-only PRs (`.claude/`, `docs/`, `openspec/`) must use `chore`/`docs` so no release is demanded. When a check fails, read just the failing step with `gh run view --job <job-id> --log-failed`.
 
 The reliable flow:


### PR DESCRIPTION
One paragraph in the "PRs with jj + gh" section: `jj workspace add` creates bare workspaces (no colocate option in this jj version) — dev and `pnpm check` work there after `pnpm install`; `git`/`gh`/`version:prep` run from the main repo, with `jj new <bookmark>` first when a command reads git HEAD. Retro outcome from the fast-check session; corrects a stale "colocate workspaces" habit that is not executable with this jj version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)