### PR TITLE
fix(ci): publish the gate-tested image + release-tooling hardening (S4)

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -174,7 +174,9 @@ jobs:
           E2E_SKIP_BUILD: '1'
         run: pnpm test:e2e
       - name: Upload Playwright traces (parity-phase failures)
-        if: failure()
+        # cancelled() included: a job-timeout cancellation (the new timeout-minutes ceilings) must
+        # still surface its diagnostics, or a wedge dies unexplained.
+        if: failure() || cancelled()
         uses: actions/upload-artifact@v7
         with:
           name: playwright-traces
@@ -193,11 +195,26 @@ jobs:
         if: steps.ver.outputs.released == 'false'
         run: |
           set -euo pipefail
+          # A missing/renamed step output interpolates as EMPTY STRING silently — without these
+          # guards a metadata-action drift would push zero tags, exit 0, and release over a
+          # nonexistent image (surfacing days later at deploy time).
+          TAGS="${{ steps.meta.outputs.tags }}"
+          if [ -z "${TAGS//[[:space:]]/}" ]; then
+            echo "::error::metadata produced no tags — refusing to release without publishing an image"
+            exit 1
+          fi
+          PUSHED=0
           while IFS= read -r tag; do
             [ -n "$tag" ] || continue
             docker tag music-downloader:e2e "$tag"
             docker push "$tag"
-          done <<< "${{ steps.meta.outputs.tags }}"
+            PUSHED=$((PUSHED + 1))
+          done <<< "$TAGS"
+          if [ "$PUSHED" -lt 1 ]; then
+            echo "::error::zero tags pushed — the publish loop must move at least one tag"
+            exit 1
+          fi
+          echo "pushed ${PUSHED} tag(s) of the e2e-gated image"
 
       - name: Tag + GitHub Release
         if: steps.ver.outputs.released == 'false'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -25,6 +25,7 @@ jobs:
   version-check:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 5 # observed ~20s; a wedge should fail in minutes, not GitHub's 6h default
     steps:
       - uses: actions/checkout@v7
         with:
@@ -42,6 +43,7 @@ jobs:
   # Static checks that need no runtime dependencies; runs in parallel with tests. Gates the release.
   quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 10 # observed ~75s
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -65,6 +67,7 @@ jobs:
   # adapter tests; Chromium is the browser-mode runner for the web client project.
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # observed ~100s; Chromium + apt installs dominate on a cold cache
     steps:
       - uses: actions/checkout@v7
       - name: Install ffmpeg
@@ -97,6 +100,7 @@ jobs:
     if: github.event_name == 'push'
     needs: [quality, test]
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # observed ~3.5min warm; a cold-cache build + full E2E stays well under this
     permissions:
       contents: write # create the release tag + GitHub Release
       packages: write # push the GHCR image
@@ -138,14 +142,18 @@ jobs:
             type=raw,value=latest
             type=sha
 
-      # Build once, load locally as `music-downloader:e2e`, cache to gha so the publish step below
-      # reuses the exact same layers (no rebuild).
+      # Build ONCE, load locally as `music-downloader:e2e`. This is the only build in the job: the
+      # publish step below re-tags and pushes these exact bytes, so the published artifact is
+      # byte-for-byte the image the E2E gate ran (a rebuild — even fully cache-hit — re-executes
+      # non-hermetic Dockerfile steps like apt-get/pip and can publish an untested image). The
+      # metadata labels are applied here so the gated image already carries them.
       - name: Build image (load, no push)
         uses: docker/build-push-action@v7
         with:
           context: .
           load: true
           tags: music-downloader:e2e
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -159,8 +167,8 @@ jobs:
         run: pnpm --dir packages/web exec playwright install --with-deps chromium
 
       # THE GATE: stand up the freshly built image + WireMock stubs, drive it end to end over a real
-      # socket — a real browser first (parity phase), then the two loop phases — tear down. A failure
-      # here fails the job and blocks the publish + release steps below.
+      # socket — a real browser first (parity phase), then the loop phases (run.sh owns the list) —
+      # tear down. A failure here fails the job and blocks the publish + release steps below.
       - name: Out-of-process E2E gate
         env:
           E2E_SKIP_BUILD: '1'
