### PR TITLE
docs: arm gh auto-merge in the PR flow; fix stale --allow-new in ship.md

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -52,11 +52,11 @@ CI's required `version-check` re-runs `version:prep --check`, so this commit mus
 ## Phase 5 — PR and merge
 
 1. **Run the out-of-process E2E tier locally first: `pnpm test:e2e`.** It is the same gate the main pipeline runs post-merge — the PR's required checks do NOT include it, so this is the only pre-merge execution it gets. It needs Docker running (plus this host's NAT modules — see memory). If the environment can't run it, stop and ask rather than skip: a miss here surfaces only as a dead main pipeline run after merge.
-2. Create a bookmark and push: `jj bookmark create <change-name> -r @` then `jj git push --bookmark <change-name> --allow-new`.
+2. Create a bookmark and push: `jj bookmark create <change-name> -r @` then `jj git push --bookmark <change-name>` (no `--allow-new` — not a flag in this jj version; `--bookmark` pushes new bookmarks by default).
 3. `gh pr create --head <change-name>` with a concise body: what the change does, link to the archived OpenSpec change, review outcome (cycles run, anything consciously skipped). End the body with the standard Claude Code attribution line.
 4. Watch required checks (`version-check`, `quality`, `test`): `gh pr checks <PR#> --watch`. If a required check fails, fix, commit, `jj git push --bookmark <change-name>`, and re-watch.
 5. **CHECKPOINT — stop and ask the user to confirm the merge**, presenting: PR URL, version, one-paragraph summary, review-cycle summary, check status.
-6. On confirmation: `gh pr merge <PR#> --rebase` (always pass the PR number explicitly — detached-HEAD breaks gh's branch inference; do not pass `--delete-branch`). Then `jj git fetch` to confirm the commit landed on `main`.
+6. On confirmation: `gh pr merge <PR#> --auto --rebase` (always pass the PR number explicitly — detached-HEAD breaks gh's branch inference; do not pass `--delete-branch`). `--auto` merges immediately if checks are green and tolerates an in-flight re-run; it does NOT rescue an out-of-date branch — if main moved, fetch + rebase + push and it fires on the green re-run. Poll `gh pr view <PR#> --json state` until `MERGED`, then `jj git fetch` to confirm the commit landed on `main`.
 7. Retire the workspace now that its work is on trunk: `cd` back to the main repo, `jj workspace forget <change>`, and remove the workspace directory. Only do this after verifying the merge via `gh pr view <PR#> --json state` and the fetch.
 
 ## Phase 6 — Wait for the image publish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,11 +58,11 @@ The reliable flow:
 jj git fetch && jj rebase -b <bookmark> -d 'main@origin'  # sync FIRST — concurrent sessions move main mid-ship (recurring collision)
 jj git push --bookmark <bookmark>
 gh pr create --head <bookmark> --base main …              # explicit --head; refer to the PR by number from here on
-gh pr checks <#> --watch
-gh pr merge <#> --rebase                                  # rebase-merge only; NO --delete-branch (remote auto-deletes; local: jj git fetch)
+gh pr merge <#> --auto --rebase                           # arm auto-merge NOW — GitHub merges the moment checks go green (kills the watch-then-merge race, incl. after an amend re-push)
+gh pr checks <#> --watch                                  # then watch for the outcome; rebase-merge only; NO --delete-branch (remote auto-deletes; local: jj git fetch)
 ```
 
-If checks took a while, fetch + rebase again before merging — "head branch is not up to date" means main moved underneath you.
+Auto-merge does NOT update an out-of-date branch: required checks are strict, so if main moves after you armed it the PR just sits — fetch + rebase + push again and auto-merge fires when the re-run goes green. Confirm with `gh pr view <#> --json state` before building on the result.
 
 ## Stack
 


### PR DESCRIPTION
Retro outcome: PR #149 took three merge attempts because `gh pr checks --watch` raced re-run checks and auto-merge was disabled. Flow now arms `gh pr merge --auto --rebase` right after PR creation (CLAUDE.md) and post-checkpoint in /ship; documents that strict checks mean auto-merge never updates an out-of-date branch. Also fixes ship.md's stale `--allow-new` push flag (rejected by this jj version).

Note: needs the repo setting **Allow auto-merge** enabled (Settings → General → Pull Requests) — blocked for the agent by the auto-mode classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)