### PR TITLE
chore(openspec): draft mutation-gate-diff-scope — line-scoped failure, shadow first

### DIFF
--- a/docs/research/blocking-mutation-gate-scope.md
+++ b/docs/research/blocking-mutation-gate-scope.md
@@ -1,0 +1,1096 @@
+# What failure scope should a blocking per-PR mutation gate use, and what do you do about legacy and provably-equivalent survivors?
+
+**Research date:** 2026-08-07. All URLs accessed 2026-08-07 unless noted. Findings are input to a
+decision, **not normative until adopted** through an OpenSpec change and a PR.
+
+**Question.** A StrykerJS mutation gate runs per-PR in `.github/workflows/pipeline.yml`, scoped to
+the production **files** a branch changed, with `continue-on-error: true` and no required-check
+flag. The owner wants it to genuinely block. `main` is not mutant-clean and — as the shipped design
+now documents — cannot honestly reach 100%. So: what **failure scope** should a blocking gate use,
+and what happens to legacy survivors and to provably-equivalent mutants that cannot be waived
+without silencing a killable twin? Six options were on the table: (1) changed-line/diff-hunk failure
+scope, (2) a committed accepted-survivor baseline, (3) refactoring equivalents onto their own lines,
+(4) a node-precise ignorer plugin, (5) a percentage `thresholds.break`, (6) `--incremental` against a
+main baseline.
+
+**Method.** Repo state verified directly against `main` (`git show main:…`; the local working copy
+is behind), not taken from the prompt: `.github/workflows/{pipeline,mutation}.yml`,
+`stryker.config.mjs`, `scripts/mutation/*`, `test/boundaries/mutation-scope.test.ts`,
+`openspec/changes/mutation-gate/{proposal,design,tasks,specs}`, `docs/development/quality-gates.md`,
+`docs/development/testing.md`, `CLAUDE.md`. CI wall-clock read from the GitHub Actions API
+(`gh api …/actions/runs/<id>/jobs`) for three real runs rather than from the design doc's single
+measurement. Primary sources fetched 2026-08-07: the StrykerJS documentation and the
+`stryker-mutator/stryker-js` source and issue tracker (via `gh api` / `gh search issues`, so GitHub's
+own index rather than a web search of it); the mutation-testing-elements report schema; Google's
+ICSE-SEIP 2018 paper read **in full from the PDF** (not from the prior doc's summary), plus TSE 2021
+and ICSE 2021 in full and Papadakis et al. ICSE 2018 in full; Budd & Angluin 1982, Jia & Harman 2011,
+Schuler & Zeller 2010 and the mutant-subsumption papers;
+arcmutate, pitest, Mull, Cosmic Ray, mutmut and Stryker.NET documentation;
+Sonar, Codecov, GitLab, golangci-lint, diff-cover, undercover; PHPStan, Psalm, ESLint bulk
+suppressions, Android lint, Checkstyle, Error Prone, NullAway, betterer. Sub-agents did the breadth
+sweeps under a "quote-or-say-you-couldn't-reach-it" contract; the load-bearing facts (mutation
+ranges, the directive keying, Google's blocking question, arcmutate's default scope, the CI timings)
+were re-verified first-hand. Citations inline; sources in §12. Unreachable pages are named in §12.
+
+This doc **builds on** `docs/research/automated-quality-function.md` §5.1 and does not re-argue it;
+where shipping the gate revealed that doc's conclusions need amending, §9 says so explicitly.
+
+---
+
+## 1. House facts being decided against (verified on `main`)
+
+- **The job.** `.github/workflows/pipeline.yml` job `mutation`: `if: github.event_name ==
+  'pull_request'`, `timeout-minutes: 20`, scope resolved by `git diff --name-only --diff-filter=ACMR
+  $(git merge-base …)` filtered to `^packages/(downloader|importer)/src/….ts$`, then
+  `pnpm exec stryker run --mutate "$MUTATE"` under `continue-on-error: true`. A following step
+  (`if: always()`) writes `scripts/mutation/report.ts` output to the step summary. Confirmed.
+- **The rationale is conditional on a false precondition.** The job's comment block justifies file
+  scope with: *"once main is mutant-clean, a changed file's untouched lines carry no survivors, so
+  the two give the same verdict — and file scope additionally catches a change that weakens an
+  assertion elsewhere in the same file."* Main is not mutant-clean, and §5 establishes it cannot
+  become so by any mechanism currently shipped: equivalence is undecidable, StrykerJS offers no
+  per-mutant suppression, and the one route that would work (an ignorer plugin) is an unwritten
+  deferred item. The identity the argument rests on is unavailable, so "stricter and far simpler"
+  reduces to "stricter" — i.e. it fails branches on debt they did not create.
+- **The spec was amended to match the code, not the other way round.**
+  `openspec/changes/mutation-gate/specs/mutation-testing/spec.md` ADDs *"The PR gate SHALL run
+  mutation testing over the branch's changed production **lines**"* and then MODIFIEs it to
+  *"changed production **files**"*, with the same conditional justification. Line scope was the
+  drafted requirement.
+- **The measurement.** `design.md`'s rebase table records, at the tip that became `main`: **7088
+  mutants, 929 ignored, 64 surviving, 98.96%** (the detected split — 6028 killed + 67 timeout —
+  reconciles: 7088 − 929 − 64 = 6095). Of the 64: **~45 arrived with the v3.18.0 correlation
+  feature**, in production code that change added; **17** are provably-equivalent narrowing operands
+  **deliberately left unwaived**; **2** are a real unspecified-behaviour finding in the MusicBrainz
+  album path. The 45 are the single most instructive fact in the whole file: a one-day burn-down took
+  464 → 19, and one unrelated feature put 45 back inside a week. **Mutation debt is a flow, not a
+  stock** — which is an argument *for* a diff-time gate and *against* ever expecting a clean main to
+  be the precondition for one.
+- **The blocking obstacle, verified in Stryker's source.** `// Stryker disable` keys on *(line,
+  mutator name)* and nothing else — `DirectiveBookkeeper`'s `IgnoreRule.matches()` is
+  `lineMatches() => this.line === undefined || this.line === line` AND `mutatorNames.includes(
+  mutatorName) || mutatorNames.includes('all')`
+  ([directive-bookkeeper.ts](https://github.com/stryker-mutator/stryker-js/blob/master/packages/instrumenter/src/transformers/directive-bookkeeper.ts)).
+  There is no column, no node identity. So waiving one operand silences every mutant that mutator
+  emits on the line — and `ConditionalExpression` emits `true` *and* `false` from one node, so the
+  equivalent and its killable twin are co-located by construction.
+- **The prior failure this caused.** A first pass reported 99.89% / 6 survivors. It was false: two
+  block-form `disable` … `restore all` pairs never closed, because Stryker reads only a node's
+  *leading* comments and both `restore`s sat as the last token inside a `case`. Suppression ran to
+  end-of-file, silencing 96 mutants across `read-models.ts` and `effect-lander.ts` — including the
+  whole retry-vs-dead-letter landing decision — while both files reported 100.00. Fifteen further
+  waivers were silencing killable twins. 104 of the 206 silenced mutants turned out to be killable.
+  `test/boundaries/mutation-scope.test.ts` now bans the block form outright and pins a suppression
+  ceiling of **58 directives / 75 mutants**.
+- **Suppression is already at the doctrine's own alarm threshold.** `quality-gates.md`: *"a rising
+  suppression count is the signal that the rule failed admission and nobody noticed."* 1 → 58 in one
+  change. `design.md` records this rather than absorbing it, and already recommends the fix (an
+  `ignore-unions` ignorer plugin) as a deferred item with its own change.
+- **Measured CI cost — three real runs, read from the Actions API, not projected.** The job's own
+  comment still says `# projected low-minutes on a 4-core runner; NOT yet observed in CI`; it has
+  now been observed three times:
+
+  | PR | changed prod files | Stryker step | whole job |
+  | --- | --- | --- | --- |
+  | mutation-gate's own (#161) | 2 | 1m43s | 2m32s |
+  | v3.18.0 correlation | 53 | 8m54s | 9m37s |
+  | the burn-down | 36 | **13m16s** | **13m58s** |
+
+  Against `timeout-minutes: 20`. Cost is **not** linear in file count — it is mutants × tests per
+  mutant, and the burn-down's 36 domain/adapter files are far more densely covered than the
+  correlation change's 53. Sibling jobs on the same run: `quality` **1m16s**, `test` **2m04s**,
+  `version-check` 19s.
+- **Latency consequence, stated up front.** Making `mutation` required moves the PR critical path
+  from ~2 minutes to ~14, a **~7×** increase, and puts a job with 30% timeout headroom on the merge
+  path. `quality-gates.md`'s latency budget explicitly exempts CI from the seconds-order rule, so
+  this violates no non-negotiable — but it is the largest single cost of the flip and is currently
+  unrecorded anywhere.
+
+## 2. What the tool can actually do (StrykerJS primary sources)
+
+This section exists because three of the six options turn entirely on tool capability, and two of
+those capabilities were assumed rather than checked.
+
+### 2.1 StrykerJS supports line-range mutation natively — the decisive fact
+
+The config docs: *"It is possible to specify exactly which code blocks to mutate by means of a
+_mutation range_. This can be done postfixing your file with `:startLine[:startColumn]-endLine[:endColumn]`."*
+Documented examples: `"src/app.js:1-11"`, `"src/app.js:5:4-6:4"`, `"src/app.js:5-6:4"`
+([configuration](https://stryker-mutator.io/docs/stryker-js/configuration/)). Shipped in **v4.6.0**
+(2021-04-16, [PR #2751](https://github.com/stryker-mutator/stryker-js/pull/2751)).
+
+Constraint: *"It is **not** possible to combine mutation range with a globbing expression in the
+same line."* The validation is **per array element** — `options-validator.ts` throws *"Config option
+"mutate[${index}]" is invalid. Cannot combine a glob expression with a mutation range"* — so a
+comma-separated list of explicit `path:start-end` entries (which is exactly what the job already
+builds) is valid.
+
+**And the maintainer explicitly recommends this for diff gating.** On
+[issue #2843](https://github.com/stryker-mutator/stryker-js/issues/2843) ("Generate mutant only for
+the changed lines in a range of commits"), nicojs (2021-07-05): *"We've recently added support to
+mutate a specific range only… Example: `stryker run --mutate foo.js:25-30`. This can be combined
+with some kind of pipeline git diff command."* Earlier, on
+[#551](https://github.com/stryker-mutator/stryker-js/issues/551) ("Mutate only modified files (based
+on git)"), he rejected building git in: *"I wouldn't want to use git as a source of files, as it
+would tightly couple with it."* So: **no native `--since`, by deliberate design, with the
+range syntax as the sanctioned substitute and the diff computation left to the caller.** The
+repo's merge-base shell step is precisely the sanctioned shape; it is just resolving to files
+instead of ranges.
+
+**One semantic trap, verified in source.** Range filtering uses *containment*, not overlap:
+`babel-transformer.ts`'s `shouldMutate` requires `locationIncluded(range, path.node.loc)`, i.e. the
+mutant's whole node must sit inside the range. A `BlockStatement` mutant spanning an entire function
+is therefore **not generated** when only one line inside it changed. That matters: in Google's data
+`SBR` (statement block removal) is **72.18%** of all mutants and *"the mutation type second-least
+likely to survive"* (ICSE-SEIP 2018, Fig. 5 and §5.3). Strict range scoping silently drops the
+biggest and bluntest mutant family. §9 recommends around this.
+
+### 2.2 Disable comments: no per-mutant granularity, and none planned
+
+Docs: *"Disabled mutants will remain in your report but will get the `ignored` status."* Block form
+*"applies from that point forward until a corresponding restore statement"*
+([disable-mutants](https://stryker-mutator.io/docs/stryker-js/disable-mutants/)). Source confirms
+matching on `(line, mutatorName)` only (§1). The tracker history:
+
+- [#1472](https://github.com/stryker-mutator/stryker-js/issues/1472) "Ignore specific mutations"
+  (2019 → closed 2021-09-01) — resolved by shipping the comment syntax in 5.4.
+- [#1174](https://github.com/stryker-mutator/stryker-js/issues/1174) "Ignore Function With Comment" —
+  closed, later pointed at the ignore-plugin.
+- [#3229](https://github.com/stryker-mutator/stryker-js/issues/3229) "Allow users to ignore mutants
+  based on heuristics" (opened by nicojs 2021-10-26, **closed as implemented** 2023-10-14) — this is
+  the ignorer plugin, and its body cross-references *"a couple of requests in the past to allow to
+  ignore specific mutants: #2966 #1174 #1470 #1464."*
+- [#3228](https://github.com/stryker-mutator/stryker-js/issues/3228) — closed in favour of #3229.
+
+**Verdict: there is no mechanism keyed on an individual mutant** (no "suppress mutant with id X", no
+mutator+replacement+position key). Every StrykerJS suppression is by *source pattern*: line+mutator
+(comment) or AST-node predicate (plugin). The maintainer's consistent answer to "I want finer
+control over what gets mutated" is **write an ignorer plugin** — e.g. on
+[#4141](https://github.com/stryker-mutator/stryker-js/issues/4141): *"#3229 is probably what you
+want."*
+
+### 2.3 The ignorer plugin is the node-precise mechanism, and this repo already ships one
+
+`declareValuePlugin(PluginKind.Ignore, name, { shouldIgnore(path) { return "reason" } })`, where
+*"The `path` parameter is a babel `NodePath` object"*
+([disable-mutants#using-an-ignore-plugin](https://stryker-mutator.io/docs/stryker-js/disable-mutants/#using-an-ignore-plugin)),
+and the interface from #3229 is `shouldIgnore(path: NodePath): string | void`, called *"inside the
+instrumenter on each AST node visitation."* Full AST granularity — it can ignore one operand of a
+condition and leave its killable sibling on the same line measured, which is exactly what a
+line-scoped comment cannot do.
+
+`scripts/mutation/ignore-logging.mjs` is already this, with a test pinning its blast radius. The
+machinery for option 4 exists in-repo; only the rule is missing.
+
+### 2.4 `--incremental` cannot be a baseline here, for two independent reasons
+
+Docs: *"StrykerJS will do a git-like diff of your code and test files to the previous version it
+finds in the incremental report file"* and the report is the *"full mutation report"*
+([incremental](https://stryker-mutator.io/docs/stryker-js/incremental/)). `design.md` D4a already
+rejects it for the PR job because the merged whole-repo report re-imports untouched debt into the
+verdict. Two additions:
+
+- The docs do **not** state explicitly whether `thresholds.break` applies to the merged whole. The
+  sub-agent reported this as an absence rather than inferring it, and I did not find the sentence
+  either. D4a's claim is empirically grounded on this repo but is **not** documented upstream — mark
+  it as measured-here, not attested.
+- **The incremental file is not committable with the vitest runner.**
+  [Issue #6004](https://github.com/stryker-mutator/stryker-js/issues/6004) (open, 2026-05-13, filed
+  against 9.6.1 — the exact version pinned here): non-deterministic vitest test IDs produce a ~15k
+  line diff on every no-op run. *"This is a blocker for storing the incremental baseline in version
+  control."* That kills option 6's "baseline against main" framing outright.
+
+  The same issue carries a useful positive: *"Mutant `id` — stable. `status`, `mutatorName`,
+  `replacement`, `location` — stable. Test IDs in `killedBy`/`coveredBy` — different on each run."*
+  So a hand-rolled baseline keyed on `(file, location, mutatorName, replacement)` **would** be
+  run-to-run stable. Note `id` itself is a per-run ordinal (`MutantCollector`'s `nextMutantId++`),
+  stable only for byte-identical input — never key a baseline on it.
+
+### 2.5 Score semantics, for option 5
+
+`break`: *"mutation score < break: Error! Stryker will exit with exit code 1"*
+([configuration](https://stryker-mutator.io/docs/stryker-js/configuration/)). Mutation score is
+`detected / valid * 100` where `valid = detected + undetected`, and the denominator **excludes**
+`Ignored`, `CompileError`, `RuntimeError` and `Pending`
+([mutant states and metrics](https://stryker-mutator.io/docs/mutation-testing-elements/mutant-states-and-metrics/)).
+So today's `break: 100` is exactly "zero survivors among non-ignored mutants", which is what
+`design.md` D1 says it is. Full status set: `Pending, Killed, Survived, NoCoverage, Timeout,
+RuntimeError, CompileError, Ignored` — `Ignored` is distinct, as `report-model.ts` already assumes.
+
+### 2.6 What a baseline could key on
+
+The [report schema](https://github.com/stryker-mutator/mutation-testing-elements/blob/master/packages/report-schema/src/mutation-testing-report-schema.json)
+gives each mutant `id`, `mutatorName`, `replacement`, `location.{start,end}.{line,column}`, `status`,
+`statusReason`, `static`, `coveredBy`, `killedBy`, `description`, `duration`. So a baseline keyed on
+exact position + mutator + replacement is **mechanically possible** — richer than any in-source
+comment can express. Whether it is *wise* is §4.
+
+## 3. Q1 — legacy survivors: is diff/changed-line scoping the established answer?
+
+### 3.1 Google mutates changed **lines**, at most one mutant per line, and does not block
+
+Read from the ICSE-SEIP 2018 PDF directly, not from a summary:
+
+- Scope: *"For each file in the diff, a set of mutants is requested, one for each affected covered
+  line. Affected lines are added or modified lines in the diff, and the covered lines are defined by
+  the coverage analysis results."* And, decisively: ***"Only lines affected by the diff under review
+  that are covered and are not arid are mutated."***
+- Density: *"For each line, at most one mutant is generated. Surfacing multiple mutants for a single
+  line clutters the code review interface and looks confusing."*
+- Deployment: *"the results of the mutation analysis, e.g. living mutants, are surfaced during a code
+  review as code findings."* A finding carries *"'Please fix' and 'Not useful' links"*; *"If an
+  automated analyzer finding (e.g. a living mutant) is not useful, developers can report that with a
+  single click."* Rationale: *"We argue that the code review process is the best location for
+  surfacing changed code metrics because it maximizes the probability that the change will be acted
+  upon."*
+- **Did they ever block? No — and TSE 2021 §2.4 settles it in one sentence:** *"These findings do
+  not need to be resolved by the author before submission, unless a human reviewer marks them as
+  mandatory."* Blocking, where it exists at all, is a **human** decision on a specific finding, never
+  the tool's.
+- **Their non-actionable-rate target is the same number as this repo's admission bar.** TSE 2021
+  reports mutant *productivity* — the complement of the "Not useful" rate — as *"82% of all reported
+  mutants"* aggregate, *"increased over time from 80% to 89%"*, with the stated goal *"to maintain a
+  mutant productivity rate around 90%"* and a policy of disabling a mutator on any node type whose
+  productivity drops below 80%. So Google, after years of tuning, sits at 82–89% useful against a
+  ~90% target — i.e. **hovering at or just under `quality-gates.md`'s ten-percent effective-FP bar,
+  with a human "Not useful" button as the release valve.**
+- Mutation score, rejected explicitly: *"At present it is infeasably expensive to compute the
+  absolute mutation score for the codebase at any given fixed point… In addition to the computation
+  costs of the mutation score, we were also unable to find a good way to surface it to the engineers
+  in an actionable way."* And *"Living mutants are a precondition for surfacing an actionable
+  finding, but alone do not make a good measure of efficacy."*
+- Usefulness: *"75% of all findings with feedback were found useful by developers"*; the abstract
+  reports *"the reported usefulness of the surfaced results improved from 20% to 80%"* and §6:
+  *"we have reduced the probability of non-actionable result rates to 25% manually."*
+
+TSE 2021 restates the same three ideas as the core contribution: *"(1) Mutation testing is done
+incrementally, mutating only changed code during code review… (2) Mutants are filtered… limiting the
+number of mutants per line and per code review process; (3) Mutants are selected based on the
+historical performance of mutation operators"* ([arXiv:2102.11378](https://arxiv.org/abs/2102.11378)).
+It also justifies the one-per-line cap empirically: *"In more than 90% of the cases, either all
+mutants in a line are killed, or all mutants in a line survive"* — so surfacing more than one is
+almost always redundant. **This repo's 17 are the other ≤10%**: a line whose two mutants disagree is
+exactly the case Stryker's line-keyed `disable` cannot express.
+
+**And the surfaced volume is tiny.** TSE 2021 §7: the median mutants per changelist falls from
+**820** (traditional) to **77** (one per line) to **7** (arid suppression + one per line). Google
+gates a human's attention at ~7 findings per review. This repo's blocking gate would surface every
+survivor in every changed file, uncapped — 13 on a 2-file diff (`design.md`, PR #161), 45 on the
+correlation feature. §9 returns to this.
+
+**So the deviation matters.** `stryker.config.mjs`'s header names two deliberate deviations from the
+Google recipe — file scope instead of line scope, and blocking instead of advisory. Both are real
+deviations, and the shipped file scope is the one the paper's own sentence contradicts most directly.
+The prior research doc's §5.1 summary ("mutate only changed, covered lines") was accurate; the
+implementation drifted from it, and the workflow comment's justification for drifting depends on a
+precondition that does not hold.
+
+### 3.2 Every other mutation tool that gates on a diff gates on **lines**
+
+- **arcmutate** (the commercial pitest extensions — the only mature *productised* mutation gate):
+  *"In change based mode, only code modified between the specified git refs will be analysed"*, and
+  the default `scope` is **line** — *"only mutations on lines that have been modified will be
+  analysed"* — widenable to `class` as an explicit opt-in
+  ([git-integration](https://docs.arcmutate.com/docs/git-integration.html)). *"This mode is designed
+  to be used when integrating pitest into pull requests, and for receiving fast feedback on local
+  changes."* Their GitHub integration is **advisory by default**: a PR comment plus per-line diff
+  annotations, with an optional `LEVEL` parameter (error / **warning, default** / info) that decides
+  whether the check run fails
+  ([github/overview](https://docs.arcmutate.com/docs/github/overview.html)).
+- **Mull** (LLVM/C++): *"Incremental mutation testing is a feature that enables running Mull only on
+  the mutations found in Git Diff changesets"*, line-scoped — *"if a Git diff … is only one line,
+  Mull will only find mutations in that line"*
+  ([docs](https://mull.readthedocs.io/en/latest/IncrementalMutationTesting.html)).
+- **Cosmic Ray** (Python): `cr-filter-git` *"looks for edited or new lines from the given git branch.
+  Any mutation in a session that would mutate other lines is skipped"*
+  ([filters](https://cosmic-ray.readthedocs.io/en/stable/how-tos/filters.html)).
+- **Stryker.NET** is the outlier and is the *file*-ish one: `--since` *"Use git information to test
+  only code changes since the given target. Stryker will only report on mutants within the changed
+  code"*, and for test files *"all mutants covered by tests in that file will be seen as changed"*
+  ([stryker-net configuration](https://stryker-mutator.io/docs/stryker-net/configuration/)).
+  **StrykerJS has no `--since`** — confirmed absent from its configuration docs; the JS analogue is
+  `incremental`, which is a caching mechanism, not a scope.
+- **OSS pitest removed its diff support**: the `scm` Maven goal was deprecated (`#1353 Warn about
+  future SCM goal removal`, 1.17.1) and *"Fully remove deprecated scm maven goal"* (`#1379`, 1.18.0)
+  ([pitest README changelog](https://github.com/hcoles/pitest/blob/master/README.md)). Diff-scoped
+  mutation is now a paid feature of the same author's commercial product — which is itself evidence
+  of how much demand there is for it.
+
+### 3.3 The coverage-gate analogy: diff scoping is the industry's stock answer for a dirty metric
+
+- **Sonar's "Clean as You Code"** is the strongest official statement anyone makes. The recommended,
+  read-only **Sonar way** gate *"focuses on keeping high quality standards for new code, rather than
+  spending a lot of effort remediating old code"*
+  ([quality gates](https://docs.sonarsource.com/sonarqube-server/quality-standards-administration/managing-quality-gates/introduction-to-quality-gates)),
+  and CaYC's framing is *"You aren't responsible for anyone else's code. You own the quality and
+  security of the new code you are working on today"*
+  ([clean as you code](https://docs.sonarsource.com/sonarqube-server/10.5/user-guide/clean-as-you-code)).
+  All four locked conditions are new-code-scoped. Sonar even hard-caps the boundary: *"Code that is
+  older than 90 days cannot be considered new."*
+- **Codecov** ships exactly the two-status split this decision is about: *"The `codecov/project`
+  status measures overall project coverage… The `codecov/patch` status **only** measures lines
+  adjusted in the pull request"* ([commit status](https://docs.codecov.com/docs/commit-status)). The
+  legacy argument lives on their blog, not the docs [secondary, maintainer-published]: *"the burden
+  of writing tests stems away from legacy code"*.
+- **golangci-lint** has the full ladder: `new-from-merge-base` — *"Show only new issues created after
+  the best common ancestor (merge-base against HEAD)"* — plus a `whole-files` escape hatch, *"Show
+  issues in any part of update files"*
+  ([configuration](https://golangci-lint.run/docs/configuration/file/)). Note that the tool treats
+  **line scope as the default and file scope as the widening**, same as arcmutate.
+- **diff-cover**: *"Diff coverage is the percentage of new or modified lines that are covered by
+  tests. This provides a clear and achievable standard for code review"* — *"If you touch a line of
+  code, that line should be covered"* ([README](https://github.com/Bachmann1234/diff_cover)). Honest
+  correction to a tempting citation: its README never says "legacy"; its motivation is
+  achievability-in-review, not legacy remediation.
+- **undercover** (Ruby) gives a third granularity — changed **methods/blocks** — and is explicit
+  about the motive: for *"large or legacy codebases that lack testing"*
+  ([README](https://github.com/grodowski/undercover)).
+- **GitLab** is the weak case and should not be cited as diff scoping: coverage annotations are
+  diff-scoped for *display* (*"Annotations appear only on files that are changed in the MR diff"*)
+  but the gate is a delta — the `Coverage-Check` approval rule *"can require approval when coverage
+  drops"* ([code coverage](https://docs.gitlab.com/ci/testing/code_coverage/)). That is a ratchet
+  (§7), not a diff gate.
+
+**Answer to Q1: yes, unambiguously.** Diff/changed-line scoping is the established answer for making
+a metric blocking on a codebase that cannot reach the metric's ceiling — attested independently in
+mutation testing (Google, arcmutate, Mull, Cosmic Ray), coverage (Sonar, Codecov, diff-cover,
+undercover) and static analysis (golangci-lint). Where the granularity is stated, **line is the
+default and file is the deliberate widening**, which is the reverse of what shipped here.
+
+## 4. Q2 — is a committed accepted-survivor baseline a recognised pattern?
+
+Yes, and it is well-documented — including its failure modes, which the tools themselves are candid
+about.
+
+**The pattern.** PHPStan: *"The baseline enables you to start using PHPStan on an existing codebase
+_as if_ it had no existing errors"* ([baseline](https://phpstan.org/user-guide/baseline)). Psalm:
+baselines *"grandfather-in errors in existing code, while ensuring that new code doesn't have those
+same sorts of errors"*
+([dealing with code issues](https://psalm.dev/docs/running_psalm/dealing_with_code_issues/)). ESLint
+bulk suppressions (v9.24.0+): *"This feature allows for enabling new lint rules as `"error"` without
+fixing all violations upfront"*
+([v9.24.0 release](https://eslint.org/blog/2025/04/eslint-v9.24.0-released/)). Android lint: *"take a
+snapshot of your project's current set of warnings and use it as a baseline for future inspection
+runs so that only new issues are reported"*
+([lint](https://developer.android.com/studio/write/lint)).
+
+Note what these say about the relationship to §3: **a baseline is an implementation of diff scoping,
+not an alternative to it.** Mirtes' own post title is *"PHPStan's baseline feature lets you hold new
+code to a higher standard"*
+([Medium, 2019-10-21](https://medium.com/@ondrejmirtes/phpstans-baseline-feature-lets-you-hold-new-code-to-a-higher-standard-e77d815a5dff)).
+The real question is *where the "what is old" boundary is computed*: in a committed file
+(PHPStan/Psalm/ESLint/Android/betterer), from VCS at gate time (golangci-lint, diff-cover, Codecov
+patch), or from server-side history (Sonar).
+
+**Keying, and what it costs.** Psalm keys on file + issue type + **code snippet**, no line numbers
+(read off Psalm's own committed `psalm-baseline.xml`) — survives moves within a file, breaks on an
+edit to the expression. ESLint keys on file → rule → **count**: `"src/file1.js": {"no-undef":
+{"count": 1}}`. Checkstyle keys on **regex patterns** — broadest blast radius, silently covers future
+violations. arcmutate is the closest thing in mutation testing: an external `.pitest.exclude` CSV of
+`file, clazz, method, mutator, line start, line end`, *"each field is glob"*
+([exclusions](https://docs.arcmutate.com/docs/exclusions.html)) — note it keys on **mutator name**,
+which is the one axis a Stryker comment also has.
+
+**Documented failure modes, from the tools' own mouths.**
+
+| Failure mode | Official statement |
+| --- | --- |
+| Rot; never shrinks | PHPStan: *"The life goal of a baseline file is to not exist."* Adding new errors makes elimination *"an impossible task."* |
+| Loses the *why* and the location | PHPStan contrasts inline ignores, which *"implicitly track the line number and therefore the location of the error"*; a baseline entry carries neither reason nor site. |
+| Cannot attribute a regression | ESLint, explicitly, on what happens when a count goes up: *"There's no reliable way to determine whether the new violations were introduced recently or already existed"* ([introducing bulk suppressions](https://eslint.org/blog/2025/04/introducing-bulk-suppressions/)). |
+| Stale entries accumulate | ESLint nags *"There are suppressions left that do not occur anymore. Consider re-running the command with `--prune-suppressions`"*; PHPStan defaults `reportUnmatchedIgnoredErrors` on. |
+| A fixed issue silently returns | Android lint warns that issues *"are no longer reported"* and says you *"can optionally re-create the baseline to prevent an error from coming back undetected."* |
+| Regeneration as a silencer | PHPStan warns against it directly; Android lint requires you to *"manually delete the file"*; Psalm's `--update-baseline` *"will remove fixed issues, but will not add new issues."* |
+| Scale limit | PHPStan: *"It works best when you want to get rid of a few dozen to a few hundred reported errors."* |
+
+**The one consistent design consensus across the whole corpus:** every mature baseline tool makes
+*growing* the baseline harder than *shrinking* it — Psalm's safe command cannot add, betterer
+auto-updates only on improvement, Android lint makes you delete the file by hand, PHPStan nags by
+default. If a baseline is ever built here, replicate that asymmetry; it is the single most
+reproducible finding in §4.
+
+**Android lint's counter-design is the most transferable idea in this section:** baselines *"are
+enabled when you run inspections in batch mode… but they are ignored for the in-editor checks"*,
+because they are *"intended for codebases with a large number of existing warnings where you still
+want to fix issues locally while touching the code."* **Suppress the gate, never the feedback.** That
+is precisely the shape §9 recommends: a narrow failure scope over a wide reporting scope.
+
+**Answer to Q2:** recognised, well-supported, and the *wrong tool for this repo's problem* — see §9.
+Two reasons specific to here. (a) The 64 are not homogeneous legacy debt: 17 are a *structural*
+class that will keep being regenerated by new code written in the same style, and a baseline
+enumerating instances of a class is the anti-pattern `quality-gates.md` already names ("a rising
+suppression count is the signal that the rule failed admission"). (b) A baseline is redundant with
+diff scoping, which computes the same boundary from VCS with zero artefact to rot, merge-conflict,
+or regenerate.
+
+## 5. Q3 — equivalent mutants: state of the art, and StrykerJS's actual position
+
+**The problem is undecidable, and identification is manual. This is not a hedge.** Two independent
+primary statements:
+
+- Google, in the context of designing production suppression rules: *"An equivalent mutant is a
+  program that is syntactically different from the original, but semantically equivalent to it. The
+  question of equivalence is unfortunately undecidable, so avoiding generating equivalent mutants is
+  important"* (ICSE-SEIP 2018 §A.2.1).
+- Papadakis, Shin, Yoo, Bae, ICSE 2018 §2: *"some mutants cannot be killed as they are functionally
+  equivalent to the original program. These mutants are called equivalent and need to be removed from
+  the calculation of the mutation score. However, their identification is done manually as it is an
+  instance of an undecidable problem"*
+  ([PDF](https://coinse.github.io/publications/pdfs/Papadakis2018hi.pdf)).
+
+**A precision correction worth carrying, because the folklore citation is wrong.** Budd & Angluin
+1982 is universally cited as *proving* equivalent-mutant detection undecidable. Read directly, it
+does not: it takes program equivalence as already known undecidable (*"it is well known that the
+equivalence problem for the set of all FORTRAN programs is undecidable"*) and proves the **link** to
+test-data generation — Theorem 9: *"If a generator procedure is computable then the equivalence
+problem for 𝒫 is decidable"*, and Theorem 12: *"There exists neighborhoods Φ for which the problem
+of deciding whether an adequate test set exists is undecidable"*
+([ETH-hosted scan](https://archiv.infsec.ethz.ch/intranet_secured/8/0/BA82.pdf)). Jia & Harman's
+canonical restatement is the one everyone actually means: *"Automatically detecting all equivalent
+mutants is impossible, because program equivalence is undecidable. The equivalent mutant problem has
+been a barrier that prevents Mutation Testing from being more widely used"* (TSE 2011 §II —
+**sourcing tier (iii), see §12**; the two quotes above it are first-hand and carry the point alone).
+
+**No tool can prove a mutant equivalent in general**, so every "provably equivalent" row in
+`design.md` is a *local* proof by a reader of the types — sound, but unautomatable, and invisible to
+the gate. That is why the 17 sit in a prose table: there is nowhere else for them to live.
+
+**Partial detection exists and does not help here.** Trivial Compiler Equivalence (Papadakis, Jia,
+Harman, Le Traon, ICSE 2015) compiles mutant and original and compares object code; it detects
+roughly **30%** of equivalent mutants against the benchmark ground truth and discards *"more than 7%
+of all the mutants as being equivalent and 21% as duplicated"* on large real programs
+([UCL Discovery PDF](https://discovery.ucl.ac.uk/1499169/1/Jia_Trivial_Compiler_mutation-testing-papadakis-icse15.pdf)).
+TCE needs an optimising compiler; TypeScript's emit is type erasure, not optimisation, so TCE is not
+available on this stack. Carry the second number too: **a fifth of mutants are *duplicates* of one
+another** — the same phenomenon as this repo's "equivalent and its killable twin come from one node",
+seen from the other side, and a reason to expect a residue no amount of test-writing removes.
+
+### 5.1 The residue is not a defect of this repo — it is the expected shape of a strong suite
+
+This is the finding that most changes how the 64 should be read, and it was not on the table.
+
+- **The equivalent fraction among *survivors* rises as the suite gets stronger.** Schuler & Zeller
+  (ICST 2010), hand-classifying 140 mutants across seven Java programs: *"about 45% of all undetected
+  mutants turned out to be equivalent"*, and — boxed as a finding — *"The percentage of equivalent
+  mutants increases as the test suite improves."* Their reasoning is arithmetic: *"A perfect test
+  suite would detect **all** non-equivalent mutants; hence, 100% of undetected mutants would be
+  equivalent"*
+  ([PDF](https://www.st.cs.uni-saarland.de/publications/files/schuler-icst-2010.pdf)).
+  For a repo at 100% line coverage that has just burned 464 survivors down to 19, **a survivor list
+  that is mostly unkillable is the predicted outcome, not a failure of the burn-down.** On the
+  pre-rebase branch it was 17 of 19 — 89%. That number is high but it is on the curve, not off it.
+- **As a fraction of *all* mutants, roughly 7–40% equivalent is the historical range.** Jia & Harman
+  TSE 2011: *"Empirical results indicate that there are 10% to 40% of mutants which are equivalent"*
+  [tier (iii)]; TCE measured 7.4% mechanically detectable as equivalent [tier (ii)]; Google's ICSE
+  2021 Defects4J sample came out at 10.6% [tier (ii)]. Wide, but every point in the range is far
+  above zero.
+- **Most mutants are redundant, not informative.** Minimal/dominator-set studies converge hard:
+  Ammann, Delamaro & Offutt (ICST 2014) — *"on average, only 1.2% of mutants are in a minimal set"*
+  [tier (ii)]; Kurtz et al. (FSE 2016) — ~0.85% dominators, a **116:1** redundancy ratio [tier (ii)];
+  Papadakis et al. (ISSTA 2016) — *"fewer than 5% of all mutants are subsuming… The remaining 95% of
+  mutants are subsumed by some other mutants"* [tier (iii)]. The 2019 survey's summary: *"only few of
+  the mutants produced (approximately 5%) is practically useful. The rest is noise to the process
+  with severe consequences"* [tier (iii)].
+- **Classifying one equivalent mutant costs real time.** Grün, Schuler & Zeller (2009): *"it took us
+  15 minutes to assess the equivalence of a single mutation."* Schuler & Zeller (2010): *"On average,
+  it took us 14 minutes 28 seconds to classify one single mutation for equivalence"*, max 130
+  minutes. Google, on a Defects4J sample, got it down to *"an average of 4.6 minutes per mutant"* —
+  and found the asymmetry that matters here: *"The time to write a test to kill an unproductive
+  mutant is on average higher than the time to determine mutant equivalence"* (5.2 min to kill an
+  unproductive killable mutant vs 3.5 min to determine equivalence).
+
+**Read against `quality-gates.md`, this is decisive.** A blocking gate whose only exits are "kill it"
+or "waive it" imposes a 4–15 minute human-or-agent judgement per survivor, on a population where the
+literature expects a large unkillable fraction *precisely because the suite is good*. That is the
+appeasement pressure the admission contract exists to bound, and it does not go away by burning the
+list down — the burn-down makes the remaining fraction *worse*.
+
+### 5.2 What the state of the art does about equivalents in production: class-level AST rules
+
+Google's `expert` function is exactly this, and the papers are unusually concrete:
+
+- *"In the for-statement condition, the less than operator is not mutated to a not-equal operator.
+  This usually results in the equivalent mutant and is suppressed."* (Fig. 10)
+- For C++ `nullptr`: *"The mutants marked in bold are equivalent because of the falsy value of
+  `nullptr`… These mutation subtypes are suppressed."* (Fig. 11)
+- Memoisation: *"Such an if statement is a cache-lookup statement and is considered arid by the
+  `expert` function… the change is not detectable by any semantic tests."* (Fig. 9)
+- And the governing sentence: *"This process is manual: if we decide a certain mutation is not useful
+  and that the whole class of mutants should not be created, the rule is added to the `expert`
+  function. This is the critical part of the system because, without it, users would become
+  frustrated with non-actionable feedback and opt out of the system altogether."*
+
+The scale is worth stating, because it sets expectations for `ignore-unions`: TSE 2021 §5 records
+*"currently 26 rules that are applied to all languages, and 114 language-specific rules"*, and the
+suppression happens **before** mutants are generated — *"Suppression of arid nodes reduced the number
+of mutants by 11% for Java and by 30% for C++."*
+
+That is **exactly** option 4, and exactly what `design.md` already proposes as `ignore-unions`. The
+attested industrial answer to a recurring equivalent-mutant family is a **rule at the config site
+that inspects the AST**, not N suppressions at N sites, and not a list of instances. Note one
+mechanical difference: Stryker's ignorer marks a mutant `Ignored` rather than preventing generation,
+so the compute is still spent — but `Ignored` is outside the score denominator (§2.5), so the effect
+on the verdict is identical.
+
+**And the field's own answer to "should we chase zero survivors" is no.** Petrović, Ivanković,
+Fraser & Just, *Does mutation testing improve testing practices?* (ICSE 2021), state it as flatly as
+anything in this document: *"achieving mutation adequacy is neither practical nor desirable"*, and
+*"Considering the fact that most mutants are irrelevant and that mutant equivalence is undecidable,
+aiming at mutation adequacy is hopeless… a rational goal for a developer is to just make a test
+suite better, but not mutation adequate"*
+([PDF](https://homes.cs.washington.edu/~rjust/publ/mutation_testing_practices_icse_2021.pdf)).
+The same paper adds the nuance that stops this becoming an excuse: *"there exist killable mutants for
+which developers justifiably should not and, in practice, will not write tests. Conversely,
+equivalent mutants sometimes reveal issues in the source code, and hence are useful."* Both halves
+match this repo's experience exactly — the burn-down found no live defect but a long list of unpinned
+invariants, and the `codec !== ''` equivalent was *deleted as dead code* rather than waived.
+
+**Does any tool offer per-mutant suppression?**
+
+- **StrykerJS: no.** Suppression is by line+mutator (comment) or AST predicate (plugin). §2.2.
+- **pitest (OSS): no** — `excludedMethods` is method-glob, `avoidCallsTo` is class/package-level
+  ([quickstart/maven](https://pitest.org/quickstart/maven/)). A `DoNotMutate` marker exists in the
+  source tree but is **not documented** on pitest.org. pitest 1.25.0 added *"introduce equivalent
+  status"* (`#1471`) — the PR body is empty, so the mechanics are unconfirmed; the surrounding
+  changelog (e.g. *"filter mutants in enum switch default block"*) shows the direction is **built-in
+  interceptor filters**, i.e. class rules again.
+- **arcmutate: closest.** The `.pitest.exclude` CSV keys on `mutator` **and** a line range **and**
+  class/method globs — narrower than a Stryker comment, still not node-identity.
+- **Cosmic Ray + spor: the most interesting near-miss.** `cosmic-ray-spor-filter` reads *"a spor
+  anchored metadata repository"*; spor keeps metadata *"in a separate file from your source code, and
+  spor uses 'anchoring' techniques to keep the metadata in sync with the source code"* as it changes,
+  via offset + width + a **context window** ([spor](https://github.com/abingham/spor)). This is the
+  only mechanism found anywhere that is explicitly designed to make a suppression **survive
+  refactoring**. Still span-based, not mutator-keyed.
+- **mutmut, Mull, Stryker.NET: no** per-mutant suppression found.
+
+**Answer to Q3.** Nobody offers suppression keyed on `(mutator, replacement, AST node)`. The field's
+answer to a *family* of equivalents is a class-level AST rule; its answer to a *one-off* equivalent
+is a coarse site suppression, accepted as coarse. StrykerJS is squarely on that line, and the repo
+has already discovered the coarseness the hard way. Option 3 (refactor onto separate lines) is
+**ruled out on evidence already in the repo**: `ConditionalExpression` emits `true` and `false` from
+one node and `EqualityOperator` emits both substitutions from one operator token, so the equivalent
+and its twin are co-located whatever the formatting — no line split can separate them. Attempting it
+anyway would be contorting production code to satisfy a tool, which `quality-gates.md` names as the
+appeasement the admission contract exists to prevent.
+
+## 6. Q4 — is a percentage `thresholds.break` sound on a scoped run?
+
+No, and the evidence is unusually direct.
+
+- **Google, who could compute it, chose not to.** *"we were also unable to find a good way to surface
+  it to the engineers in an actionable way"* and *"Living mutants… alone do not make a good measure
+  of efficacy"* (§3.1). Their own §5.3 warns the raw survival ratio *"is not the mutation score…
+  because of the probabilistic nature of mutagenesis where only a subset of mutants is generated."*
+  That caveat applies verbatim to any scoped Stryker run: the denominator is whatever the scope
+  produced.
+- **The denominator moves with the diff.** Stryker's score is `detected / valid`, excluding `Ignored`
+  (§2.5). On the measured PRs that denominator ranged from 372 mutants (2 files) to thousands. A
+  fixed percentage means "one survivor is fatal on a small diff and free on a large one" — the gate's
+  strictness would be inversely proportional to the size of the change, which is backwards.
+- **The academic evidence is against the *number*, and for the *findings*.** Papadakis, Shin, Yoo &
+  Bae (ICSE 2018) tested the mutation-score-vs-real-fault-detection relationship on CoreBench and
+  Defects4J while controlling for suite size, and found *"that all correlations between mutation
+  scores and real fault detection are weak when controlling for test suite size."* Their diagnosis is
+  the one that matters here: *"mutants are indeed capable of representing the behaviour of real
+  faults. However, these mutants are very few (less than 1% of the involved mutants)… mutation scores
+  are subject to 'noise effects' caused by the large numbers of mutants that are, in some sense,
+  'irrelevant' to the studied faults."* And their positive finding is equally important — *"achieving
+  higher mutation scores improves significantly the fault detection"* and *"mutants provide good
+  guidance for improving the fault detection of test suites, but their correlation with fault
+  detection are weak."* Read together: **mutation testing earns its place; the mutation score does
+  not.** That is D1 restated by an independent empirical study, and it is the strongest external
+  support the current design has.
+- **`design.md` D1 already rejects it** on Goodhart grounds, and the repo's own history is the proof:
+  the same document records a score that read **99.89%** while 96 mutants were silenced by a
+  suppression that never ended. A percentage is precisely the shape that made that invisible; a named
+  per-mutant finding is the shape that made it visible again.
+- **Sonar's own advice against piling conditions onto a gate applies:** adding more *"may lead to
+  bottlenecks in the pace of development with minimal benefit"* and risks *"an ignored quality
+  gate."*
+
+- **A practitioner warning from the one industrial report that considered gating.** Zenseact's
+  IEEE-published experience report on adopting mutation testing in automotive discusses a threshold
+  gate and warns that engineers *"could be tempted to write tests to increase the mutation score
+  without actually testing the code"* — the appeasement failure named from the field rather than
+  from doctrine ([IEEE](https://ieeexplore.ieee.org/document/10371613)) **[abstract/landing page
+  only; the full text was not reachable]**.
+
+Keep `thresholds: { break: 100 }` if Stryker's exit code remains the verdict, since at 100 it is
+literally "zero survivors" and not a percentage in any meaningful sense. Do not introduce a sub-100
+number. **Answer to Q4: unsound; do not adopt option 5.**
+
+**But note what §5.2 does to `break: 100` even read as "zero survivors".** Google: *"aiming at
+mutation adequacy is hopeless."* Zero-survivors is mutation adequacy, restricted to a scope. That is
+tolerable only because the scope is small — which is another way of saying **the narrower the failure
+scope, the more defensible the zero-tolerance threshold on it.** File scope plus `break: 100` is
+adequacy over every line of every file you touched; changed-line scope plus `break: 100` is adequacy
+over the lines you wrote, which is what "you own the new code" means everywhere else in §3.3.
+
+## 7. Q5 — CI cost, timeouts, and ratchets that do not become rubber stamps
+
+**Cost.** Measured (§1): 13m16s for the Stryker step on a 36-file diff against a 20-minute job
+timeout — 66% of budget, 6m44s of headroom. Today a timeout is invisible (`continue-on-error`).
+Once blocking, a timeout is a **red required check on a correct branch**, which is the worst failure
+a gate can have: it is unattributable, it re-runs non-deterministically, and an agent loop learns
+that the mutation check is the flaky one. Three levers, in the order `design.md` D4 already names:
+`--concurrency` first, then narrowing scope; add a third, raising `timeout-minutes`, which is free
+and should be done regardless. A fourth, larger runners, costs money.
+
+The scope lever is the interesting one: under changed-**line** scope the mutant count falls roughly
+with changed lines rather than changed files, which is exactly the cost reduction Google built their
+system around (*"A diff-based approach greatly reduces the number of lines in which mutants are
+created, and the suppression of arid lines cuts the number of potential mutants further"*) — and
+which they quantify as 820 → 77 → 7 median mutants per changelist (§3.1). Two orders of magnitude,
+from the same two levers this repo has half-applied.
+
+**Google's own compute framing is worth borrowing:** TSE 2021 describes mutation analysis as *"about
+a 2% overhead compared to the tests being executed regularly"* and notes they run it *"during
+off-peak hours"*. Nothing here is off-peak — the job sits on the merge path — which raises the value
+of the scope lever further.
+
+**Flakiness is a real category here.** `report-model.ts` treats `Timeout` as detected and
+`NoCoverage` as surviving. A loaded runner turning a `Killed` into a `Timeout` is safe; a mutant that
+is killed by a timing-sensitive test is not. Nothing in the repo currently measures mutation-verdict
+stability across reruns, and once the check blocks, that number matters.
+
+**Ratchets.** The canonical named source is Patrick Kua's *An Appropriate Use of Metrics* on
+martinfowler.com: *"Ratcheting involves adding a code analysis tool to a continuous integration build
+that fails when a certain metric exceeds a certain value"*, and *"On each small improvement, the team
+revises the current value downwards."* The repo already has one: `mutation-scope.test.ts`'s
+suppression `CEILING = 58`, documented as *"a CEILING TO DRIVE DOWN, never a budget to spend"*. That
+is the right shape and should be kept.
+
+The rubber-stamp failure mode is documented rather than hypothetical. betterer — the purest ratchet
+tool, *"If it gets better, the .betterer.results file will be updated… If it gets worse, your test
+will fail"* — has an open bug, [#1181](https://github.com/phenomnomnominal/betterer/issues/1181),
+that once a goal is met the ratchet stops holding [reporter's account; no maintainer confirmation on
+the page]. ESLint concedes it cannot attribute a count increase. PHPStan names operator regeneration
+as the thing that makes cleanup *"an impossible task."* The common thread: **a ratchet whose value is
+mechanically regenerable by the party it constrains is a rubber stamp.** In an agent loop, the
+constrained party *is* the party that edits the file. That is the decisive argument against any
+committed, agent-writable survivor list, and it is stronger here than in any human team.
+
+## 8. Where the prior research needs amending
+
+`docs/research/automated-quality-function.md` ranked StrykerJS #1 and was right about the mechanism.
+Shipping it revealed four things that doc could not have known and that should be carried forward:
+
+1. **Its own §5.1 recipe was not implemented.** The doc says "mutate only changed, covered lines";
+   the shipped gate mutates changed *files*. §3 establishes that the line form is the attested one
+   and that the deviation's stated justification is unavailable.
+2. **"Advisory → then gating" understated the cost of the second step.** Its verdict phrased the
+   ramp as "(per-diff or nightly-with-cache, advisory → then gating on changed-code mutation score)"
+   — two errors: `--incremental` is unusable in the PR job (D4a, §2.4) and gating on a *score* is
+   unsound (§6). The correct phrasing is "advisory → then gating per-mutant on changed lines."
+3. **The doc's pitfall "mutate only changed covered lines, suppress arid lines, cap mutants per line,
+   or mutation testing drowns in noise" was right and is only two-thirds implemented.** The arid
+   suppression (D6/D7) and the one-per-line surfacing (`summarize.ts`) shipped; the line scoping did
+   not.
+4. **A new pitfall the literature does not contain, discovered here:** *the suppression mechanism
+   itself can silently lie.* A `// Stryker disable` whose `restore` never fires silences to
+   end-of-file and produces a **higher** score. Any adoption of a comment-based suppression mechanism
+   needs a boundary test that re-derives what was actually silenced from the instrumenter, which is
+   what `mutation-scope.test.ts` now does. This belongs in the pitfall list of any future doc.
+
+Also worth recording against `docs/research/result-lint-and-tier-enforcement.md`: its
+measure-violations-before-adopting method is what §9 asks for again here (measure the effective
+false-positive rate of the *blocking* configuration on real PRs before making it required), and its
+conclusion that a rule must be `error` or off is the same argument as `continue-on-error` being a
+disguised warning.
+
+## 9. Verdict and recommendation
+
+### The leaning is right, and under-specified. Adopt option 1, with option 4 as its partner.
+
+**Recommendation, in one sentence:** make the *failure* scope the changed lines (option 1), keep the
+*reporting* scope the changed files, and retire the two structural equivalent-mutant families with a
+narrowly-scoped ignorer plugin (option 4) in its own change — then flip.
+
+This is the only combination that is attested end-to-end. Line-scoped failure is what Google does
+(*"Only lines affected by the diff under review that are covered and are not arid are mutated"*),
+what arcmutate, Mull and Cosmic Ray default to, and what Sonar/Codecov/golangci-lint/diff-cover do
+in the adjacent coverage problem. Class-level AST rules are what Google does about recurring
+equivalents. Wide reporting under a narrow gate is Android lint's *"suppress the gate, never the
+feedback."*
+
+**How to implement the failure scope — a real choice with a real trade.**
+
+- **(A) Post-filter a file-scoped run.** Keep `--mutate <changed files>` exactly as today; keep
+  `continue-on-error: true` on the *Stryker* step so its exit code stops being the verdict; add a new
+  **failing** step that reads `reports/mutation/mutation.json` and fails only if a surviving mutant's
+  span intersects a changed hunk (computed with `git diff -U0` against the same merge-base).
+  Advantages: the step summary keeps the full file-scoped inventory, which is strictly more
+  information and preserves the "catches a weakened assertion elsewhere in the same file" property as
+  *reporting*; no change to Stryker invocation. Cost: no wall-clock saving (§1's 13m16s stands).
+- **(B) Range-scope the run.** Pass `--mutate 'path:start-end,path:start-end,…'` built from the diff
+  hunks (§2.1 — valid, and the maintainer's own recommendation), and let Stryker's `break: 100` be
+  the verdict, so `continue-on-error` is deleted outright. Advantages: much cheaper, simpler, no new
+  verdict code. Cost: the report shrinks to the changed lines, and **containment semantics drop
+  whole-block mutants** (§2.1) — the family that is 72% of Google's mutants.
+
+**Take (A) first, keep (B) as the named tuning lever** the moment wall-clock or the 20-minute
+timeout becomes the binding constraint. (A) also lets the intersection test use **overlap** rather
+than Stryker's **containment**, so a `BlockStatement` mutant covering a function you edited one line
+of still counts — recovering exactly what (B) loses. That is the single strongest argument for (A),
+and it is not available in (B) at all.
+
+**The trade is genuinely close, so here is the decision rule rather than a preference.** (A) costs
+~14 minutes on the merge path and buys complete diff-time reporting plus overlap semantics; (B) costs
+minutes-to-seconds and buys neither. Take (A) if the 7× merge-latency increase is acceptable to the
+owner; take (B) the first time a PR's Stryker step exceeds ~15 minutes, and accept two consolations:
+the changed-line findings — the ones the gate actually blocks on — are unaffected, and the
+**weekly full run already exists** as the wide channel for everything (B) stops seeing at diff time.
+What (B) genuinely loses is *timeliness* of the file-wide signal, not the signal itself. Do not treat
+this as a permanent fork: instrument the Stryker-step duration in the job summary so the switch is
+triggered by a number rather than by irritation.
+
+**Reject options 2, 3, 5, 6.**
+
+- **2 (baseline file):** recognised but wrong here — §4. It duplicates what diff scoping computes for
+  free, it rots (PHPStan: *"The life goal of a baseline file is to not exist"*), it cannot attribute
+  a regression once a count moves (ESLint's own admission), and in an agent loop the constrained
+  party can regenerate it (§7). If it were ever built, key on `(file, location, mutatorName,
+  replacement)` — never on `id` (§2.4/§2.6) — and make growing it harder than shrinking it.
+- **3 (refactor onto separate lines):** ruled out by evidence already in `design.md` — the equivalent
+  and its killable twin come from the *same node* for both mutator families. §5.
+- **5 (percentage break):** unsound on a varying denominator; rejected by D1, by Google, and by the
+  repo's own 99.89% incident. §6.
+- **6 (`--incremental` baseline):** rejected by D4a for the right reason, and additionally blocked
+  upstream — [#6004](https://github.com/stryker-mutator/stryker-js/issues/6004), open against the
+  pinned 9.6.1, makes the incremental file uncommittable with the vitest runner. §2.4.
+
+### What to do about the ~17 unwaivable equivalents
+
+**First, stop treating them as debt.** §5.1 says the equivalent fraction among survivors *rises* as
+the suite improves (Schuler & Zeller: *"The percentage of equivalent mutants increases as the test
+suite improves"*), that under 5% of mutants carry unique information at all, and that Google calls
+mutation adequacy *"hopeless"*. Seventeen unkillable survivors after a 464→19 burn-down is the
+literature's predicted outcome, not a residue of incomplete work. Task 2.1's exit criterion — "main
+becomes mutant-clean" — is therefore **unreachable in principle**, not just unreached, and any plan
+whose next step is "finish the burn-down" is planning against a state that does not exist.
+
+**Second, under the recommendation nothing has to be done to them before the flip.** That is the
+point of line scoping: a mutant on a line no PR touched cannot fail that PR. The 17 stop being a
+blocker the moment the failure scope stops including untouched lines — and when a PR *does* edit one
+of those lines, being asked to re-audit the equivalence claim is correct behaviour, not friction.
+This is the same property Sonar sells: *"You own the quality and security of the new code you are
+working on today."*
+
+Three follow-ups, in priority order, none of them blocking:
+
+1. **Write the `ignore-unions` ignorer plugin** that `design.md` already recommends, in its own
+   change with its own grilling, and let it retire families 1 (exhaustive `switch` arms that yield
+   nothing) and 2 (type-narrowing operands on discriminated unions) at the config site. This is the
+   attested shape (Google's `expert` function; Stryker's own maintainer pointing every "control which
+   contexts get mutated" request at #3229) and the doctrine-preferred one (*"A rejected rule is
+   disabled once, in configuration, with its reason"*). Expected effect per `design.md`: ~17
+   recorded survivors cleared and the inline-waiver count back to roughly 25. Its false-negative cost
+   — it would also hide a genuinely wrong `case` grouping — must be argued and bounded by a test the
+   way `ignore-logging.mjs` is.
+2. **Keep the recorded-survivor table in `design.md` as the audit record**, and add a boundary test
+   that fails if the table and the weekly full run disagree. Right now the table is prose that
+   nothing checks; the same class of drift that produced a false 99.89% can produce a false table.
+3. **Take the free wins that already exist.** `design.md` records that `'location' in state` /
+   `'remediation' in state` removed two of these rows outright, because `in` is not a
+   `ConditionalExpression` operator — the equivalent mutant does not exist to begin with. That is the
+   promotion ladder's top rung ("type it away") and it is available wherever it does not cost domain
+   readability. It was correctly *not* applied to `decide.ts`'s phase guard.
+
+The **2 MusicBrainz survivors are a different animal and must not be swept up with the 17.** They are
+a real unspecified-behaviour finding (an album title that normalises to empty comparing equal to an
+absent title; `÷`, `+`, `?` are real releases). Under line scope they also stop blocking, but they
+are a domain bug to fix — the `undefined`-not-`''` identity change `design.md` names — not a mutant
+to suppress. Fixing them is the honest close; waiving them would be exactly the fiction
+`testing.md` forbids.
+
+### Can `continue-on-error` be removed, and what else must change with it
+
+**Under (A): no — it moves, and this must be stated plainly rather than presented as a removal.**
+The flag stays on the Stryker step *because the verdict moves off Stryker's exit code*; the job then
+gains a new step that carries the verdict and does **not** have the flag. That step must fail on
+three things, not one:
+
+1. a surviving mutant whose span intersects a changed hunk;
+2. a **missing or unreadable** report — `report-model.ts` already models all three "no report" cases
+   and `file-drift.ts` already refuses to report zero drift on an unreadable one; the PR verdict step
+   needs the same refusal, or a Stryker crash becomes a green gate;
+3. a scope that resolved to files but produced **zero analysed mutants**, which `summarize.ts`
+   already detects and describes (*"Every mutant here was ignored, so nothing in this scope was
+   actually audited"*) but does not act on.
+
+Under (B), `continue-on-error` is deleted outright and Stryker's `break: 100` is the verdict — which
+is cleaner, and is a genuine argument for (B) if the extra verdict code feels like too much machinery.
+
+**What else must change with the flip:**
+
+- **`timeout-minutes: 20` becomes load-bearing.** 13m16s observed, 66% of budget, and the cost is not
+  bounded by the file count. Raise it (30 is the same order as the existing `release` job) *and*
+  record the observed numbers where the comment currently says *"NOT yet observed in CI"*. A blocking
+  job that times out is worse than no job.
+- **Merge latency goes from ~2 min to ~14** (§1). Nothing forbids it, but it should be a decision,
+  not a discovery. Under (B) it largely goes away.
+- **Measure the effective false-positive rate on this repo before requiring the check.**
+  `quality-gates.md`'s bar is *"Under ten percent effective false positives, measured on *this*
+  repository, not on the check's reputation elsewhere."* Google, after years of tuning across seven
+  languages and 140 arid rules, reports mutant productivity of **82% aggregate, 80→89% over time,
+  against a stated ~90% target** (§3.1). So the industry-best number is *at* this repo's bar, not
+  comfortably inside it — **and Google's release valve is a human clicking "Not useful", which this
+  factory does not have.** The flip is admissible only if the *scoped, post-D6/D7,
+  post-`ignore-unions`* configuration measures under 10% on real PRs here. Run the blocking logic in
+  shadow (compute the verdict, print it, don't fail) across a handful of real PRs and count. This is
+  the same measure-before-adopt method `result-lint-and-tier-enforcement.md` used for a lint rule.
+- **Cap the *verdict* per line, not just the summary.** `summarize.ts` already applies Google's
+  one-mutant-per-line surfacing rule, and says so (*"killing the shown one usually kills its
+  siblings"*) — which TSE 2021 confirms empirically (*"In more than 90% of the cases, either all
+  mutants in a line are killed, or all mutants in a line survive"*). But the *verdict* still counts
+  every survivor, so one weak line can present as a dozen blocking findings. Google caps the surfaced
+  set to a median of **7 per changelist**; this gate has no cap at all. Deduplicating the failing set
+  per line costs nothing and makes the finding count honest.
+- **A cheap, justified escape hatch must remain.** 100% mutant-clean is unreachable (§5), so the gate
+  needs a legitimate "this one is equivalent, here is why" exit that does not require appeasing it
+  with a fiction test. Today that is `// Stryker disable next-line`, which is too coarse for the very
+  family that needs it. The ignorer plugin is the durable answer; until it lands, an explicitly
+  recorded survivor with a written reason is better than a waiver that silences a twin — which is the
+  position `design.md` already took, and it was right.
+- **`test/boundaries/mutation-scope.test.ts` pins the job's command shape** (`expect(pipeline).toMatch(
+  /run: pnpm exec stryker run --mutate/)`) and the scope alternation. Both need updating with the
+  job, and the new verdict step deserves its own scenario — otherwise deleting the gate leaves the
+  boundary tier green.
+- **`report.ts`'s contract inverts.** Its header says *"Never decides pass/fail — Stryker's exit code
+  does that."* Under (A) that stops being true and the comment becomes a lie of exactly the kind this
+  repo hunts.
+- **`design.md` D2's "blocking is a deviation from Google" remains unattested and should stay marked
+  so.** §3.1 confirms Google never blocked. The deviation may still be right for an unattended loop —
+  the Meta 0%-vs-70% batch/diff finding says an advisory channel with no consumer is dead — but it is
+  reasoning by analogy, not evidence, and the compensations D2 promised (narrower scope than Google's,
+  a seeded arid list) are only half delivered while scope is *wider* than Google's.
+
+### Pitfall checklist (drawn from the sources)
+
+- **Do not let a suppression mechanism grade itself.** A block-form `disable` with no firing
+  `restore` silences to end of file and *raises* the score. Re-derive what was actually silenced from
+  the instrumenter, in a test. (This repo, discovered the hard way; not in any literature.)
+- **A mutant is a sub-expression, not a line.** Triage off `location.start/end` columns, never off the
+  printed source line. (`design.md`; and the report schema carries columns — §2.6.)
+- **Range scoping drops whole-block mutants.** `locationIncluded` is containment. SBR is 72% of
+  Google's mutants and the second-least likely to survive — losing it silently is a big hole. Prefer
+  overlap in a post-filter.
+- **Parse `git diff -U0` hunk headers carefully.** `@@ -a,b +c,d @@` with `d` absent means one line;
+  **`d == 0` means a pure deletion** and adds no lines to mutate — turning it into the range `c-c`
+  would gate on a line the branch never touched. (Verified against a real diff in this repo:
+  `-U0` emits both `+85` and `+44,25` forms.)
+- **Never key a baseline or a report join on Stryker's mutant `id`** — it is a per-run ordinal
+  (`MutantCollector.nextMutantId++`). Key on `(file, location, mutatorName, replacement)`.
+- **A ratchet the constrained party can regenerate is a rubber stamp.** betterer #1181, ESLint's
+  count-attribution admission, PHPStan's warning against regeneration. In an agent loop this is not a
+  risk, it is the default.
+- **Baselines rot and lose the *why*.** If one is ever built: reason required per entry, staleness
+  detection on by default, and growth harder than shrinkage.
+- **An arid/ignore rule that is too broad stops auditing real code with nobody noticing.** D6's
+  narrow scoping (arguments only, statically-named receiver *and* level) and its own test are the
+  model; `ignore-unions` must be held to the same bar, and its false-negative named.
+- **A blocking check that can time out or flake is worse than no check.** Raise the timeout, measure
+  verdict stability across reruns, and make a missing/unreadable report a failure rather than a pass.
+- **Do not gate on a score.** Denominator varies with scope; Google could compute it and chose not
+  to; this repo already produced a false 99.89%. Zenseact's field warning is the concrete failure:
+  engineers *"tempted to write tests to increase the mutation score without actually testing the
+  code."*
+- **Do not set "zero survivors anywhere" as a milestone.** The equivalent fraction among survivors
+  *rises* as the suite improves (Schuler & Zeller); <5% of mutants carry unique information
+  (subsumption studies); Google calls adequacy *"hopeless"*. A plan that waits for a clean main waits
+  forever.
+- **Cap findings per line and per PR.** One weak line spawns a dozen mutants; Google surfaces ≤1 per
+  line and a median of 7 per changelist. An uncapped blocking gate turns one fix into a wall.
+- **Appeasement is the failure mode, not noise.** `quality-gates.md` and `testing.md` both say it:
+  a finding an agent cannot honestly fix gets a fiction test. Every mutation finding must have a
+  legitimate non-test exit (kill, delete, type away, or a justified precise waiver).
+
+### Attested vs unattested in the current design
+
+**Attested (named prior art, verified this pass):**
+- Diff-time deployment of the finding — Google (mutation), Meta (static analysis), Sonar, Codecov.
+- Per-mutant findings rather than a score — Google explicitly rejects the score (§3.1, §6).
+- At most one surfaced mutant per line (`summarize.ts`) — Google's exact rule, quoted §3.1.
+- Arid-node suppression as a **configured rule with its reason** (D6, `ignore-logging.mjs`) —
+  Google's `expert` function, and the mechanism Stryker's maintainer points every such request at.
+- A class-level rejection of a mutant family that is false for a structural reason (D7 `ignoreStatic`)
+  — same category as Google's `nullptr`/`for`-condition suppressions.
+- Adapters in scope (D3) — no contrary evidence found; consistent with mutation testing's general
+  claim to find assertion gaps wherever they are.
+- The suppression **ceiling** in `mutation-scope.test.ts` — a textbook ratchet (Kua).
+- A weekly full run filing tracker issues rather than blocking — the "durable channel" half of the
+  Meta batch-vs-diff finding.
+
+**Unattested / this repo running ahead of the evidence (flag as risk):**
+- **Blocking rather than advisory** (D2). Google never blocked — *"These findings do not need to be
+  resolved by the author before submission, unless a human reviewer marks them as mandatory"* (TSE
+  2021 §2.4); arcmutate defaults to a *warning*-level check run; Meta's mutation work surfaced
+  mutants as review comments [secondary, and the source link did not survive re-check — see §12].
+  **No peer-reviewed deployment of a blocking mutation gate was found in this sweep.** The argument
+  for blocking here (no human to shrug, and an advisory
+  channel with no consumer is the attested-dead Meta batch shape) is sound reasoning by analogy, but
+  it is analogy, not evidence — and this repo has now *observed* the dead-advisory shape directly:
+  v3.18.0's 45 survivors were reported into a step summary that nothing consumed.
+- **A gate with no per-changelist cap on findings.** Google caps at ~7 median; this one is uncapped.
+  Unattested at any volume.
+- **File scope** (the shipped deviation). No source found anywhere that recommends file granularity
+  as a *default* for a mutation gate; golangci-lint and arcmutate both offer it explicitly as the
+  *widening*.
+- **A 100% break threshold on a codebase with known-unkillable mutants.** No source found that gates
+  a mutation run at zero survivors; Google calls mutation adequacy *"neither practical nor
+  desirable"*. Defensible only in proportion to how narrow the scope is (§6).
+- **Task 2.1's "main becomes mutant-clean" exit criterion.** Contradicted by Schuler & Zeller,
+  Papadakis (subsumption), and Google (adequacy) — the target state is not reachable, so the task as
+  written can never close. This is arguably the single most consequential correction in this doc.
+- **`design.md` D4a's claim that `thresholds.break` applies to the merged incremental whole** — true
+  as measured on this repo, **not** documented upstream (§2.4). Keep it labelled as measured.
+- **An agent loop as the consumer of mutation findings.** Google's 82–89% productivity was tolerable
+  because a human clicks "Not useful"; there is no evidence about what an agent does with the other
+  11–18% under a *blocking* gate. This is the gap that most needs measuring here, and §9 says how.
+
+## 10. Documentation drift found (report, not fixed — this doc changes nothing else)
+
+1. **`.github/workflows/pipeline.yml`, the `mutation` job comment** argues the `continue-on-error`
+   decision from *"464 survivors to 6 (99.89%)"*, *"the 6 sit in…"*, and *"Four are provably
+   equivalent narrowing operands"*. `design.md` **explicitly retracts** that number: run 6's 99.89%
+   was false, corrected to 19 at 99.67%, and the tip of `main` is **64 at 98.96%**. The workflow's
+   blocking rationale is argued from a figure its own design document calls a counterexample.
+2. **Same file: `timeout-minutes: 20 # projected low-minutes on a 4-core runner; NOT yet observed in
+   CI`.** Observed three times since (§1), the largest being 13m58s.
+3. **`design.md` §Open Questions / task 3.3** records 2m31s on a 2-file diff and says *"Re-measure on
+   the first PR that actually changes production code."* Two such PRs have since run (9m37s, 13m58s);
+   neither is recorded, and the 2m31s figure now reads as representative when it is the smallest of
+   three.
+4. **`openspec/changes/mutation-gate/tasks.md` task 4.1** says the flip needs *"split the four
+   narrowing-operand lines so their waivers become precise"*. `design.md` supersedes this twice over:
+   there are **seventeen**, and splitting **cannot work** for this mutator family. The task's exit
+   criterion is unreachable as written.
+5. **The `mutation-scope.test.ts` ceiling (58)** and the burn-down's *"the repo's waiver count is now
+   58"* coexist in `design.md` with an earlier paragraph claiming *"it was the one waiver in the
+   repo"*, parenthetically corrected. Readable, but the parenthetical is doing a lot of work.
+
+## 11. Cross-references
+
+- `docs/research/automated-quality-function.md` — produced this chain; §5.1 is the Google recipe this
+  doc verifies from source, and §8 above records where it needs amending.
+- `docs/research/result-lint-and-tier-enforcement.md` — the in-house exemplar of measuring violations
+  against this repo before adopting a rule; §9's "measure the effective FP rate in shadow before
+  requiring the check" is the same method applied to a gate rather than a lint rule.
+- `docs/development/quality-gates.md` — the admission contract, the waiver doctrine, the promotion
+  ladder and the latency budget every recommendation above is weighed against.
+- `docs/development/testing.md` — the coverage ladder and the anti-fiction doctrine that bounds what
+  "kill the mutant" is allowed to mean.
+- `openspec/changes/mutation-gate/{design,tasks}.md` — D1, D2, D4a, D5, D6, D7, the burn-down, the
+  17-row survivor table, and task 4.1, which this doc's verdict would rewrite.
+
+## 12. Sources
+
+**StrykerJS (primary: docs, source, tracker — all accessed 2026-08-07)**
+- Configuration (`mutate`, mutation range, `thresholds`, `ignorers`, `ignoreStatic`, `incremental`): https://stryker-mutator.io/docs/stryker-js/configuration/
+- Disable mutants + ignore-plugin API: https://stryker-mutator.io/docs/stryker-js/disable-mutants/
+- Incremental mode: https://stryker-mutator.io/docs/stryker-js/incremental/
+- Mutant states & metrics (score denominator, status set): https://stryker-mutator.io/docs/mutation-testing-elements/mutant-states-and-metrics/
+- Report schema (fields incl. `location.start/end.column`): https://github.com/stryker-mutator/mutation-testing-elements/blob/master/packages/report-schema/src/mutation-testing-report-schema.json
+- `DirectiveBookkeeper` (line+mutator keying, verified): https://github.com/stryker-mutator/stryker-js/blob/master/packages/instrumenter/src/transformers/directive-bookkeeper.ts
+- `babel-transformer.ts` — `shouldMutate` gates on `locationIncluded(range, node.loc)` (range containment, verified): https://github.com/stryker-mutator/stryker-js/blob/master/packages/instrumenter/src/transformers/babel-transformer.ts
+- `util/syntax-helpers.ts` — `locationIncluded` / `locationOverlaps` definitions (verified): https://github.com/stryker-mutator/stryker-js/blob/master/packages/instrumenter/src/util/syntax-helpers.ts
+- `MutantCollector` (`nextMutantId` is a per-run ordinal): https://github.com/stryker-mutator/stryker-js/blob/master/packages/instrumenter/src/transformers/mutant-collector.ts
+- Mutation-range validation (`options-validator.ts`): https://github.com/stryker-mutator/stryker-js/blob/master/packages/core/src/config/options-validator.ts
+- PR #2751 (mutation range, v4.6.0): https://github.com/stryker-mutator/stryker-js/pull/2751
+- Issue #2843 (mutate only changed lines; maintainer recommends `--mutate foo.js:25-30` + git diff): https://github.com/stryker-mutator/stryker-js/issues/2843
+- Issue #551 (mutate only modified files; "I wouldn't want to use git as a source of files"): https://github.com/stryker-mutator/stryker-js/issues/551
+- Issue #1980 (specify lines to mutate — closed as implemented): https://github.com/stryker-mutator/stryker-js/issues/1980
+- Issue #1472 (ignore specific mutations — closed by the comment syntax): https://github.com/stryker-mutator/stryker-js/issues/1472
+- Issue #3229 (ignorer plugin — closed as implemented): https://github.com/stryker-mutator/stryker-js/issues/3229
+- Issue #3228 (checker-plugin ignore — closed in favour of #3229): https://github.com/stryker-mutator/stryker-js/issues/3228
+- Issue #4141 (more control over mutation context — maintainer points at #3229): https://github.com/stryker-mutator/stryker-js/issues/4141
+- Issue #6004 (OPEN: vitest-runner non-deterministic test IDs block committing the incremental baseline; 9.6.1): https://github.com/stryker-mutator/stryker-js/issues/6004
+- Stryker.NET configuration (`--since`, `--with-baseline`, for contrast): https://stryker-mutator.io/docs/stryker-net/configuration/
+
+**Google's production mutation system**
+- Petrović & Ivanković, "State of Mutation Testing at Google", ICSE-SEIP 2018 (read in full from the PDF): https://research.google.com/pubs/archive/46584.pdf (302s to https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/46584.pdf)
+- Petrović, Ivanković, Fraser, Just, "Practical Mutation Testing at Scale: A View from Google", IEEE TSE 2021 (§2.4 the non-blocking sentence; §5 the 26+114 arid rules and the 11%/30% mutant reduction; §7 the 820→77→7 median; the 82%/80→89%/~90% productivity figures; the ~2% compute overhead): https://arxiv.org/abs/2102.11378 — PDF: https://arxiv.org/pdf/2102.11378
+- Petrović, Ivanković, Fraser, Just, "Does Mutation Testing Improve Testing Practices?", ICSE 2021 ("achieving mutation adequacy is neither practical nor desirable"; "aiming at mutation adequacy is hopeless"; the productive/unproductive framing; the 4.6-min-per-mutant classification cost): https://homes.cs.washington.edu/~rjust/publ/mutation_testing_practices_icse_2021.pdf
+
+**Equivalent mutants, redundancy, and the cost of triage**
+
+*Verification note, because it matters for how much weight these carry.* Three tiers. **(i) Read
+first-hand in this session, from the PDF:** Google ICSE-SEIP 2018, and Papadakis/Shin/Yoo/Bae ICSE
+2018. **(ii) Fetched by a sub-agent under a quote-or-say-so contract, at a URL I re-checked and
+found live:** Budd & Angluin, Schuler & Zeller, Grün et al., Ammann/Delamaro/Offutt,
+Kurtz et al., TCE, TSE 2021, ICSE 2021. **(iii) Fetched by a sub-agent at a URL I could NOT
+re-verify:** Jia & Harman, ISSTA 2016, the 2019 survey — canonical landing pages are cited instead
+and the figures are flagged. One sub-agent URL for the 2019 survey resolved to an entirely unrelated
+paper on re-check and has been removed; treat tier (iii) figures as corroborating, not load-bearing.
+Nothing in §9's verdict depends on a tier-(iii) number alone.
+
+- Budd & Angluin, "Two notions of correctness and their relation to testing", Acta Informatica 18(1), 1982 — ETH-hosted scan, live. Note it does **not** directly prove equivalent-mutant undecidability; it assumes program equivalence undecidable and establishes the link (Thms 9, 12): https://archiv.infsec.ethz.ch/intranet_secured/8/0/BA82.pdf
+- Schuler & Zeller, "(Un-)Covering Equivalent Mutants", ICST 2010 ("about 45% of all undetected mutants turned out to be equivalent"; "The percentage of equivalent mutants increases as the test suite improves"; 14m28s to classify one) — live: https://www.st.cs.uni-saarland.de/publications/files/schuler-icst-2010.pdf
+- Grün, Schuler, Zeller, "The Impact of Equivalent Mutants", Mutation 2009 ("it took us 15 minutes to assess the equivalence of a single mutation") — live: https://www.st.cs.uni-saarland.de/publications/files/gruen-mutation-2009.pdf
+- Ammann, Delamaro, Offutt, "Establishing Theoretical Minimal Sets of Mutants", ICST 2014 ("on average, only 1.2% of mutants are in a minimal set") — live: https://cs.gmu.edu/~offutt/rsrch/papers/minimal-mutants.pdf
+- Kurtz et al., "Analyzing the Validity of Selective Mutation with Dominator Mutants", FSE 2016 (~0.85% dominators; ~116:1 redundancy) — live: https://cs.gmu.edu/~offutt/rsrch/papers/dominator-mutants.pdf
+- Jia & Harman, "An Analysis and Survey of the Development of Mutation Testing", IEEE TSE 37(5), 2011 ("program equivalence is undecidable"; "10% to 40% of mutants which are equivalent") — **tier (iii)**; the CREST PDF mirror refused connections on re-check (ECONNREFUSED 128.16.10.31). Canonical: https://ieeexplore.ieee.org/document/5487526 ; DOI 10.1109/TSE.2010.62
+- Papadakis, Henard, Harman, Jia, Le Traon, "Threats to the Validity of Mutation-Based Test Assessment", ISSTA 2016 ("fewer than 5% of all mutants are subsuming") — **tier (iii)**; ACM and UCL Discovery both 403'd my re-check. Canonical: https://dl.acm.org/doi/10.1145/2931037.2931040
+- Papadakis, Kintis, Zhang, Jia, Le Traon, Harman, "Mutation Testing Advances: An Analysis and Survey", Advances in Computers 112, 2019 ("only few of the mutants produced (approximately 5%) is practically useful") — **tier (iii)**; no free full text I could verify. Canonical: https://www.sciencedirect.com/science/article/pii/S0065245818300305 (403 to fetch) ; dblp: https://dblp.org/rec/journals/ac/PapadakisK00TH19.html
+- Papadakis, Jia, Harman, Le Traon, "Trivial Compiler Equivalence", ICSE 2015: https://discovery.ucl.ac.uk/1499169/1/Jia_Trivial_Compiler_mutation-testing-papadakis-icse15.pdf (~30% of equivalent mutants detected; >7% of all mutants equivalent, 21% duplicated)
+- Papadakis, Shin, Yoo, Bae, "Are Mutation Scores Correlated with Real Fault Detection?", ICSE 2018 (read from the PDF; the undecidability + manual-identification statement, the weak-correlation result, and the "<1% of mutants" noise finding): https://coinse.github.io/publications/pdfs/Papadakis2018hi.pdf — ACM: https://dl.acm.org/doi/10.1145/3180155.3180183
+
+**Other mutation tools**
+- arcmutate git integration (change-based mode, default scope = line): https://docs.arcmutate.com/docs/git-integration.html
+- arcmutate exclusions (`.pitest.exclude` CSV: file, class, method, mutator, line range): https://docs.arcmutate.com/docs/exclusions.html
+- arcmutate GitHub integration (advisory by default; `LEVEL` makes it blocking): https://docs.arcmutate.com/docs/github/overview.html
+- pitest quickstart (`mutationThreshold`, `excludedMethods`, `avoidCallsTo`): https://pitest.org/quickstart/maven/
+- pitest README changelog (SCM goal deprecated #1353, removed #1379; "introduce equivalent status" #1471): https://github.com/hcoles/pitest/blob/master/README.md
+- Mull incremental mutation testing (git-diff, line-scoped): https://mull.readthedocs.io/en/latest/IncrementalMutationTesting.html
+- Cosmic Ray filters (`cr-filter-git`, `cr-filter-pragma`, `cosmic-ray-spor-filter`): https://cosmic-ray.readthedocs.io/en/stable/how-tos/filters.html
+- spor (anchored metadata designed to survive edits): https://github.com/abingham/spor
+- mutmut (incremental re-test; no threshold gate found): https://mutmut.readthedocs.io/
+
+**Diff-scoped gating**
+- Sonar, Clean as You Code: https://docs.sonarsource.com/sonarqube-server/10.5/user-guide/clean-as-you-code
+- Sonar, quality gates ("focuses on keeping high quality standards for new code"): https://docs.sonarsource.com/sonarqube-server/quality-standards-administration/managing-quality-gates/introduction-to-quality-gates
+- Sonar, defining new code (90-day cap): https://docs.sonarsource.com/sonarqube-server/10.6/project-administration/clean-as-you-code-settings/defining-new-code
+- Sonar, managing issues (accepted issues as the per-issue escape hatch): https://docs.sonarsource.com/sonarqube-server/10.6/user-guide/issues/managing
+- Codecov commit status (project vs patch): https://docs.codecov.com/docs/commit-status
+- Codecov blog, why patch coverage matters **[secondary — maintainer blog, not reference docs]**: https://about.codecov.io/blog/why-patch-coverage-is-more-important-than-project-coverage/
+- golangci-lint configuration (`new`, `new-from-rev`, `new-from-merge-base`, `whole-files`): https://golangci-lint.run/docs/configuration/file/
+- diff-cover: https://github.com/Bachmann1234/diff_cover
+- undercover (changed methods/blocks; explicit legacy framing): https://github.com/grodowski/undercover
+- GitLab code coverage (annotations diff-scoped; gate is a delta, not a diff): https://docs.gitlab.com/ci/testing/code_coverage/
+- Danger JS (framework for diff-scoped rules): https://danger.systems/js/
+
+**Baselines & suppression files**
+- PHPStan baseline ("The life goal of a baseline file is to not exist"): https://phpstan.org/user-guide/baseline
+- Mirtes, "PHPStan's baseline feature lets you hold new code to a higher standard": https://medium.com/@ondrejmirtes/phpstans-baseline-feature-lets-you-hold-new-code-to-a-higher-standard-e77d815a5dff
+- Psalm, dealing with code issues (`--update-baseline` cannot add): https://psalm.dev/docs/running_psalm/dealing_with_code_issues/
+- Psalm's own committed baseline (keying = file + issue type + code snippet): https://github.com/vimeo/psalm/blob/master/psalm-baseline.xml
+- ESLint, introducing bulk suppressions (keying = file → rule → count; the attribution admission): https://eslint.org/blog/2025/04/introducing-bulk-suppressions/
+- ESLint v9.24.0 release notes: https://eslint.org/blog/2025/04/eslint-v9.24.0-released/
+- ESLint suppressions docs (`--prune-suppressions`): https://eslint.org/docs/latest/use/suppressions
+- Android lint baseline ("suppress the gate, never the feedback"): https://developer.android.com/studio/write/lint
+- Checkstyle SuppressionFilter (regex-keyed): https://checkstyle.org/filters/suppressionfilter.html
+- Error Prone flags (severity demotion + path exclusion, no occurrence baseline): https://errorprone.info/docs/flags
+- NullAway configuration (package-scoped adoption): https://github.com/uber/NullAway/wiki/Configuration
+
+**Ratchets**
+- Kua, "An Appropriate Use of Metrics" (the canonical definition of ratcheting), martinfowler.com: https://martinfowler.com/articles/useOfMetrics.html
+- betterer introduction (auto-tighten on improvement, fail on regression): https://phenomnomnominal.github.io/betterer/docs/introduction
+- betterer issue #1181 (ratchet stops holding once a goal is met) **[reporter's account; no maintainer confirmation on the page]**: https://github.com/phenomnomnominal/betterer/issues/1181
+
+**Industrial adoption / gating**
+- Zenseact, "Mutation Testing in Practice: Insights From [an] Automotive Industry Case Study" (the threshold-gate temptation to "cheat the score") — **landing page only; full text not reachable** **[secondary]**: https://ieeexplore.ieee.org/document/10371613
+- Meta, mutation-guided test improvement / "Mutation Monkey" (review-time surfacing, not gating; the *"We are never going to land this diff"* reviewer quote) — **[secondary; the engineering.fb.com permalink I was given 404s on re-check, so this is reported as a sub-agent finding I could not verify]**
+
+**Could not reach / negative findings (stated rather than paraphrased)**
+- **No peer-reviewed report of a mutation gate that *blocks* merge was found.** Every industrial deployment located (Google, Meta, arcmutate's default, Zenseact's discussion) is advisory or human-escalated. Absence of a found source, not proof of absence — but the sweep was deliberate.
+- The full TSE 2021 text was read from the arXiv PDF; the ACM version was not fetched. ICSE 2021 was read from the author-hosted PDF.
+- StrykerJS docs do **not** state whether `thresholds.break` applies to the merged `--incremental` report. Reported as an absence; D4a's claim stands on this repo's measurement, not on documentation.
+- No dedicated StrykerJS page on "adopting mutation testing on a legacy codebase" or "CI on changed files only" was found. Absence of a found page, not proof of absence.
+- pitest PR #1471 ("introduce equivalent status") has an empty description; its mechanics are unconfirmed.
+- `arcmutate.com` (the marketing site) is a JS-rendered SPA and returned only its tagline; all arcmutate claims above come from `docs.arcmutate.com`, which served fine.
+- Sonar's `…/latest/core-concepts/clean-as-you-code/introduction/` 404s; versioned URLs (10.5/10.6) were substituted and are the ones cited.
+- The ThoughtWorks Technology Radar has **no** technique named "ratcheting"; the martinfowler.com/Kua article is the citation that holds.
+- PHPStan issue #3648's "no line numbers to avoid merge conflicts" rationale appears only as the *reporter's* assumption, with no maintainer reply on the page.
+</content>
+</invoke>

--- a/openspec/changes/mutation-gate-diff-scope/.openspec.yaml
+++ b/openspec/changes/mutation-gate-diff-scope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-07

--- a/openspec/changes/mutation-gate-diff-scope/design.md
+++ b/openspec/changes/mutation-gate-diff-scope/design.md
@@ -1,0 +1,421 @@
+# Design — mutation-gate-diff-scope
+
+## Context
+
+See `proposal.md` — Why. The evidence base is `docs/research/blocking-mutation-gate-scope.md`
+(2026-08-07), which verified the house facts against `main` and the tool facts against
+StrykerJS's own source, docs and tracker. This document does **not** re-argue that research; it
+records which of its options were taken, and why the rejected ones were rejected. Section
+references below (§n) are to that document.
+
+What exists today, and constrains the approach:
+
+- `.github/workflows/pipeline.yml` job `mutation`: PR-only, `timeout-minutes: 20`, a scope step
+  resolving changed production files via `git merge-base` + `git diff --name-only`, then
+  `pnpm exec stryker run --mutate "$MUTATE"` under `continue-on-error: true`, then an
+  `if: always()` step writing `scripts/mutation/report.ts` to the step summary.
+- `stryker.config.mjs` sets `thresholds.break: 100` — literally "zero survivors among
+  non-ignored mutants", not a percentage in any meaningful sense (§2.5) — and writes its JSON to
+  `reports/mutation/mutation.json`.
+- `scripts/mutation/report-model.ts` is the one tolerant reader over that JSON. It already
+  models all three "no report" cases (absent, unparseable, wrong shape) as `undefined`, and
+  `summarize.ts` already detects and describes the all-ignored scope. `file-drift.ts` already
+  refuses to report zero drift from an unreadable report.
+- `test/boundaries/mutation-scope.test.ts` pins the job's command shape, the scope alternation,
+  the report path, the waiver doctrine and the suppression ceiling.
+- Main is not mutant-clean: 64 survivors at 98.96% at the tip — 45 of them arrived with one
+  unrelated feature (v3.18.0) inside a week, 17 are provably-equivalent narrowing operands
+  deliberately left unwaived, 2 are a real unspecified-behaviour finding.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Make the *failure* scope the changed lines while the *reporting* scope stays the changed files.
+- Move the verdict off the mutation runner's exit code onto a step that owns it, and make that
+  step fail closed.
+- Ship the verdict in shadow, with one switch to enforcement and a measurement gating it.
+- Leave the record honest: fix the drift the research found, and restate the two tasks whose
+  premise this change supersedes.
+
+**Non-Goals**
+
+- **Enabling enforcement.** The switch ships off. Flipping it is a separate decision on separate
+  evidence.
+- **The `ignore-unions` ignorer plugin**, and **fixing the two MusicBrainz survivors.** Both are
+  named in `proposal.md` as out of scope with their reasons.
+- **Any change to what Stryker mutates or how.** No mutator changes, no new suppressions, no
+  threshold change. `thresholds.break: 100` stays exactly as it is (§6: keep it while it means
+  "zero survivors"; never introduce a sub-100 number).
+- **Wall-clock reduction.** Variant (A) buys none, deliberately (D2). The lever is recorded, not
+  pulled.
+
+## Decisions
+
+### D1 — Failure scope is the changed lines; reporting scope stays the changed files
+
+The shipped file scope was justified in the job's own comment by an identity: *"once main is
+mutant-clean, a changed file's untouched lines carry no survivors, so the two give the same
+verdict."* Main is not mutant-clean and §5 establishes it cannot become so by any mechanism
+currently shipped — equivalence is undecidable, StrykerJS has no per-mutant suppression, and the
+one mechanism that would work is an unwritten deferred item. With the precondition unavailable,
+"stricter and far simpler" reduces to "stricter": it fails branches for debt they did not create.
+
+Line-scoped failure is the attested shape, independently, in three fields (§3): mutation testing
+(Google's *"Only lines affected by the diff under review that are covered and are not arid are
+mutated"*; arcmutate's default `scope: line`, widenable to `class` as an explicit opt-in; Mull;
+Cosmic Ray), coverage (Sonar's Clean as You Code, Codecov's `patch` status, diff-cover,
+undercover) and static analysis (golangci-lint's `new-from-merge-base`, with `whole-files` as the
+*widening*). Everywhere the granularity is stated, **line is the default and file is the
+deliberate widening.** Line scope was also this capability's own drafted requirement, amended to
+files during adoption to match the code.
+
+Reporting stays wide because narrowing it would throw away information for nothing. Android
+lint's design is the transferable one (§4): baselines *"are enabled when you run inspections in
+batch mode… but they are ignored for the in-editor checks"* — **suppress the gate, never the
+feedback.** A wide report under a narrow gate also preserves the one genuine property file scope
+had: an assertion weakened elsewhere in a file the branch touched still shows up, as a report
+rather than as a block.
+
+**Consequence, stated rather than discovered:** the seventeen recorded equivalents and the two
+MusicBrainz survivors stop blocking the moment the failure scope stops including untouched lines
+— without being suppressed, and without silencing the killable twins that share their lines. When
+a PR *does* edit one of those lines, being asked to re-audit the equivalence claim is correct
+behaviour, not friction. That is exactly what Sonar sells: *"You own the quality and security of
+the new code you are working on today."*
+
+### D2 — Variant (A): post-filter a file-scoped run, not (B) range-scope the run
+
+Two ways to implement D1 (§9):
+
+- **(A)** Keep `--mutate <changed files>` exactly as today; add a verdict step that reads
+  `reports/mutation/mutation.json` and fails only on survivors overlapping a changed hunk.
+- **(B)** Pass `--mutate 'path:start-end,path:start-end,…'` built from the hunks and let
+  Stryker's `break: 100` be the verdict, deleting `continue-on-error` outright.
+
+(B) is cheaper, simpler, and needs no new verdict code — and it is native and maintainer-endorsed:
+mutation ranges shipped in **v4.6.0**, and nicojs recommends exactly this for diff gating
+(*"stryker run --mutate foo.js:25-30. This can be combined with some kind of pipeline git diff
+command"*), having deliberately refused to build git in (*"I wouldn't want to use git as a source
+of files"*). A comma-separated list of explicit `path:start-end` entries is valid; only mixing a
+range with a *glob* in one array element is rejected.
+
+**(A) is taken anyway, for one reason that (B) cannot supply at all.** Stryker's range filtering
+is **containment**: `babel-transformer.ts`'s `shouldMutate` requires `locationIncluded(range,
+node.loc)`, so a mutant whose node is larger than the range is never generated. A
+`BlockStatement` mutant spanning a whole function is therefore **not produced** when only one line
+inside it changed. In Google's data `SBR` (statement block removal) is **72.18%** of all mutants
+and *"the mutation type second-least likely to survive"* — the biggest and bluntest family, and
+the one most likely to be a real finding. (A) filters after the fact, so the intersection test can
+use **overlap** instead, recovering precisely what (B) drops.
+
+(A) also keeps the full file-scoped inventory in the step summary, which D1 wants.
+
+**The cost is honest and it is the whole cost:** (A) buys no wall-clock saving. The 13m16s
+Stryker step on a 36-file diff stands. That is D6 and D7's problem, not a hidden one.
+
+**(B) is the recorded tuning lever, not a rejected option.** Take it the first time a PR's Stryker
+step exceeds ~15 minutes, accepting two consolations: the changed-line findings — the ones the
+gate actually blocks on — are unaffected, and the weekly full run already exists as the wide
+channel for everything (B) stops seeing at diff time. What (B) loses is the *timeliness* of the
+file-wide signal, not the signal. To make the switch a number rather than an irritation, the
+Stryker step's duration is surfaced in the job summary (task 3.4).
+
+### D3 — Shadow mode is the shipped first state, and the switch is a flag
+
+`quality-gates.md` admits a check only **"under ten percent effective false positives, measured on
+*this* repository, not on the check's reputation elsewhere"**, where anything the loop ignores,
+waives without cause, or appeases counts as false. Nothing here has been measured against that
+bar in the *blocking* configuration, and the reference points are not comfortable:
+
+- Google's mutant productivity — the complement of their "Not useful" rate — is **82% aggregate,
+  80→89% over time, against a stated ~90% target**, with a policy of disabling a mutator on any
+  node type that drops below 80%. That is the industry-best number after years of tuning across
+  seven languages and 140 arid rules, and it sits *at* this repo's bar rather than inside it.
+- **Google's release valve is a human clicking "Not useful."** This factory has no such human. §9
+  names this as the gap that most needs measuring: there is no evidence at all about what an
+  agent loop does with the residual 11–18% under a *blocking* gate.
+
+So the verdict computes and publishes, and does not fail. Enforcement is one environment switch
+(`MUTATION_GATE_ENFORCE`), read at the entrypoint, changing the exit code and nothing else — so
+the shadow measurement is a measurement of the *enforcing* logic, not of a different program.
+This is the method `docs/research/result-lint-and-tier-enforcement.md` used before adopting a lint
+rule: count the violations against this repo first.
+
+**Alternative rejected — ship enforcing and back it out if noisy.** A blocking check that turns
+out noisy has already taught the loop to appease it, and appeasement is not recoverable by
+reverting the flag: the fiction tests remain. `quality-gates.md` is explicit that an agent which
+cannot ignore a noisy finding will write one.
+
+**Alternative rejected — a warning-level check (arcmutate's default).** `quality-gates.md`: *"A
+blanket severity downgrade is not a carve-out. A warning nobody blocks on is the attested-dead
+nightly-batch shape. A rule is `error` or it is off."* Shadow mode is not that: it is a
+time-boxed measurement with a named exit criterion, not a permanent severity.
+
+### D4 — The verdict fails on three conditions, reusing what already models them
+
+Once enforcing, the verdict step fails on:
+
+1. a surviving mutant whose span overlaps a changed hunk;
+2. a **missing or unreadable** report;
+3. a resolved scope in which **no mutant was actually analysed** — all ignored, or none
+   generated.
+
+Conditions 2 and 3 exist because the alternative is a gate that greens on its own breakage, which
+is the one failure mode this job must not have — the same reasoning already written into the scope
+step's `match()` helper, into `file-drift.ts`'s refusal to report zero drift from an unreadable
+report, and into `summarize.ts`'s refusal to print "no surviving mutants" over a scope it did not
+audit. None of this is new machinery: `report-model.ts`'s `readReport` already returns `undefined`
+for absent, unparseable and wrong-shaped reports, and `summarizeSurvivors` already distinguishes
+"no mutants at all" from "every mutant ignored" from "clean". The verdict *acts* on what they
+already *detect*.
+
+**A fourth failure mode, folded into condition 3 rather than named separately.** Stryker keys its
+report `files` by its own path spelling; the changed hunks come from git. If those two spellings
+disagree, every intersection test returns false and the gate is vacuously, permanently green — the
+most dangerous outcome available, because it looks like success. The join therefore normalises
+both sides to repo-relative POSIX paths, and a resolved scope whose changed files match no file in
+the report is treated as "nothing was audited" (condition 3), not as "nothing was found". Task 1.4
+pins this with a test, and task 5.1's first shadow run verifies it against a real report.
+
+### D5 — `continue-on-error` moves; it does not disappear
+
+Under (A) the flag stays on the Stryker step, and the artifacts must say so plainly rather than
+describe a removal. The reason is not caution — it is that **the Stryker step's exit code stops
+being the verdict**. `thresholds.break: 100` makes Stryker exit 1 for any survivor anywhere in the
+file-wide reporting scope, which is exactly the verdict D1 rejects. The job's decision moves to the
+new step, which does **not** carry the flag.
+
+Two things follow that are easy to get wrong:
+
+- The verdict step must run even when Stryker failed, so it is `if: always()`-shaped like the
+  summary step — otherwise a crashed run skips the step that was supposed to fail on a crashed
+  run.
+- Under (B) this inverts: `continue-on-error` would be deleted outright and `break: 100` would be
+  the verdict again. That is a genuine argument for (B) and is recorded with the lever in D2.
+
+### D6 — Raise `timeout-minutes` 20 → 30, and replace the stale comment with the measurements
+
+The comment says `# projected low-minutes on a 4-core runner; NOT yet observed in CI`. It has been
+observed three times (§1), read from the Actions API:
+
+| PR | changed prod files | Stryker step | whole job |
+| --- | --- | --- | --- |
+| `mutation-gate`'s own (#161) | 2 | 1m43s | 2m32s |
+| v3.18.0 correlation | 53 | 8m54s | 9m37s |
+| the burn-down | 36 | **13m16s** | **13m58s** |
+
+13m16s is **66% of the current budget**, leaving 6m44s of headroom, and cost is **not** linear in
+file count — it is mutants × tests per mutant, so the burn-down's 36 densely-covered domain files
+cost more than the correlation change's 53. Today a timeout is invisible (`continue-on-error`).
+Once enforcing, a timeout is a **red required check on a correct branch**: unattributable,
+non-deterministically reproducible, and precisely the thing that teaches an agent loop that the
+mutation check is the flaky one. Raising the timeout is free and should be done regardless of when
+enforcement lands; `release` already sits at a comparable order.
+
+The other levers, in the order `mutation-gate` D4 already names them, remain: `--concurrency`
+first, then narrowing scope (which is D2's variant (B)), then larger runners, which cost money.
+
+### D7 — Record the merge-latency consequence: ~2 min → ~14 min, a 7× increase
+
+Sibling jobs on the same run: `quality` 1m16s, `test` 2m04s, `version-check` 19s. Requiring the
+mutation check moves the PR critical path to the mutation job's duration — ~14 minutes at the
+largest measured diff. `quality-gates.md`'s latency budget explicitly exempts CI from the
+seconds-order rule, so this violates no non-negotiable, and Google's own framing (~2% overhead,
+run *off-peak*) does not apply to a job on the merge path. But it is the largest single cost of
+the flip and it is currently written down nowhere. It is written down here so the flip is a
+decision rather than a discovery. Under (B) it largely goes away — a second reason the lever
+exists.
+
+### D8 — The verdict names at most one finding per changed line
+
+`summarize.ts` already applies Google's one-mutant-per-line **surfacing** rule, and TSE 2021
+confirms it empirically: *"In more than 90% of the cases, either all mutants in a line are killed,
+or all mutants in a line survive."* But the verdict as designed would count every survivor, so one
+weak line can present as a dozen blocking findings. Google caps the surfaced set at a **median of
+7 per changelist**; this gate has no cap at all, and §9 flags "a gate with no per-changelist cap"
+as unattested at any volume. Deduplicating the *failing* set per line costs nothing and makes the
+finding count honest. It is included here rather than deferred because it is part of the same
+verdict computation and would otherwise be a second pass over the same data.
+
+No per-PR cap is introduced: a cap that hides findings from a blocking gate would make the gate
+lie about what it wants. The volume question is instead something the shadow measurement (task
+5.1) is expected to answer with numbers.
+
+### D9 — Parse `git diff -U0` hunk headers carefully; the diff is data, not a subprocess
+
+The changed lines come from `git diff -U0 "$BASE" HEAD -- <in-scope files>` against the **same**
+merge-base the scope step resolves, exported as a step output so the two cannot drift onto
+different bases. The workflow writes the diff to a file and the entrypoint reads it; the parser
+itself takes text and returns ranges, so it is a pure function with tests rather than a shell-out
+buried in a script.
+
+Two parsing rules the research verified against a real diff in this repo, both of which produce a
+*wrong gate* rather than a crash if got wrong:
+
+- `@@ -a,b +c,d @@` with `d` **absent** means exactly one line (`-U0` emits both the `+85` and
+  `+44,25` forms).
+- **`d == 0` means a pure deletion** and adds no lines to mutate. Turning it into the range `c-c`
+  would gate the branch on a line it never touched.
+
+Deletions are already dropped from the mutate scope by `--diff-filter=ACMR`; this is the same rule
+one level down, at the hunk.
+
+### D10 — Alternatives rejected, with the reason in one line each
+
+These were the other four options on the research's table (§4, §5, §6, §2.4). Each is genuinely
+recognised prior art; each is wrong *here*, and the reasons are summarised rather than re-argued.
+
+- **A committed accepted-survivor baseline** (the PHPStan / Psalm / ESLint-bulk-suppressions /
+  Android-lint / betterer pattern). Recognised and well documented — including by its own
+  authors' candour about its failure modes: PHPStan's *"The life goal of a baseline file is to not
+  exist"*, ESLint's admission that once a count moves *"there's no reliable way to determine
+  whether the new violations were introduced recently or already existed"*, Android lint's warning
+  that a fixed issue silently returns. Rejected for three reasons: (a) it is **redundant** with
+  diff scoping, which computes the same boundary from VCS with no artefact to rot,
+  merge-conflict, or regenerate — a baseline *is* an implementation of diff scoping, not an
+  alternative to it; (b) the 17 are not homogeneous legacy debt but a **structural class** that
+  new code in the same style keeps regenerating, and enumerating instances of a class is the
+  anti-pattern `quality-gates.md` already names; (c) **a ratchet the constrained party can
+  regenerate is a rubber stamp**, and in an agent loop the constrained party *is* the party that
+  edits the file. If one is ever built anyway: key on `(file, location, mutatorName, replacement)`
+  — never on Stryker's mutant `id`, which is a per-run ordinal — require a reason per entry, and
+  make growing it harder than shrinking it, which is the one consistent design consensus across
+  every mature baseline tool.
+- **Refactoring the equivalents onto their own lines** so their waivers become precise. Ruled out
+  by evidence already in `mutation-gate`'s `design.md`: `ConditionalExpression` emits `true` *and*
+  `false` from one node and `EqualityOperator` emits both substitutions from one operator token,
+  so the equivalent and its killable twin are co-located **whatever the formatting**. No line
+  split can separate them. Attempting it anyway would be contorting production code to satisfy a
+  tool — the appeasement the admission contract exists to prevent. This is also why
+  `mutation-gate` task 4.1 cannot close as written (D12).
+- **A percentage `thresholds.break`.** Unsound on a scoped run, and rejected by four independent
+  arguments: the denominator moves with the diff (372 mutants on a 2-file PR, thousands on a
+  large one), so a fixed percentage makes the gate's strictness *inversely* proportional to the
+  size of the change; Google could compute a mutation score and explicitly chose not to
+  (*"unable to find a good way to surface it to the engineers in an actionable way"*, and *"living
+  mutants… alone do not make a good measure of efficacy"*); mutation *scores* correlate weakly with
+  real fault detection once suite size is controlled, even though mutation *testing* earns its
+  place (Papadakis et al., ICSE 2018); and this repo has already produced a score of **99.89% that
+  was false** while 96 mutants sat silenced by a suppression that never ended. A percentage is the
+  shape that made that invisible. Keep `break: 100`, which at 100 is "zero survivors", not a
+  percentage; introduce no sub-100 number.
+- **`--incremental` against a main baseline.** Already rejected by `mutation-gate` D4a for the
+  right reason — Stryker's incremental report is **whole-repo**, so the break threshold applies to
+  the merged whole and a branch fails on files it never touched, converting a diff gate back into
+  a repo gate. Two additions from the research: the docs do **not** state whether `thresholds.break`
+  applies to the merged whole, so D4a's claim stands on this repo's own measurement and should
+  stay labelled as measured-here, not attested; and the incremental file is **not committable**
+  with the vitest runner at all — issue #6004, open against the pinned 9.6.1, reports
+  non-deterministic vitest test IDs producing a ~15k-line diff on every no-op run, which its
+  reporter calls *"a blocker for storing the incremental baseline in version control."*
+
+### D11 — Corrections to the record this change is obliged to make
+
+The research's §10 lists documentation drift found while verifying the house facts. Fixing it is
+part of this change because three of the five items are the *stated rationale* for behaviour this
+change alters, and leaving a retracted figure arguing for a decision is how the next reader
+relitigates it:
+
+1. **The job's `continue-on-error` comment argues from a retracted number.** It cites *"464
+   survivors to 6 (99.89%)"*, *"the 6 sit in…"*, and *"Four are provably equivalent narrowing
+   operands"*. `design.md` explicitly retracts that: run 6's 99.89% was false (it was hiding 104
+   killable mutants behind two block directives that never closed), corrected to 19 at 99.67%, and
+   the tip of main is **64 at 98.96%**. The comment is rewritten around D5's actual reason.
+2. **The stale timeout comment** (D6).
+3. **`design.md`'s task 3.3 / Open Questions** records 2m31s on a 2-file diff and asks for a
+   re-measurement on the first PR that changes production code. Two such PRs have since run;
+   neither is recorded, and 2m31s now reads as representative when it is the smallest of three.
+4. **Task 4.1's exit criterion is unreachable as written** — D12.
+5. **The spec delta lists three requirements under both MODIFIED and ADDED**, which fails
+   `openspec validate --strict`. Since `mutation-testing` is a *new* capability that has not been
+   archived into `openspec/specs/`, the honest form is one statement of each requirement under
+   ADDED carrying the text that actually shipped, with the "restated during adoption" note kept as
+   the section's preamble. Cheap, and it makes this change's own MODIFIED delta well-formed.
+
+### D12 — `mutation-gate` tasks 2.1 and 4.1 are restated, because this change supersedes their premise
+
+**Task 2.1 — "Seeding triage (main becomes mutant-clean)".** The parenthetical is not achievable.
+§5.1 is unambiguous: the equivalent fraction among *survivors* **rises** as the suite improves
+(Schuler & Zeller: *"The percentage of equivalent mutants increases as the test suite improves"*,
+with the arithmetic — *"A perfect test suite would detect all non-equivalent mutants; hence, 100%
+of undetected mutants would be equivalent"*); 7–40% of all mutants are equivalent across the
+historical range; under 5% of mutants are subsuming at all; and classifying a single equivalent
+costs 4.6–15 minutes of human-or-agent judgement. Seventeen unkillable survivors after a 464→19
+burn-down is the literature's **predicted outcome**, not a residue of incomplete work. Restated:
+2.1 closes on *the triage being complete with its residue recorded*, which it is, and its heading
+loses the unreachable parenthetical. Under line scope the recorded equivalents stop blocking
+without being suppressed, so nothing has to be done to them before a flip.
+
+**Task 4.1 — the required-check flip.** Its stated exit criterion is *"split the four
+narrowing-operand lines so their waivers become precise"*. That is doubly superseded by
+`mutation-gate`'s own `design.md`: there are **seventeen**, not four, and **splitting cannot work**
+for this mutator family (D10, second bullet). The task can never close as written. Restated as the
+two-step it now is, with the criterion this change makes reachable:
+
+- **4.1a** — enable enforcement (`MUTATION_GATE_ENFORCE`) once the shadow measurement clears the
+  ten-percent effective-false-positive bar on real PRs here.
+- **4.1b (Jake)** — add the check to the main-branch ruleset's required checks, together with
+  4.1a, in one step. Repo settings are outside agent permissions.
+
+The old "once main is mutant-clean" precondition is deleted, not weakened: it names a state that
+does not exist.
+
+## Risks / Trade-offs
+
+- **Blocking at all is unattested — carry it forward, do not quietly drop it.** `mutation-gate` D2
+  flagged blocking as a deliberate deviation from Google's advisory deployment, and the research
+  confirms the deviation is real and larger than D2 assumed. Google never blocked: TSE 2021 §2.4
+  settles it in one sentence — *"These findings do not need to be resolved by the author before
+  submission, unless a human reviewer marks them as mandatory."* Blocking, where it exists at all,
+  is a **human** decision on a specific finding, never the tool's. arcmutate's GitHub integration
+  defaults to *warning*. **No peer-reviewed deployment of a blocking mutation gate was found in a
+  deliberate sweep.** The argument for blocking here — no human to shrug, and an advisory channel
+  with no consumer is the attested-dead shape, now *observed* on this repository in v3.18.0's 45
+  unconsumed survivors — is sound reasoning by analogy, but it is analogy, not evidence. → This is
+  the risk shadow mode exists to convert into a number (D3). D2's compensations (scope narrower
+  than Google's, a seeded arid list) are only half delivered while scope is *wider* than Google's;
+  D1 delivers the other half.
+- **A 100% break threshold on a codebase with known-unkillable mutants is also unattested.** No
+  source gates a mutation run at zero survivors, and Google calls adequacy *"neither practical nor
+  desirable"*. → Defensible only in proportion to how narrow the scope is: adequacy over the lines
+  you wrote is what "you own the new code" means everywhere in §3.3, where adequacy over every
+  line of every file you touched is not. D1 is what makes `break: 100` defensible, and the two
+  should be read together.
+- **A gate with no per-changelist finding cap is unattested at any volume.** → D8 caps per line;
+  the per-PR volume is left to the shadow measurement rather than guessed at.
+- **Verdict stability across reruns is unmeasured.** `report-model.ts` treats `Timeout` as
+  detected, so a loaded runner turning a `Killed` into a `Timeout` is safe — but a mutant killed
+  only by a timing-sensitive test is not, and nothing in the repo measures mutation-verdict
+  stability across reruns. Once the check blocks, that number matters. → Task 5.1 records rerun
+  disagreements alongside the false-positive count; a flaky blocking check is worse than no check.
+- **(A) buys no wall-clock, and a blocking job that times out is the worst failure available.** →
+  D6 raises the timeout; D2 records (B) as the lever and task 3.4 surfaces the duration so the
+  switch is triggered by a number.
+- **The path-spelling join is a silent-green hazard.** → D4's fourth mode, folded into condition 3
+  and pinned by a test.
+- **Shadow mode is itself the attested-dead shape if it never ends.** A verdict nothing blocks on
+  is a warning nobody blocks on. → It is time-boxed by task 5.1's named exit criterion, and the
+  measurement is a deliverable, not an intention. If the measurement says the configuration cannot
+  clear ten percent, the honest outcome is to *say so and not flip* — `quality-gates.md`'s "a
+  check can be worth running once without earning a seat" applies, and both halves get recorded.
+
+## Migration Plan
+
+Ships as one change, artifacts and tooling only — no runtime surface, no version bump. The job
+keeps reporting exactly as it does today; the only observable difference on a PR is an extra
+step that prints a verdict it does not act on. Rollback is deleting the verdict step and its
+module.
+
+Enforcement is *not* migrated here. Task 5.1 collects the measurement; `mutation-gate` 4.1a/4.1b
+flip enforcement and the required check together, in one step, so the gate never spends time in
+the "fails but is not required" shape `quality-gates.md` rejects.
+
+## Open Questions
+
+- **How many shadow PRs are enough?** Task 5.1 sets a floor of six PRs that change production
+  code, on the reasoning that the false-positive rate to be estimated is around 10% and fewer
+  samples cannot distinguish 0 from 20. If the first six produce zero findings, the answer is that
+  the sample is uninformative rather than that the rate is zero — collect until the shadow verdict
+  has fired at least a handful of times. This can be settled with the data in hand and does not
+  change the specs, the approach, or the task breakdown.

--- a/openspec/changes/mutation-gate-diff-scope/proposal.md
+++ b/openspec/changes/mutation-gate-diff-scope/proposal.md
@@ -1,0 +1,117 @@
+# Proposal: mutation-gate-diff-scope
+
+## Why
+
+The mutation gate ships inert. `mutation-gate` left `continue-on-error: true` on the Stryker
+step and the check unrequired, and made the flip conditional on main becoming mutant-clean —
+a precondition `docs/research/blocking-mutation-gate-scope.md` (2026-08-07) establishes is
+**unreachable in principle**, not merely unreached. The equivalent fraction among survivors
+*rises* as a suite improves (Schuler & Zeller, ICST 2010); under 5% of mutants carry unique
+information at all (subsumption studies); Google calls mutation adequacy *"neither practical
+nor desirable"* and aiming at it *"hopeless"* (ICSE 2021). So the current plan waits forever,
+while the advisory channel it waits behind has already been observed dead on this repository:
+v3.18.0 shipped **45 surviving mutants** into a step summary nothing consumed.
+
+The research's verdict is that the failure scope, not the burn-down, is the thing in the way.
+Diff/changed-**line** scoping is the attested answer for gating a metric on a codebase that
+cannot reach the metric's ceiling — Google (*"Only lines affected by the diff under review
+that are covered and are not arid are mutated"*), arcmutate, Mull and Cosmic Ray in mutation
+testing; Sonar, Codecov, golangci-lint and diff-cover in the adjacent coverage problem. Where
+granularity is stated anywhere, **line is the default and file is the deliberate widening** —
+the reverse of what shipped here. Under line scope the seventeen recorded equivalents stop
+blocking without being suppressed, and a mutant on a line no PR touched cannot fail that PR.
+
+This change moves the failure scope and ships the verdict in **shadow mode**, because
+`docs/development/quality-gates.md` admits a check only under ten percent effective false
+positives *measured on this repository* — and Google, after years of tuning, sits at 82–89%
+mutant productivity against a ~90% target, i.e. *at* this repo's bar rather than comfortably
+inside it, with a human "Not useful" button this factory does not have. Measuring first is
+the same method `result-lint-and-tier-enforcement.md` used before adopting a lint rule.
+
+## What Changes
+
+- **A new verdict step** in the `mutation` job fails only when a surviving mutant's span
+  **overlaps** a line the branch added or modified, computed from `git diff -U0` against the
+  same merge-base the scope step already resolves. Overlap, not Stryker's containment: a
+  whole-block mutant covering a function you edited one line of still counts. Statement-block
+  removal is 72.18% of Google's mutants and the mutation type second-least likely to survive,
+  so dropping it silently would be a large hole.
+- **Reporting scope stays the changed files.** Android lint's rule: *suppress the gate, never
+  the feedback.* The step summary keeps the full file-scoped inventory; only the verdict
+  narrows.
+- **Shadow mode is the shipped first state.** The verdict step computes its decision, prints
+  it to the step summary, and does not fail the job. A single documented switch
+  (`MUTATION_GATE_ENFORCE`) flips it to enforcing — a flag, not a rewrite — and a task
+  collects the effective-false-positive measurement on real PRs *here* before that flip.
+- **Once enforcing, the verdict fails on three conditions, not one**: a survivor overlapping a
+  changed hunk; a missing or unreadable report; and a scope that analysed zero mutants.
+  `report-model.ts` already models every "no report" case and `summarize.ts` already detects
+  the all-ignored case — both are reused. A Stryker crash must never read as a green gate.
+- **`continue-on-error` MOVES rather than disappears.** It stays on the Stryker step precisely
+  *because* that step's exit code stops being the verdict; the new verdict step carries the
+  decision and does not have the flag. The artifacts say this plainly instead of describing a
+  removal.
+- **Variant (B) is recorded as the named tuning lever** — range-scoping the run itself with
+  `--mutate 'path:start-end,…'` (native since StrykerJS v4.6.0, and the maintainer's own
+  recommendation for diff gating), to be taken when wall-clock becomes binding, with its
+  containment trade-off stated rather than discovered.
+- **`timeout-minutes` rises 20 → 30** with the measurement recorded: 13m16s observed on a
+  36-file diff is 66% of the current budget, and the `release` job already sits at a
+  comparable order. The stale `# NOT yet observed in CI` comment is replaced with the three
+  measured runs (2m32s / 9m37s / 13m58s).
+- **The merge-latency consequence is written down**: requiring this check takes the PR
+  critical path from ~2 minutes to ~14, a **~7×** increase. `quality-gates.md`'s latency
+  budget exempts CI from the seconds-order rule, so this violates no non-negotiable — but it
+  is the single largest cost of the flip and is currently recorded nowhere.
+- **Documentation drift is fixed** (research §10): the job comment arguing from the retracted
+  "464 → 6 (99.89%)" figure, the stale timeout comment, `design.md` task 3.3's unrepresentative
+  2m31s, and `mutation-gate`'s task 4.1 — whose exit criterion ("split the four
+  narrowing-operand lines") is **unreachable as written**: there are seventeen, and `design.md`
+  proves splitting cannot work for that mutator family. 4.1 is restated onto this change's
+  premise, and task 2.1's "main becomes mutant-clean" framing is corrected.
+- **`test/boundaries/mutation-scope.test.ts` is updated with the job.** It pins the command
+  shape and the scope alternation today; the verdict step gets its own scenario, or deleting
+  the gate would leave the boundary tier green.
+- **`report.ts`'s header comment is corrected.** It says *"Never decides pass/fail — Stryker's
+  exit code does that."* Under this design that becomes false.
+
+**Explicitly out of scope**, recorded here so neither is mistaken for an omission:
+
+- The **`ignore-unions` ignorer plugin**. It is the right durable fix for the two structural
+  equivalent families, and the research says so — but it is a rule-pack decision with its own
+  false-negative cost (it would also hide a genuinely wrong `case` grouping), so it gets its
+  own change and its own grilling.
+- The **two MusicBrainz album-title survivors**. They are a real domain bug — an absent title
+  carried as `''` rather than `undefined`, letting punctuation-titled albums (`÷`, `+`, `?`)
+  bypass the ambiguity guard — not a mutant to suppress. Waiving them would be the fiction
+  `testing.md` forbids.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `mutation-testing`: the gate's failure scope narrows from changed files to changed lines
+  while its reporting scope stays file-wide; the verdict moves off the mutation runner's exit
+  code onto a step that owns it; the verdict ships in shadow and fails closed on an absent or
+  unmeasured audit.
+
+## Impact
+
+- **Code:** a new verdict module + entrypoint under `scripts/mutation/` with its own tests; a
+  changed-hunk parser; `report-model.ts` gains the mutated span's end position;
+  `.github/workflows/pipeline.yml` (new step, moved `continue-on-error`, raised timeout,
+  rewritten comments); `test/boundaries/mutation-scope.test.ts`; `report.ts`'s header comment.
+- **Artifacts:** `openspec/changes/mutation-gate/{tasks,design,specs}` amended where this
+  change supersedes their premise (tasks 2.1 and 4.1, the 3.3 timing, and the spec's three
+  requirements currently listed under both MODIFIED and ADDED — which fails
+  `openspec validate --strict`).
+- **Version:** `chore` — CI/tooling and artifacts only, no bump, no release.
+- **Dependencies:** none new. Builds on `mutation-gate` (merged, unarchived).
+- **Not in this change:** enabling enforcement, and the ruleset's required-check flip. Both
+  wait on the shadow measurement clearing the ten-percent bar; both are a follow-up.
+- **Risk retired:** the gate stops being conditional on a state that cannot exist, and starts
+  measuring whether it can honestly block.

--- a/openspec/changes/mutation-gate-diff-scope/specs/mutation-testing/spec.md
+++ b/openspec/changes/mutation-gate-diff-scope/specs/mutation-testing/spec.md
@@ -1,0 +1,87 @@
+# mutation-testing — delta for mutation-gate-diff-scope
+
+## MODIFIED Requirements
+
+### Requirement: Changed lines carry mutant-killing tests
+
+The PR gate SHALL run mutation testing over the production **files** the branch changed in the
+bounded-context packages, and SHALL report every surviving non-suppressed mutant in them, per
+mutant (file, line, mutation) rather than as an aggregate score. That is the gate's **reporting**
+scope, and it stays file-wide: a wide report under a narrow gate is strictly more information,
+and it preserves the ability to notice an assertion weakened elsewhere in a file the branch
+touched.
+
+The gate's **failure** scope SHALL be narrower than its reporting scope. A branch SHALL fail only
+for a surviving mutant whose mutated span **overlaps** a line that branch added or modified,
+computed from the diff against the same merge-base the scope resolution uses. Overlap, not
+containment: a mutant whose span merely *encloses* a changed line — the removal of a block the
+branch edited one line of — SHALL count as a finding. A surviving mutant whose span lies wholly
+outside the changed lines SHALL be reported and SHALL NOT fail the branch.
+
+The verdict SHALL be carried by the step that owns it rather than by the mutation runner's exit
+code, and SHALL name at most one finding per changed line, so that one weak line presents as one
+thing to do rather than a wall.
+
+#### Scenario: A surviving mutant on a changed line is a finding
+
+- **WHEN** a PR changes a production line whose surviving mutant no test kills
+- **THEN** the verdict names it — file, line, mutator — as a blocking finding
+
+#### Scenario: A survivor on an untouched line is reported, not blocking
+
+- **WHEN** a PR changes a production file that also carries a surviving mutant on a line the
+  branch did not touch
+- **THEN** that mutant appears in the run's report and is not part of the verdict
+
+#### Scenario: A block mutant spanning an edited line still counts
+
+- **WHEN** a surviving mutant's span encloses the changed lines rather than sitting inside them
+- **THEN** the verdict counts it, because the spans overlap
+
+#### Scenario: Nothing in scope changed
+
+- **WHEN** a PR changes no production file in the bounded-context packages
+- **THEN** the job resolves an empty scope, says so, and runs no mutation pass
+
+## ADDED Requirements
+
+### Requirement: The verdict is measured in shadow before it blocks
+
+The verdict SHALL ship in a shadow state: it computes its decision and publishes it where the
+run's findings are read, and it does not fail the job. Enforcement SHALL be enabled by a single
+documented configuration switch, without changing how the verdict is computed.
+
+Enforcement SHALL NOT be enabled until the effective false-positive rate of the *enforcing*
+configuration has been measured on real pull requests in this repository and recorded against the
+ten-percent admission bar — where a finding the loop ignores, waives without cause, or appeases
+counts as false. Measurement on the check's reputation elsewhere SHALL NOT substitute.
+
+#### Scenario: Shadow publishes the decision without failing
+
+- **WHEN** the verdict finds a surviving mutant overlapping a changed line while shadow is on
+- **THEN** the decision is published with the findings that produced it, and the job stays green
+
+#### Scenario: The flip is gated on a measurement taken here
+
+- **WHEN** enforcement is proposed
+- **THEN** the shadow verdicts collected on this repository's own pull requests, and the
+  effective false-positive rate derived from them, are on the record first
+
+### Requirement: The verdict fails closed on an absent or unmeasured audit
+
+Once enforcing, the verdict SHALL fail on each of three conditions, not one: a surviving mutant
+overlapping a changed line; a report that is missing or cannot be read as a mutation report; and
+a resolved scope in which no mutant was actually analysed — every mutant ignored, or none
+generated at all. A run that crashed, wrote nothing, or measured nothing SHALL NOT read as a
+passing gate.
+
+#### Scenario: A crashed run is not a green gate
+
+- **WHEN** the mutation run dies before writing a report, or writes one that cannot be read
+- **THEN** the verdict fails and says which of the two happened, rather than reporting no
+  findings
+
+#### Scenario: A scope that audited nothing is not clean
+
+- **WHEN** every mutant in the resolved scope was ignored, or the scope produced no mutants
+- **THEN** the verdict fails as unaudited rather than passing as clean

--- a/openspec/changes/mutation-gate-diff-scope/tasks.md
+++ b/openspec/changes/mutation-gate-diff-scope/tasks.md
@@ -1,0 +1,119 @@
+# Tasks — mutation-gate-diff-scope
+
+Sequencing: the pure model first (parser, overlap, verdict), then the entrypoint, then the CI
+wiring, then the record corrections, then the measurement that gates enforcement. Every task
+touching code is red-first: write the failing test, watch it fail, then make it pass.
+
+Group 5 runs **after this change merges** — it collects data from real PRs, and it is the exit
+criterion for enforcement. Enforcement itself is deliberately not in this change (design D3).
+
+## 1. The verdict model — pure, red-first
+
+- [ ] 1.1 Red: a `report-model.test.ts` scenario asserting the mutated span's **end** position is
+      read, not just its start. Then extend `ReportedMutant.location` with `end: { line: number }`,
+      require it in `isMutant`, and keep `VendorReportStaysAssignable` compiling against Stryker's
+      own `schema.MutationTestResult`. Done when a report whose mutants carry no `end` is reported
+      as unreadable rather than parsed with a silently narrowed span, and `summarize.ts` /
+      `drift.ts` still pass unchanged.
+- [ ] 1.2 Red: parser scenarios for `git diff -U0` hunk headers — `@@ -a,b +c,d @@`, the `+85`
+      form where `d` is absent (exactly one line), the **`d == 0` pure-deletion** form (contributes
+      no lines), several hunks in one file, several files in one diff, and a diff with no hunks at
+      all. Then implement `scripts/mutation/changed-lines.ts` as a pure text → per-file line-range
+      function. Done when the two `-U0` forms this repo actually emits are both covered by a named
+      scenario and a pure deletion adds no gated line.
+- [ ] 1.3 Red: overlap scenarios — a mutant wholly inside a changed hunk, a mutant whose span
+      **encloses** the hunk (the whole-block case Stryker's containment filter would drop), a
+      mutant abutting the hunk without touching it, and a mutant in a file with no hunks. Then
+      implement the intersection predicate. Done when the enclosing case is a finding and the
+      abutting case is not.
+- [ ] 1.4 Red: path-join scenarios — a report keyed in one path spelling and hunks keyed in
+      another normalise to the same repo-relative POSIX key, and a scope whose changed files match
+      **no** file in the report is reported as *unaudited*, not as clean. Then implement the
+      normalisation. Done when a deliberate spelling mismatch fails the verdict instead of
+      producing an empty finding set (design D4, the silent-green hazard).
+- [ ] 1.5 Red: verdict scenarios for all three failure conditions — a survivor overlapping a
+      changed line; a missing report and an unreadable one; a scope where every mutant was
+      `Ignored` and a scope with no mutants at all — plus per-line deduplication of the failing
+      set (design D8) and the shadow/enforce distinction. Then implement `scripts/mutation/
+      verdict.ts` as a pure function returning the verdict **as a value** (errors as values; no
+      throws, no `process.exit` in the model). Reuse `readReport` and the counts `summarize.ts`
+      already derives rather than reimplementing either. Done when each condition has its own
+      named scenario and two survivors on one changed line produce one finding.
+
+## 2. The entrypoint
+
+- [ ] 2.1 Red: rendering scenarios — the blocking-finding table, the shadow banner that names the
+      switch and says the job is not failing on this, and a distinct sentence for each of the three
+      refusals (crashed / unreadable / audited nothing). Then implement the renderer beside the
+      model, mirroring how `summarize.ts` presents `report-model.ts`. Done when a reader of the
+      step summary can tell "clean", "shadow would have blocked", and "nothing was audited" apart.
+- [ ] 2.2 Red: switch scenarios — unset, `false`, `0`, `true`, `1` — pinning that shadow is the
+      default and that only an explicit enable enforces. Then implement `scripts/mutation/
+      pr-verdict.ts` as the thin entrypoint (read report path + diff path, print Markdown, set
+      `process.exitCode`), mirroring `report.ts` and `file-drift.ts`. Done when the same verdict
+      computation yields exit 0 under shadow and exit 1 under enforce for identical input.
+
+## 3. CI wiring
+
+- [ ] 3.1 Export the merge-base the scope step already computes as a step output, and write
+      `git diff -U0 "$BASE" HEAD -- <the in-scope files>` to a file in the same step. Done when the
+      hunks and the mutate scope provably come from one merge-base — no second `git merge-base`
+      call anywhere in the job.
+- [ ] 3.2 Add the verdict step after the summary step: `if: always() && steps.scope.outputs.files
+      != ''`, **no** `continue-on-error`, appending its Markdown to `$GITHUB_STEP_SUMMARY`, with
+      the enforce switch absent (shadow). Done when a PR run shows the verdict in the summary and
+      the job's conclusion is unchanged from today.
+- [ ] 3.3 Rewrite the `continue-on-error` comment block on the Stryker step: state that the flag
+      **moves rather than disappears** and why — that step's exit code stops being the verdict
+      (design D5) — and delete the argument built on the retracted "464 → 6 (99.89%)" figure and
+      its "four narrowing operands" (there are seventeen). Done when no comment in the workflow
+      cites a number `mutation-gate`'s `design.md` retracts.
+- [ ] 3.4 Raise `timeout-minutes` to 30 and replace `# projected low-minutes on a 4-core runner;
+      NOT yet observed in CI` with the three measured runs (2m32s / 9m37s / 13m58s, the largest at
+      66% of the old budget) and the reason a blocking job must not time out. Surface the Stryker
+      step's duration in the job summary so variant (B)'s trigger is a number rather than an
+      irritation (design D2/D6). Done when the comment states measurements, not projections.
+- [ ] 3.5 Red: extend `test/boundaries/mutation-scope.test.ts` with the verdict step's own
+      scenarios — the step exists and runs the entrypoint, it does **not** carry
+      `continue-on-error`, and the enforce switch is absent (shadow is the shipped state). Keep the
+      existing command-shape and scope-alternation pins working. Done when deleting the verdict
+      step turns the boundary tier red, which is the property the existing scenarios were written
+      for and would otherwise not cover.
+
+## 4. Correct the record
+
+- [ ] 4.1 Fix `scripts/mutation/report.ts`'s header comment: *"Never decides pass/fail — Stryker's
+      exit code does that"* stops being true under this design. Done when the comment names which
+      module decides and which one explains.
+- [ ] 4.2 Restate `openspec/changes/mutation-gate/tasks.md`: drop 2.1's unreachable "(main becomes
+      mutant-clean)" premise and close it on the triage being complete with its residue recorded;
+      split 4.1 into 4.1a (enable enforcement once the measurement clears ten percent) and 4.1b
+      (Jake: add the required check, in the same step), deleting the "split the four
+      narrowing-operand lines" criterion. Done when no open task in that change depends on a state
+      the research shows is unreachable (design D12).
+- [ ] 4.3 Record the two missing CI measurements in `openspec/changes/mutation-gate/design.md`'s
+      task-3.3 note (9m37s on 53 files, 13m58s on 36) and mark 2m31s as the smallest of three
+      rather than the representative one. Done when the note no longer asks for a re-measurement
+      that has already happened twice.
+- [ ] 4.4 Fix `openspec/changes/mutation-gate/specs/mutation-testing/spec.md`: state each of the
+      three duplicated requirements **once**, under ADDED, carrying the text that actually shipped,
+      keeping the "restated during adoption" note as the section preamble. Done when
+      `openspec validate --all --strict` is clean for both changes.
+
+## 5. Measure — the exit criterion for enforcement (post-merge)
+
+- [ ] 5.1 Collect the shadow verdict from every PR that changes production code in the mutated
+      packages, for at least six such PRs. For each, record: findings the verdict would have
+      blocked on, which of those a competent contributor would call genuine, which were ignored /
+      waived without cause / appeased, the Stryker step's duration, and any disagreement between
+      reruns of the same commit. Record the tally in this change's `design.md`.
+- [ ] 5.2 Decide against `quality-gates.md`'s bar and record **both** possible outcomes honestly:
+      under ten percent effective false positives → hand off to `mutation-gate` 4.1a/4.1b (flip the
+      switch and the required check together, in one step); at or over → say so, leave the verdict
+      in shadow, and name what would have to change first. A check can be worth running once
+      without earning a seat.
+
+## 6. Gate
+
+- [ ] 6.1 `pnpm check` green (12 lanes); `openspec validate --all --strict` clean; version
+      decision: `chore` — CI/tooling and artifacts only, no bump, no release.


### PR DESCRIPTION
Drafts the OpenSpec change **`mutation-gate-diff-scope`**, plus the research doc it implements. Artifacts only — no implementation, no version bump, no release.

## The research verdict

`docs/research/blocking-mutation-gate-scope.md` (also in this PR) asked what failure scope a blocking per-PR mutation gate should use, and what to do about legacy and provably-equivalent survivors. Six options were on the table. Its verdict is **option 1 (line-scoped failure, file-scoped reporting)** partnered with **option 4 (an ignorer plugin)**, implemented as variant **(A)**: keep the file-scoped Stryker run, add a separate verdict step that post-filters `reports/mutation/mutation.json`.

Two findings drive it:

- **Diff/changed-line scoping is the established answer**, attested independently in mutation testing (Google — *"Only lines affected by the diff under review that are covered and are not arid are mutated"* — plus arcmutate, Mull, Cosmic Ray), coverage (Sonar, Codecov, diff-cover, undercover) and static analysis (golangci-lint). Wherever granularity is stated, **line is the default and file is the deliberate widening** — the reverse of what shipped here.
- **A mutant-clean `main` is unreachable in principle, not merely unreached.** The equivalent fraction among *survivors* rises as a suite improves (Schuler & Zeller, ICST 2010); under 5% of mutants are subsuming; Google calls mutation adequacy *"neither practical nor desirable"* and aiming at it *"hopeless"*. So `mutation-gate`'s "burn down, then flip" plan waits forever — while its advisory channel has already been observed dead here (v3.18.0 shipped 45 survivors into a step summary nothing consumed).

## What the change proposes

- **A verdict step** failing only when a surviving mutant's span **overlaps** a changed hunk (`git diff -U0` against the same merge-base the job already resolves). Overlap, not Stryker's containment — that is the whole reason (A) beats (B): a whole-block mutant covering a function you edited one line of still counts, and statement-block removal is 72.18% of Google's mutants and the family second-least likely to survive.
- **Reporting scope stays file-wide.** Android lint's rule: *suppress the gate, never the feedback.*
- **Once enforcing, the verdict fails on three conditions, not one**: a survivor overlapping a changed hunk; a missing or unreadable report; a scope that analysed zero mutants. `report-model.ts` already models the no-report cases and `summarize.ts` already detects the all-ignored case — both reused. A Stryker crash must never read as a green gate.
- **`continue-on-error` MOVES rather than disappears** — it stays on the Stryker step precisely because that step's exit code stops being the verdict; the new step carries the decision without it. Variant **(B)** (range-scoped `--mutate 'path:start-end'`, native since v4.6.0 and the maintainer's own recommendation for diff gating) is recorded as the named tuning lever for when wall-clock becomes binding, with its containment trade-off stated.
- **`timeout-minutes` 20 → 30**, with the measurement: 13m16s on a 36-file diff is 66% of the current budget, and the stale `# NOT yet observed in CI` comment is replaced with three measured runs (2m32s / 9m37s / 13m58s).
- **The merge-latency consequence is written down**: requiring this check moves the PR critical path from ~2 min to ~14, a **~7×** increase, currently recorded nowhere.
- **Documentation drift fixed** (research §10): the job comment arguing from the retracted "464 → 6 (99.89%)" figure; the stale timeout comment; `design.md` 3.3's unrepresentative 2m31s; and `mutation-gate` **task 4.1, whose exit criterion is unreachable as written** — it requires splitting "the four narrowing-operand lines"; there are seventeen and `design.md` proves splitting cannot work for that mutator family. 4.1 is restated as 4.1a (flip the switch on the measurement) + 4.1b (Jake: required check), and **task 2.1's "main becomes mutant-clean" premise is corrected**.
- **`test/boundaries/mutation-scope.test.ts` updated with the job** — the verdict step gets its own scenarios, or deleting the gate leaves the boundary tier green.
- **`report.ts`'s header comment** (*"Never decides pass/fail — Stryker's exit code does that"*) becomes false under (A) and is flagged for correction.

## This ships SHADOW MODE, not enforcement

The verdict computes its decision and prints it to the step summary. **It does not fail the job.** Enforcement is one documented switch (`MUTATION_GATE_ENFORCE`) — a flag, not a rewrite — and the gate to flipping it is a measurement, not a judgement call:

> `quality-gates.md`: admitted only **"under ten percent effective false positives, measured on *this* repository, not on the check's reputation elsewhere"**.

Nothing has been measured against that bar in the *blocking* configuration, and the reference points are not comfortable. Google's mutant productivity — the complement of their "Not useful" rate — is **82% aggregate, 80→89% over time, against a stated ~90% target**, i.e. the industry-best number after years of tuning sits *at* this repo's bar rather than inside it. And **Google's release valve is a human clicking "Not useful"; this factory has no such human.** Task 5.1 collects the shadow verdicts over ≥6 production-touching PRs and records the tally; task 5.2 records **both** outcomes honestly — flip, or say plainly that it cannot clear ten percent and leave it in shadow.

## Carried forward honestly, not dropped

`design.md` D2 flagged blocking as a deviation from Google's advisory deployment. The research confirms the deviation is **larger** than D2 assumed: Google never blocked (TSE 2021 §2.4 — *"These findings do not need to be resolved by the author before submission, unless a human reviewer marks them as mandatory"*), arcmutate defaults to *warning*, and **no peer-reviewed deployment of a blocking mutation gate was found in a deliberate sweep**. Any blocking mutation gate is a deviation from the strongest available evidence. That is in the design's Risks section, along with the unattested 100% break threshold and the uncapped per-PR finding volume.

## Explicitly out of scope

- **The `ignore-unions` ignorer plugin** — the right durable fix for the two structural equivalent families, but a rule-pack decision with its own false-negative cost. Its own change, its own grilling.
- **The two MusicBrainz album-title survivors** — a real domain bug (`undefined` not `''` identity, letting `÷` / `+` / `?` bypass the ambiguity guard), not a mutant to suppress.

## Checks

`pnpm check` green (12 lanes). `openspec validate mutation-gate-diff-scope --strict` clean.

**Pre-existing and left as task 4.4:** `change/mutation-gate` fails `openspec validate --strict` with three requirements listed under both MODIFIED and ADDED. It is not implemented here because this PR deliberately implements none of the change's tasks; `pnpm check` does not run OpenSpec validation, so the gate is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