@@ -177,16 +185,19 @@ jobs:
 
       # Everything below is the release, guarded on the version not already being tagged. Order:
       # publish the image, then tag + GitHub Release — so `latest`/semver only move on a green E2E.
-      - name: Publish image
+      # Publish = re-tag + push of the ALREADY-GATED local image. Never rebuild here: the guarantee
+      # is that what lands in GHCR is the artifact the E2E gate exercised, not a cache-dependent
+      # reconstruction of it. (Single-platform image — the build above uses the runner's platform —
+      # so a plain docker push carries the exact manifest.)
+      - name: Publish image (the e2e-gated bytes)
         if: steps.ver.outputs.released == 'false'
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        run: |
+          set -euo pipefail
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            docker tag music-downloader:e2e "$tag"
+            docker push "$tag"
+          done <<< "${{ steps.meta.outputs.tags }}"
 
       - name: Tag + GitHub Release
         if: steps.ver.outputs.released == 'false'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.17.1](https://github.com/jgchk/music-downloader/compare/v3.17.0...v3.17.1) (2026-08-06)
+
+### Bug Fixes
+
+* **ci:** publish the exact e2e-gated image instead of rebuilding ([1852b5d](https://github.com/jgchk/music-downloader/commit/1852b5d80652cd02e19b069357d89e97f6d00ec3))
+* **release:** fail version:prep loudly when the version anchor finds no purchase ([3af055e](https://github.com/jgchk/music-downloader/commit/3af055e38a1dc3aac0aed4227ccb7b68540b709e))
 ## [3.17.0](https://github.com/jgchk/music-downloader/compare/v3.16.2...v3.17.0) (2026-08-06)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "music-downloader",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "private": true,
   "description": "An extensible, event-sourced music downloader and importer — a modular monolith.",
   "type": "module",

--- a/packages/downloader/test/contract/fixtures.contract.test.ts
+++ b/packages/downloader/test/contract/fixtures.contract.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { loadFixtures } from './support/fixture.js';
@@ -7,7 +7,9 @@ import {
   fixtureSchemas,
   stubSchemas,
   unconsumedResponseFixtures,
+  unconsumedStubMappings,
 } from './support/registry.js';
+import { CONTRACT_FIXTURE_ROOT } from './support/fixture.js';
 
 /**
  * Conformance: every recorded fixture and every E2E stub payload must satisfy the same contract
@@ -19,11 +21,20 @@ import {
 // The E2E tier is product-level and lives at the workspace root (the stubs serve the whole loop).
 const STUB_ROOT = new URL('../../../../test/e2e/stubs/', import.meta.url).pathname;
 
+// Fixture directories validated by their own dedicated tiers, not this conformance suite —
+// events/ by the events-upcast + events-fold contract tests, ffprobe/ by the ffprobe contract
+// test. Everything else on disk is THIS suite's remit, so a new service directory fails the
+// completeness assertions below instead of escaping wholesale.
+const OWN_TIER_FIXTURE_DIRS = ['events', 'ffprobe'];
+
 describe('recorded fixtures conform to the contract', () => {
-  const fixtures = [
-    ...loadFixtures('musicbrainz').map((f) => ({ ...f, service: 'musicbrainz' })),
-    ...loadFixtures('slskd').map((f) => ({ ...f, service: 'slskd' })),
-  ];
+  const services = readdirSync(CONTRACT_FIXTURE_ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && !OWN_TIER_FIXTURE_DIRS.includes(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+  const fixtures = services.flatMap((service) =>
+    loadFixtures(service).map((f) => ({ ...f, service })),
+  );
 
   it.each(fixtures)('$service/$name carries provenance', ({ fixture }) => {
     expect(fixture.provenance.source).toBeTruthy();
@@ -71,15 +82,40 @@ describe('recorded fixtures conform to the contract', () => {
 });
 
 describe('E2E stub payloads conform to the contract', () => {
-  const cases = Object.keys(stubSchemas).map((rel) => ({ rel }));
+  // plextv stubs belong to the web package's contract tier, which carries its own completeness
+  // assertion over that directory — excluded here so neither tier double-covers or misses it.
+  const stubServices = readdirSync(STUB_ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name !== 'plextv')
+    .map((entry) => entry.name)
+    .sort();
+  const onDisk = stubServices.flatMap((service) =>
+    readdirSync(join(STUB_ROOT, service, 'mappings'))
+      .filter((name) => name.endsWith('.json'))
+      .map((name) => `${service}/${name}`),
+  );
 
-  it.each(cases)('%s validates against its schema', ({ rel }) => {
+  // Completeness, mirroring the fixture side: every mapping on disk is either schema-bound or
+  // explicitly declared response-unconsumed — a body-less DELETE ack is a deliberate
+  // declaration, not indistinguishable from a forgotten registration.
+  it('every stub mapping is registered or explicitly declared unconsumed', () => {
+    const known = [...Object.keys(stubSchemas), ...unconsumedStubMappings].sort();
+    expect([...onDisk].sort()).toEqual(known);
+  });
+
+  const cases = onDisk.map((rel) => ({ rel }));
+
+  it.each(cases)('$rel validates against its schema', ({ rel }) => {
+    const schema = stubSchemas[rel];
+    if (schema === undefined) {
+      expect(unconsumedStubMappings).toContain(rel);
+      return;
+    }
     const mapping = JSON.parse(
       readFileSync(join(STUB_ROOT, `${rel.split('/')[0]}/mappings/${rel.split('/')[1]}`), 'utf8'),
     ) as {
       response: { jsonBody?: unknown };
     };
-    const result = stubSchemas[rel]!.safeParse(mapping.response.jsonBody);
+    const result = schema.safeParse(mapping.response.jsonBody);
     expect(result.success, `${rel}: ${JSON.stringify(result.error?.issues)}`).toBe(true);
   });
 });

--- a/packages/downloader/test/contract/fixtures.contract.test.ts
+++ b/packages/downloader/test/contract/fixtures.contract.test.ts
@@ -2,7 +2,12 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { loadFixtures } from './support/fixture.js';
-import { fixtureRequiredFields, fixtureSchemas, stubSchemas } from './support/registry.js';
+import {
+  fixtureRequiredFields,
+  fixtureSchemas,
+  stubSchemas,
+  unconsumedResponseFixtures,
+} from './support/registry.js';
 
 /**
  * Conformance: every recorded fixture and every E2E stub payload must satisfy the same contract
@@ -26,11 +31,25 @@ describe('recorded fixtures conform to the contract', () => {
     expect(fixture.request.method).toMatch(/^(GET|POST|DELETE)$/);
   });
 
+  // Completeness (the web tier's pattern): every fixture on disk is either bound to a schema or
+  // explicitly declared response-unconsumed in the registry. Without this, a fixture whose
+  // registration was forgotten would silently escape validation via the skip below.
+  it('every fixture is registered or explicitly declared unconsumed', () => {
+    const onDisk = fixtures.map((f) => `${f.service}/${f.name}`).sort();
+    const known = [...Object.keys(fixtureSchemas), ...unconsumedResponseFixtures].sort();
+    expect(onDisk).toEqual(known);
+  });
+
   it.each(fixtures)(
     '$service/$name response validates against its schema',
     ({ service, name, fixture }) => {
       const schema = fixtureSchemas[`${service}/${name}`];
-      if (schema === undefined) return; // endpoint whose response the adapter does not consume
+      if (schema === undefined) {
+        // Only a declared unconsumed-response fixture may skip validation; the completeness
+        // assertion above keeps this set and the disk in exact agreement.
+        expect(unconsumedResponseFixtures).toContain(`${service}/${name}`);
+        return;
+      }
       const result = schema.safeParse(fixture.response.body);
       expect(result.success, JSON.stringify(result.error?.issues)).toBe(true);
     },

--- a/packages/downloader/test/contract/support/registry.ts
+++ b/packages/downloader/test/contract/support/registry.ts
@@ -41,6 +41,14 @@ export const fixtureSchemas: Record<string, ZodType> = {
 };
 
 /**
+ * Fixtures recorded for endpoints whose *response body* the adapters deliberately do not consume
+ * (the request side is still exercised by the replay tier). Declaring them here is what lets the
+ * conformance suite skip schema validation without a silent early-return: every fixture on disk
+ * must appear either in {@link fixtureSchemas} or in this list, exactly.
+ */
+export const unconsumedResponseFixtures: readonly string[] = ['slskd/transfers-enqueue.json'];
+
+/**
  * Consumed fields that must be *present* in a recorded capture, not merely allowed by the
  * (all-optional, tolerant-reader) schema. The adapter's harvest-integrity gates branch on these
  * fields and fail open when one is absent — so a re-record that loses one must fail the tier and

--- a/packages/downloader/test/contract/support/registry.ts
+++ b/packages/downloader/test/contract/support/registry.ts
@@ -18,9 +18,10 @@ import {
  * The single contract registry that binds a captured response — a recorded fixture or an E2E
  * WireMock stub — to the schema it must satisfy (change: external-api-contract-tests). Both the
  * fixture-conformance and stub-conformance checks read this map, so a recorded fixture, an E2E
- * double, and the runtime adapter can never disagree about a payload's shape. Endpoints whose
- * response the adapters do not consume (e.g. the transfer-enqueue acknowledgement) are absent by
- * design — there is no contract to hold them to.
+ * double, and the runtime adapter can never disagree about a payload's shape. Absence here is an
+ * ARTIFACT-level statement only ("this recorded body is not consumed"), declared explicitly in
+ * the unconsumed lists below — never an endpoint-level one: the same endpoint can have consumed
+ * shapes this tier has not yet witnessed (see the note on the enqueue rejection body below).
  */
 
 /** Recorded-fixture filename → schema. */
@@ -41,12 +42,31 @@ export const fixtureSchemas: Record<string, ZodType> = {
 };
 
 /**
- * Fixtures recorded for endpoints whose *response body* the adapters deliberately do not consume
- * (the request side is still exercised by the replay tier). Declaring them here is what lets the
+ * Recorded ARTIFACTS whose response body the adapters do not consume (the request side is still
+ * replay-asserted). This is a statement about the artifact, not the endpoint: the transfer-enqueue
+ * 201 ack's body is unconsumed, but the SAME endpoint's 4xx rejection body IS consumed
+ * (enqueueRejectionReason's peer-unavailable classification) and is unwitnessed pending the
+ * slskd-contract-truth change (task 2.3 records it live). Declaring an artifact here lets the
  * conformance suite skip schema validation without a silent early-return: every fixture on disk
- * must appear either in {@link fixtureSchemas} or in this list, exactly.
+ * must appear either in {@link fixtureSchemas} or here, exactly. The moment an adapter consumes
+ * one of these responses, MOVE the entry to {@link fixtureSchemas} (and
+ * {@link fixtureRequiredFields} where a guard branches on a field) — do not let it linger here.
  */
 export const unconsumedResponseFixtures: readonly string[] = ['slskd/transfers-enqueue.json'];
+
+/**
+ * E2E stub mappings whose response body the TS adapters do not consume, under the same
+ * artifact-granularity rules (and the same removal obligation) as
+ * {@link unconsumedResponseFixtures}. The beets MusicBrainz stub is consumed — by beets itself,
+ * whose contract is governed by the pinned-beets bridge tier, not by any TS schema this registry
+ * could hold it to.
+ */
+export const unconsumedStubMappings: readonly string[] = [
+  'musicbrainz/beets-release-ws2.json', // consumed by beets (Python), governed by the bridge tier's beets pin
+  'slskd/search-delete.json', // 204 body-less ack
+  'slskd/transfers-delete.json', // 204 body-less ack
+  'slskd/transfers-enqueue.json', // 201 empty-body ack; the 4xx rejection body is the slskd-contract-truth 2.3 item
+];
 
 /**
  * Consumed fields that must be *present* in a recorded capture, not merely allowed by the

--- a/scripts/release/version-prep.test.ts
+++ b/scripts/release/version-prep.test.ts
@@ -257,3 +257,33 @@ describe('anchorVersion', () => {
     expect(anchorVersion(source, '3.5.4')).toBeNull();
   });
 });
+
+describe('run (write-path anchor guard)', () => {
+  it('aborts and writes nothing when the manifest cannot be anchored', async () => {
+    const logs: string[] = [];
+    const writes: string[] = [];
+    const reader = fakeReader({
+      tags: ['v3.5.3'],
+      commits: [{ hash: fullSha('abc1234'), message: 'fix(slskd): parse per-user downloads' }],
+    });
+
+    await expect(
+      run(reader, false, {
+        fail: (message: string): never => {
+          throw new Error(message);
+        },
+        log: (message: string) => {
+          logs.push(message);
+        },
+        manifest: {
+          read: () => '{ "name": "music-downloader", "ver": "3.5.3" }',
+          write: (content: string) => {
+            writes.push(content);
+          },
+        },
+      }),
+    ).rejects.toThrow(/could not anchor 3\.5\.4 .* left untouched/);
+    expect(writes).toEqual([]);
+    expect(logs).toEqual([]);
+  });
+});

--- a/scripts/release/version-prep.test.ts
+++ b/scripts/release/version-prep.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { assembleChangelog, compute, isReleaseTagTaken, run } from './version-prep.ts';
+import {
+  anchorVersion,
+  assembleChangelog,
+  compute,
+  isReleaseTagTaken,
+  run,
+} from './version-prep.ts';
 import type { ReleaseReader } from './reader.ts';
 import type { RangeCommit } from './render-changelog-section.ts';
 
@@ -215,5 +221,39 @@ describe('run (--check collision guard wiring)', () => {
 
     await expect(run(reader, true, effects)).resolves.toBeUndefined();
     expect(logs.join('')).toContain('branch is prepped for 3.5.3');
+  });
+});
+
+describe('anchorVersion', () => {
+  it('rewrites the version field, preserving the rest of the source', () => {
+    const source =
+      '{\n  "name": "music-downloader",\n  "version": "3.5.3",\n  "private": true\n}\n';
+
+    expect(anchorVersion(source, '3.5.4')).toBe(
+      '{\n  "name": "music-downloader",\n  "version": "3.5.4",\n  "private": true\n}\n',
+    );
+  });
+
+  it('accepts an unbumped prep, where the anchored version is already in place', () => {
+    const source = '{ "version": "3.5.3" }';
+
+    expect(anchorVersion(source, '3.5.3')).toBe(source);
+  });
+
+  it('returns null instead of silently writing an unanchored file when the pattern finds no purchase', () => {
+    // The rot scenario: package.json's version field changes shape (or vanishes) and the anchor
+    // regex no longer matches — String.replace would return the source unchanged, and the old
+    // shell logged "prepared" over a file it never touched.
+    const source = '{ "name": "music-downloader", "ver": "3.5.3" }';
+
+    expect(anchorVersion(source, '3.5.4')).toBeNull();
+  });
+
+  it('returns null when the replacement lands somewhere other than the real version field', () => {
+    // First-match semantics: a shape where the match is not the manifest's own version field must
+    // fail the post-condition (the parsed manifest does not carry the computed version).
+    const source = '{ "scripts": { "version": "echo" }, "version-note": "3.5.3" }';
+
+    expect(anchorVersion(source, '3.5.4')).toBeNull();
   });
 });

--- a/scripts/release/version-prep.ts
+++ b/scripts/release/version-prep.ts
@@ -80,9 +80,15 @@ export async function compute(reader: ReleaseReader): Promise<Computed> {
   return { version, bumped: true, section };
 }
 
+/** Thrown by {@link fail} after reporting, so the CLI catch below can tell "already reported and
+ * coded" from an unexpected defect. */
+class PrepFailure extends Error {}
+
 function fail(message: string): never {
   process.stderr.write(`${message}\n`);
-  process.exit(1);
+  // exitCode (not exit()): let the process drain naturally so the stderr write cannot be raced.
+  process.exitCode = 1;
+  throw new PrepFailure(message);
 }
 
 /**
@@ -93,6 +99,12 @@ function fail(message: string): never {
 export interface PrepEffects {
   fail: (message: string) => never;
   log: (message: string) => void;
+  /**
+   * package.json IO, injectable so the write path's anchor guard is testable through {@link run};
+   * defaults to the real file. CHANGELOG stays direct-to-disk — the guard aborts before either
+   * write, so the manifest seam alone is enough to prove "aborts and touches nothing".
+   */
+  manifest?: { read: () => string; write: (content: string) => void };
 }
 
 /**
@@ -120,7 +132,7 @@ export function anchorVersion(source: string, version: string): string | null {
 export async function run(
   reader: ReleaseReader,
   check: boolean,
-  { fail: abort, log }: PrepEffects,
+  { fail: abort, log, manifest }: PrepEffects,
 ): Promise<void> {
   // Best-effort: CI checks out with full history/tags; locally the developer may already have them.
   reader.fetch();
@@ -134,15 +146,21 @@ export async function run(
     // Write mode: apply the computed state to the working tree for the developer to commit. Anchor
     // package.json's version (preserving the branch's other package.json edits) and rebuild
     // CHANGELOG.md from its base content so the section is prepended exactly once.
-    const pkg = anchorVersion(readFileSync(PKG, 'utf8'), version);
+    const io = manifest ?? {
+      read: () => readFileSync(PKG, 'utf8'),
+      write: (content: string) => writeFileSync(PKG, content),
+    };
+    const pkg = anchorVersion(io.read(), version);
     if (pkg === null) {
-      abort(
+      // `return` because `abort` is a parameter binding: CFA does not treat the bare call as
+      // never-returning, and `never` is assignable to the return type — this is the narrowing.
+      return abort(
         `version:prep: could not anchor ${version} in ${PKG} — the "version" field pattern found ` +
           `no purchase, so the file was left untouched. Fix the anchor in version-prep.ts before ` +
           `trusting this prep.`,
       );
     }
-    writeFileSync(PKG, pkg);
+    io.write(pkg);
 
     if (bumped && section !== null) {
       writeFileSync(CHANGELOG, assembleChangelog(reader.baseChangelog(), section));
@@ -201,6 +219,15 @@ async function main(): Promise<void> {
 // Run only as the CLI entry point; importing the module (the unit tests) must not touch the tree.
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   void main().catch((error: unknown) => {
-    fail(`version:prep: ${error instanceof Error ? error.message : String(error)}`);
+    if (error instanceof PrepFailure) return; // already reported + exit-coded by fail()
+    // An unexpected defect. The half-mutation window: a throw after the manifest write but
+    // before the CHANGELOG write leaves package.json already bumped — say so instead of letting
+    // a "failed" prep hide a mutated tree.
+    process.stderr.write(
+      `version:prep: ${error instanceof Error ? error.message : String(error)}\n` +
+        `If this failed mid-write, package.json may already carry the bump — review the ` +
+        `working tree (jj diff) before re-running.\n`,
+    );
+    process.exitCode = 1;
   });
 }

--- a/scripts/release/version-prep.ts
+++ b/scripts/release/version-prep.ts
@@ -96,6 +96,22 @@ export interface PrepEffects {
 }
 
 /**
+ * Anchor the computed version into package.json's source text, preserving every other byte. Returns
+ * `null` when the anchor finds no purchase — the pattern not matching, or first-match semantics
+ * landing the rewrite somewhere other than the manifest's own version field — verified by parsing
+ * the result rather than trusting the replace. A `null` means the caller must fail loudly: the old
+ * shell wrote the unchanged file back and logged "prepared" over a prep that never happened.
+ */
+export function anchorVersion(source: string, version: string): string | null {
+  const anchored = source.replace(/("version":\s*)"[^"]*"/, `$1"${version}"`);
+  try {
+    return (JSON.parse(anchored) as { version?: unknown }).version === version ? anchored : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * The version:prep orchestration, parameterised over its reader and effects so both the write path
  * and the `--check` gate (including the concurrent-branch collision guard) can be exercised without
  * touching the process. {@link main} supplies the real reader + effects; the CLI behaviour is
@@ -118,7 +134,14 @@ export async function run(
     // Write mode: apply the computed state to the working tree for the developer to commit. Anchor
     // package.json's version (preserving the branch's other package.json edits) and rebuild
     // CHANGELOG.md from its base content so the section is prepended exactly once.
-    const pkg = readFileSync(PKG, 'utf8').replace(/("version":\s*)"[^"]*"/, `$1"${version}"`);
+    const pkg = anchorVersion(readFileSync(PKG, 'utf8'), version);
+    if (pkg === null) {
+      abort(
+        `version:prep: could not anchor ${version} in ${PKG} — the "version" field pattern found ` +
+          `no purchase, so the file was left untouched. Fix the anchor in version-prep.ts before ` +
+          `trusting this prep.`,
+      );
+    }
     writeFileSync(PKG, pkg);
 
     if (bumped && section !== null) {


### PR DESCRIPTION
Final small batch from the 2026-08-05 whole-project review sweep — the pipeline & release-tooling items.

## Findings → commits

| Review finding | Fix | Commit |
|---|---|---|
| The publish step **rebuilds** the image instead of pushing the e2e-gated one — on a cache miss (and for non-hermetic Dockerfile steps, even on a hit) the published artifact never passed the gate | Publish is now a re-tag + push of the exact loaded `music-downloader:e2e` bytes (single-platform image, so the manifest carries verbatim); metadata labels move to the single build; `timeout-minutes` ceilings on all four jobs (calibrated from observed runs: 75s/100s/20s/3.5min → 10/15/5/30); stale phase-count comment defers to run.sh | `fix(ci)` |
| `version-prep.ts` — a non-matching `String.replace` writes package.json unchanged and still logs "prepared" (unbumped "prepped" branch) | `anchorVersion()` — pure, parse-verified: no match, mis-landed first match, or unparseable output return `null` and the prep aborts naming the file and fix. Red-first unit tests (4 cases) | `fix(release)` |
| `fixtures.contract.test.ts` early-returns on unregistered fixtures, so a forgotten registration silently escapes validation | Completeness assertion (the web tier's pattern): every fixture on disk must be schema-bound or explicitly declared response-unconsumed; the skip path asserts the declaration. Went genuinely red on `slskd/transfers-enqueue.json` before the declaration landed | `test(contract)` |

## Verification

- `pnpm check` green (full gate, 100% coverage, zero waivers)
- Local out-of-process e2e green, all phases
- `version:prep` for this very bump (3.17.0 → 3.17.1) ran through the new `anchorVersion` path — the guard's parse-verification exercised in earnest, file demonstrably anchored
- **The publish-path change's real proof is the first post-merge pipeline run** — the workflow YAML parses and the docker re-tag/push logic is read-verified, but only a live release exercises it. Watch the `release` job on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-pass amendments (2-agent review)

| Finding | Fix | Commit |
|---|---|---|
| **Critical** — the anchor null-guard didn't narrow (`abort` is a parameter binding; `writeFileSync` received `string \| null`, a real TS2345 hidden by scripts/ being outside every tsconfig) | `return abort(...)`; write path routed through an injectable manifest seam; run-level test proves a non-anchorable manifest aborts with **nothing written** | `fix(release)` #2 |
| **High** — publish loop was a green no-op on silently-empty tag output | Empty-tags refusal before the loop, pushed-count assertion after | `fix(ci)` #2 |
| **Important** — stub conformance iterated registry keys, never disk (4 mappings unvalidated); service lists hardcoded | Disk-derived service lists (own-tier exclusions explicit; plextv → web tier's suite), stub-side registered-or-declared-unconsumed completeness, artifact-granularity "unconsumed" docs citing slskd-contract-truth 2.3 + removal obligation | `test(contract)` #2 |
| **Lows** | Traces upload on `failure() \|\| cancelled()`; `fail()` uses `process.exitCode` + typed PrepFailure; CLI catch names the half-mutation window | folded into the above |

**Provenance-attestation trade (deliberate):** `docker/build-push-action` with `push: true` emitted SLSA provenance attestations; a plain `docker push` does not. Traded away for the exact-gated-bytes guarantee — revisit if image provenance ever matters (e.g. a policy engine verifying attestations at deploy).
