### PR TITLE
chore(contract-drift): separate unreachable providers from real contract drift

### DIFF
--- a/.github/workflows/contract-drift.yml
+++ b/.github/workflows/contract-drift.yml
@@ -2,9 +2,25 @@ name: Contract drift
 
 # Tier 2 of the external-API contract tests (change: external-api-contract-tests). Verifies the
 # frozen contract against the live world on a schedule — never on a commit or PR. slskd is checked
-# by diffing its latest OpenAPI surface against our consumed-surface manifest; MusicBrainz by
-# replaying the recorded requests and validating live responses against the shared schemas. On
-# drift it opens — or refreshes — a single tracking issue.
+# by diffing its latest OpenAPI surface against our consumed-surface manifest; MusicBrainz and
+# plex.tv by replaying the recorded requests and validating live responses against the shared
+# schemas.
+#
+# Each check reports one of three outcomes by exit code (drift-signal-fidelity; the mapping lives
+# in `scripts/drift/run-check.sh`):
+#
+#   conforms     — the provider answered and the consumed surface still holds
+#   drift        — the consumed surface changed. Fails the run and opens or refreshes the single
+#                  `contract-drift` tracking issue.
+#   unavailable  — the provider could not be reached after retries, so the contract was neither
+#                  confirmed nor refuted. Leaves the run GREEN with a warning annotation and a job
+#                  summary line.
+#
+# Read a green run as "no drift found", NOT as "every provider was reached" — check the summary.
+# The split exists because both issues this job ever filed were false positives about reachability
+# (#110, a broken invocation; #184, two MusicBrainz 503s on a shared GitHub-runner egress IP), and
+# an alert channel whose whole history is noise is one nobody reads when a real dropped field
+# finally arrives.
 
 on:
   schedule:
@@ -36,44 +52,84 @@ jobs:
 
       - name: MusicBrainz drift (live replay vs schemas)
         id: mb
-        continue-on-error: true
-        # pipefail so `tee` doesn't mask a non-zero exit from the drift script.
-        run: |
-          set -o pipefail
-          pnpm tsx packages/downloader/test/contract/drift/musicbrainz.ts 2>&1 | tee mb.log
+        run: >
+          bash scripts/drift/run-check.sh MusicBrainz mb.log
+          pnpm tsx packages/downloader/test/contract/drift/musicbrainz.ts
 
       - name: plex.tv drift (live PIN surface vs schemas)
         id: plextv
-        continue-on-error: true
         # Unauthenticated PIN operations only: the token-requiring surface is replay-only by
         # design (no stored Plex credential exists to live-check it with).
-        run: |
-          set -o pipefail
-          pnpm tsx packages/web/test/contract/drift/plextv.ts 2>&1 | tee plextv.log
+        run: >
+          bash scripts/drift/run-check.sh plex.tv plextv.log
+          pnpm tsx packages/web/test/contract/drift/plextv.ts
 
       - name: Wait for slskd swagger
+        id: slskd_ready
+        # A container that never came up is an unavailable slskd, not a failed job: failing here
+        # would redden the run for the one reason this workflow has decided is not worth reddening
+        # it, and would skip the reporting steps that say so.
         run: |
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:5030/swagger/v0/swagger.json || true)
-            [ "$code" = "200" ] && exit 0
+            if [ "$code" = "200" ]; then
+              echo "ready=true" >>"$GITHUB_OUTPUT"
+              exit 0
+            fi
             sleep 2
           done
-          echo "slskd swagger did not become available" && exit 1
+          echo "ready=false" >>"$GITHUB_OUTPUT"
+          echo "slskd swagger did not become available within 60s" | tee slskd.log
 
       - name: slskd drift (latest OpenAPI vs consumed-surface manifest)
         id: slskd
-        continue-on-error: true
+        if: steps.slskd_ready.outputs.ready == 'true'
         env:
           SLSKD_SPEC_URL: http://localhost:5030/swagger/v0/swagger.json
           SLSKD_LATEST_LABEL: latest
-        # pipefail so `tee` doesn't mask a non-zero exit from the drift script.
-        run: |
-          set -o pipefail
-          pnpm tsx packages/downloader/test/contract/drift/slskd.ts 2>&1 | tee slskd.log
+        run: >
+          bash scripts/drift/run-check.sh slskd slskd.log
+          pnpm tsx packages/downloader/test/contract/drift/slskd.ts
+
+      - name: Report outcomes
+        id: report
+        uses: actions/github-script@v9
+        env:
+          MB_STATUS: ${{ steps.mb.outputs.status }}
+          PLEXTV_STATUS: ${{ steps.plextv.outputs.status }}
+          # Empty when the wait step gave up and the check was skipped — which IS unavailability.
+          SLSKD_STATUS: ${{ steps.slskd.outputs.status }}
+        with:
+          script: |
+            const checks = [
+              { target: 'MusicBrainz', status: process.env.MB_STATUS || 'unavailable' },
+              { target: 'slskd', status: process.env.SLSKD_STATUS || 'unavailable' },
+              { target: 'plex.tv', status: process.env.PLEXTV_STATUS || 'unavailable' },
+            ];
+            const badge = { conforms: '✓', drift: '✗', unavailable: '?' };
+            core.summary.addHeading('Contract drift', 3);
+            core.summary.addTable([
+              [{ data: 'Target', header: true }, { data: 'Outcome', header: true }],
+              ...checks.map((c) => [c.target, `${badge[c.status]} ${c.status}`]),
+            ]);
+            for (const { target, status } of checks) {
+              if (status === 'unavailable') {
+                core.warning(`${target} could not be reached — its contract was neither confirmed nor refuted this run. See the step log.`, { title: 'Drift check inconclusive' });
+              }
+            }
+            const drifted = checks.some((c) => c.status === 'drift');
+            if (!drifted && checks.some((c) => c.status === 'unavailable')) {
+              core.summary.addRaw('\nNo drift found, but this run did not reach every provider — a green result here is **not** a clean bill of health for the unreached ones.\n');
+            }
+            await core.summary.write();
+            core.setOutput('drifted', String(drifted));
+            core.setOutput('statuses', checks.map((c) => `- ${c.target}: **${c.status}**`).join('\n'));
 
       - name: Open or refresh drift issue
-        if: steps.mb.outcome == 'failure' || steps.slskd.outcome == 'failure' || steps.plextv.outcome == 'failure'
+        if: steps.report.outputs.drifted == 'true'
         uses: actions/github-script@v9
+        env:
+          STATUSES: ${{ steps.report.outputs.statuses }}
         with:
           script: |
             const fs = require('fs');
@@ -81,11 +137,11 @@ jobs:
             const { owner, repo } = context.repo;
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
             const body = [
-              `Automated contract drift check failed on ${new Date().toISOString()}.`,
+              `Automated contract drift check found drift on ${new Date().toISOString()}.`,
               '',
-              `- MusicBrainz: **${{ steps.mb.outcome }}**`,
-              `- slskd: **${{ steps.slskd.outcome }}**`,
-              `- plex.tv: **${{ steps.plextv.outcome }}**`,
+              process.env.STATUSES,
+              '',
+              'An **unavailable** target above was not reached and says nothing about its contract — only **drift** rows are findings.',
               '',
               '### MusicBrainz', '```', read('mb.log'), '```',
               '### slskd', '```', read('slskd.log'), '```',
@@ -105,5 +161,5 @@ jobs:
             }
 
       - name: Fail the run on drift
-        if: steps.mb.outcome == 'failure' || steps.slskd.outcome == 'failure' || steps.plextv.outcome == 'failure'
+        if: steps.report.outputs.drifted == 'true'
         run: echo "contract drift detected — see the drift issue" && exit 1

--- a/openspec/changes/drift-signal-fidelity/design.md
+++ b/openspec/changes/drift-signal-fidelity/design.md
@@ -1,0 +1,94 @@
+# Design: drift-signal-fidelity
+
+## Context
+
+Tier 2 of the contract tests (`.github/workflows/contract-drift.yml`) answers one question:
+_has an external provider changed a shape we consume?_ It answers it by going to the live
+world, which means every answer it gives is entangled with a second question it never
+separates out — _could we reach the live world at all?_ Every alert it has ever produced was
+an answer to the second question mistaken for an answer to the first.
+
+## Decisions
+
+### D1 — Three outcomes, carried by exit code
+
+A drift check exits `0` (conforms), `1` (drift), or `2` (unavailable). The workflow reads the
+code, not a boolean `outcome`, and routes accordingly.
+
+Exit code rather than a JSON artifact because the checks are already invoked as plain
+processes whose stdout is teed into the issue body, and because a code survives a crash
+faithfully: an unhandled fault still exits `1`, i.e. lands in the loud branch. That is the
+right default — #110 was a broken checker, and filing an issue for it was correct behaviour.
+Only a *deliberate* `2` is quiet.
+
+Rejected: a fourth "degraded" state for partially-unavailable runs. A run where five requests
+conform and two are unreachable has still verified five contracts and failed to verify two;
+that is `unavailable` with the detail in the log, not a new state. Aggregation is
+worst-first — any `drift` wins, then any `unavailable`, else `conforms`.
+
+### D2 — `unavailable` is green, and the masking risk is accepted deliberately
+
+The alternative (fail the run, but file no issue) keeps a loud signal at the cost of a red
+week every time MusicBrainz throttles a shared runner IP, which is the noise this change
+exists to remove. The accepted risk is that a *permanently* unreachable provider only ever
+shows as a weekly warning annotation rather than a page.
+
+Two things bound that risk rather than merely hoping about it:
+
+1. `404`/`410` is drift, not unavailability (D3). A provider that removes an endpoint — the
+   realistic permanent failure — stays loud.
+2. The warning is written to the job summary as well as an annotation, so the Actions run list
+   carries a visible ⚠ for the week rather than a silent green.
+
+### D3 — Transient by status, and "gone" is drift
+
+Retryable-and-then-unavailable: `408`, `425`, `429`, `500`, `502`, `503`, `504`, and any
+transport-level fault (DNS, TLS, connection reset, timeout).
+
+Drift: every other non-2xx. The important member is `404`/`410` on a request whose fixture
+recorded a `200` — the operation the adapter depends on no longer exists. Treating that as
+"unavailable" would be exactly the mask D2 worries about.
+
+`401`/`403` also land in drift. Neither drift script authenticates, so an auth challenge on a
+previously-anonymous endpoint is a real change in the consumed surface, not an outage.
+
+### D4 — The probe is shared tooling, not per-script cleverness
+
+`scripts/drift/probe.ts` — the workspace's existing tooling tier (`scripts/`, its own
+tsconfig, its own vitest project, already wired into `pnpm check` as the `tooling` lane).
+Both drift scripts import it.
+
+It is placed there rather than in either package's `test/contract/support/` because the two
+consumers live in **different packages**, and a cross-package reach from `packages/web` into
+`packages/downloader`'s test tree would smuggle in exactly the module coupling
+`module-architecture` forbids — through a path lint does not currently watch, which is worse
+than one it does.
+
+The probe takes its clock as a parameter (`sleep`) so its retry schedule is asserted by tests
+that do not actually wait.
+
+### D5 — `Retry-After` is honoured, with a ceiling
+
+MusicBrainz and plex.tv may both answer a throttle with `Retry-After`. Both spellings are
+parsed: delta-seconds (`Retry-After: 120`) and HTTP-date. An unparseable or absent header
+falls back to exponential backoff.
+
+A provider is entitled to ask for an hour; a weekly job is not entitled to sit for one. The
+honoured delay is clamped to a ceiling, above which the run gives up and reports
+`unavailable` — which is the honest report anyway: we were told to come back later than this
+run is willing to wait.
+
+### D6 — Requests are still paced, and identify honestly
+
+The ≤1 req/s MusicBrainz pacing stays. The User-Agent stops pointing at a repository that does
+not exist. MusicBrainz's own guidance is that an anonymous client must identify itself with a
+contactable URL; a dead URL is not politeness theatre, it is a reason to be throttled, and the
+job that suffers from being throttled is this one.
+
+## Risks / trade-offs
+
+- **A green run now means "no drift *found*", not "no drift".** Mitigated by D2's two bounds
+  and by stating it in the workflow's own comment header, so the next reader of a green
+  Actions history is not misled.
+- **More retries means a longer job.** A fully-throttled MusicBrainz run costs minutes, once a
+  week, on a job that gates nothing.

--- a/openspec/changes/drift-signal-fidelity/proposal.md
+++ b/openspec/changes/drift-signal-fidelity/proposal.md
@@ -1,0 +1,57 @@
+# Proposal: drift-signal-fidelity
+
+## Why
+
+The weekly drift job has filed two issues in its life and **both were false positives**.
+
+- **#110** (2026-07-27) — `ERR_MODULE_NOT_FOUND`: the workflow invoked the scripts from the
+  wrong working directory. No live response was ever fetched.
+- **#184** (2026-08-17) — two MusicBrainz requests answered `HTTP 503`. Replaying the exact
+  same request set against live `musicbrainz.org` today, all seven fixtures conform. Nothing
+  drifted; MusicBrainz rate-limits per IP, GitHub-hosted runners share their egress IPs with
+  every other Actions customer, and a 503 there says nothing whatsoever about our contract.
+
+A detector whose entire alert history is noise is a detector nobody reads, and the cost is not
+hypothetical: a real dropped field would arrive in a channel already trained to be ignored. The
+defect is that the job **conflates two different facts** — "the provider's shape changed" and
+"we could not reach the provider" — and reports both as drift, with the same red run and the
+same tracking issue.
+
+The scripts also under-invest in reaching the provider at all: MusicBrainz gets one retry at a
+flat 2 s, ignores `Retry-After`, and identifies itself with a User-Agent pointing at a
+repository that does not exist (`github.com/anthropics/music-downloader`) — the opposite of the
+identification etiquette MusicBrainz asks of anonymous clients, and a plausible contributor to
+being throttled in the first place. `plextv.ts` has the same latent bug from the other end: it
+labels any non-2xx `DRIFT`, so a plex.tv 502 would file the same false issue.
+
+## What Changes
+
+- **A third outcome.** Each drift check reports `conforms`, `drift`, or **`unavailable`**, and
+  says which by exit code (`0` / `1` / `2`). Only `drift` fails the run and opens or refreshes
+  the `contract-drift` issue. `unavailable` leaves the run green and surfaces as a workflow
+  `::warning::` plus a job-summary line naming the target and the reason.
+- **Unreachable is not the same as gone.** A transient status (408, 425, 429, 500, 502, 503,
+  504) or a transport fault is `unavailable`. A `404`/`410` on a request that was recorded
+  answering `200` is **drift** — the operation was removed, which is precisely the kind of
+  change the job exists to catch.
+- **A shared, tested probe.** `scripts/drift/probe.ts` holds the retry/backoff/classification
+  logic once, unit-tested in the tooling tier, and both drift scripts use it. It honours
+  `Retry-After` (delta-seconds and HTTP-date), retries transient outcomes with exponential
+  backoff, and caps its own patience.
+- **Honest identification.** The MusicBrainz User-Agent names this repository.
+
+## Impact
+
+- `openspec/specs/external-api-contracts` — the drift-detection requirement gains the
+  inconclusive outcome; the MusicBrainz requirement gains the etiquette obligation.
+- `scripts/drift/probe.ts` (new, with `probe.test.ts` in the existing tooling tier).
+- `packages/downloader/test/contract/drift/musicbrainz.ts`,
+  `packages/web/test/contract/drift/plextv.ts` — classify through the probe.
+- `.github/workflows/contract-drift.yml` — routes the three outcomes.
+- `packages/downloader/test/contract/README.md` — documents the outcome vocabulary.
+
+No runtime code changes. No public contract changes. The commit gate is untouched: this is
+tier-2 tooling that has never gated a commit and still does not.
+
+Issue #184 itself is closed by this change with no schema or fixture edit, because the live
+replay proves there is nothing to edit.

--- a/openspec/changes/drift-signal-fidelity/specs/external-api-contracts/spec.md
+++ b/openspec/changes/drift-signal-fidelity/specs/external-api-contracts/spec.md
@@ -1,0 +1,99 @@
+# external-api-contracts — delta for drift-signal-fidelity
+
+## MODIFIED Requirements
+
+### Requirement: MusicBrainz drift is detected by live replay
+
+A scheduled job SHALL replay the consumed MusicBrainz request set against the live service —
+within the service's rate-limit and identification etiquette — and validate each response
+against the shared contract schemas. The identification the job sends SHALL name a
+contactable location for this project, so the request set cannot be throttled for
+misidentifying itself.
+
+#### Scenario: Live MusicBrainz response violates the contract
+
+- **WHEN** a live response is missing or retypes a consumed field
+- **THEN** the scheduled job fails, identifying the request and the violating schema path
+
+#### Scenario: The live replay identifies itself contactably
+
+- **WHEN** the drift job issues its anonymous MusicBrainz requests
+- **THEN** each request carries a User-Agent naming this project and a location that resolves
+
+### Requirement: Drift detection is scheduled and notifies without blocking the gate
+
+Drift detection SHALL run automatically on a recurring schedule (at least weekly) and on
+manual dispatch, SHALL NOT block commits or pull requests, and on failure SHALL open — or
+update if already open — a tracking issue containing the violation details.
+
+Each check SHALL report one of three outcomes and SHALL make that outcome machine-readable to
+the workflow that invokes it: **conforms**, **drift**, or **unavailable**. Only *drift* SHALL
+fail the run and open or refresh the tracking issue. *Unavailable* — the provider could not be
+reached, so the contract was neither confirmed nor refuted — SHALL leave the run passing and
+SHALL be reported as a warning naming the unreached target and the reason, so an inconclusive
+run is never silently indistinguishable from a conforming one.
+
+#### Scenario: Drift detected on a scheduled run
+
+- **WHEN** a scheduled drift run fails
+- **THEN** a drift tracking issue is opened, or refreshed if one is already open, with the failure details, and the commit gate is unaffected
+
+#### Scenario: Manual drift check
+
+- **WHEN** a maintainer dispatches the drift workflow manually
+- **THEN** it runs the same checks as the scheduled run
+
+#### Scenario: A provider cannot be reached
+
+- **WHEN** a checked provider answers a transient failure, or no response at all, for every
+  attempt the check is willing to make
+- **THEN** the run passes, no drift issue is opened or refreshed, and the run reports a warning
+  naming the unreached provider and the reason
+
+#### Scenario: A provider is reached and only some requests are inconclusive
+
+- **WHEN** some of a provider's checked requests conform and the rest are unreachable
+- **THEN** the run reports the provider as unavailable, listing which requests conformed and
+  which were not verified, and still opens no drift issue
+
+#### Scenario: A consumed operation has been removed
+
+- **WHEN** a request whose recorded fixture answered a success status now answers `404` or `410`
+- **THEN** the check reports drift — not unavailability — so a removed operation stays loud
+
+#### Scenario: A previously anonymous operation demands authentication
+
+- **WHEN** a request the drift check issues anonymously answers `401` or `403`
+- **THEN** the check reports drift, because the consumed surface changed
+
+## ADDED Requirements
+
+### Requirement: Live drift checks retry transient failures before concluding
+
+A live drift check SHALL NOT conclude anything about the contract from a single transient
+failure. It SHALL retry a transient outcome — a transport fault, or a status the provider uses
+to signal throttling or temporary unavailability — with a backoff that honours any
+`Retry-After` the provider sends, up to a bounded number of attempts and a bounded delay. When
+the provider asks for a delay longer than the check is willing to wait, or the attempts are
+exhausted, the check SHALL report the request as unavailable rather than as drift.
+
+#### Scenario: A transient failure that clears on retry
+
+- **WHEN** a provider answers a throttling status and then answers successfully on a retry
+- **THEN** the check validates the successful response and reports no drift
+
+#### Scenario: The provider names its own backoff
+
+- **WHEN** a provider answers a transient failure carrying a `Retry-After` header
+- **THEN** the check waits the interval the provider named, rather than its own default backoff
+
+#### Scenario: The provider asks for longer than the check will wait
+
+- **WHEN** a provider's `Retry-After` exceeds the check's ceiling
+- **THEN** the check stops retrying and reports the request as unavailable, naming the
+  requested delay
+
+#### Scenario: Attempts are exhausted
+
+- **WHEN** every attempt a check makes for a request fails transiently
+- **THEN** the request is reported as unavailable, naming the last failure, and never as drift

--- a/openspec/changes/drift-signal-fidelity/tasks.md
+++ b/openspec/changes/drift-signal-fidelity/tasks.md
@@ -1,0 +1,118 @@
+# Tasks — drift-signal-fidelity
+
+Sequencing: the pure probe first (classification, backoff, `Retry-After`), then each drift
+script onto it, then the workflow that routes the three outcomes, then the docs. Every task
+touching code is red-first: write the failing test, watch it fail, then make it pass.
+
+Task 0 is the triage of #184 itself and comes first, because if the live replay had shown real
+drift this change would be the wrong change.
+
+## 0. Triage the open drift issue
+
+- [x] 0.1 Replay the recorded MusicBrainz request set against the live service and record the
+      result. Done when every fixture is shown to conform (no schema edit, no re-record needed)
+      or, if any genuinely drifted, this change is abandoned in favour of a schema/fixture fix.
+      _All seven fixtures conform against live `musicbrainz.org`, including the two #184 named
+      (`recording-lookup.json`, `release-group-no-official-browse.json`). Nothing drifted; the
+      503s were the shared runner egress IP hitting MusicBrainz's per-IP rate limit. No schema
+      or fixture is touched by this change._
+
+## 1. The probe — pure, red-first
+
+- [x] 1.1 Red: `scripts/drift/probe.test.ts` scenarios for the transient/terminal split — each
+      of `408, 425, 429, 500, 502, 503, 504` classified transient; `404`, `410`, `401`, `403`,
+      `400` classified terminal (drift). Then implement the classifier. Done when a status
+      table drives the test rather than one hand-picked example per branch.
+      _`it.each` over `TRANSIENT_STATUSES` itself, so widening the set cannot leave a member
+      unasserted, plus a terminal table carrying `501`/`505` — a not-implemented operation is a
+      statement about shape, not about load._
+- [x] 1.2 Red: `Retry-After` parsing — delta-seconds, an HTTP-date in the future, an HTTP-date
+      already past (⇒ no wait), and an unparseable value (⇒ fall back to backoff). Then
+      implement. Done when the clock is injected, so no test sleeps.
+      _Plus two the first draft got wrong and the tests caught: a negative delta-seconds, and an
+      empty header — `Number('')` is `0`, which would have read as "retry immediately" and
+      hammered a provider that told us nothing._
+- [x] 1.3 Red: the retry loop — a transient status that clears on attempt 2 returns the
+      response; exhausted attempts return `unavailable` naming the last failure; a transport
+      fault (a rejected fetch) is transient too and is never allowed to escape as an exception;
+      a `Retry-After` above the ceiling stops retrying immediately and reports the requested
+      delay. Then implement `probe()`. Done when the recorded sleep schedule is asserted, not
+      the wall clock.
+      _`MAX_ATTEMPTS` is derived from `RETRY_BACKOFF_MS.length + 1` and the loop's "is there a
+      backoff entry for this attempt?" IS its stopping condition, so the budget and the schedule
+      cannot drift into disagreeing. A non-`Error` rejection is pinned too — undici is third
+      party and may reject with whatever it likes._
+- [x] 1.4 Red: outcome aggregation — `drift` beats `unavailable` beats `conforms`, and the
+      exit codes are `1`/`2`/`0`. Then implement. Done when the mapping lives in one place both
+      drift scripts read.
+      _`worstOutcome` + `DRIFT_EXIT_CODES` in `scripts/drift/probe.ts`; all three checks import
+      them, and `scripts/drift/run-check.sh` is the single place that turns a code into a word._
+
+## 2. MusicBrainz drift check onto the probe
+
+- [x] 2.1 Rewrite `packages/downloader/test/contract/drift/musicbrainz.ts` to classify each
+      fixture replay as conforms / drift / unavailable through the probe, print a per-fixture
+      line naming which, and exit with the aggregated code. Done when a run whose only failures
+      are transient exits `2` and prints no `drift` line.
+      _Verified against a local server answering 503: seven `?` lines, exit `2`, no drift
+      section. Against one answering 404: seven `✗` lines, exit `1`._
+- [x] 2.2 Point the User-Agent at this repository. Done when the URL it sends resolves.
+      _`github.com/anthropics/music-downloader` → `github.com/jgchk/music-downloader`._
+- [x] 2.3 Verify against the live service: the whole set still conforms and exits `0`.
+
+## 3. plex.tv drift check onto the probe
+
+- [x] 3.1 Rewrite `packages/web/test/contract/drift/plextv.ts` so a transient status on the PIN
+      operations is `unavailable`, not `DRIFT`. Done when the expected-`404` assertion on a
+      nonexistent PIN is untouched — that 404 is the contract, not a fault — and a 502 on PIN
+      create no longer files an issue.
+      _Verified against local servers: 502 → `UNAVAILABLE pin create`, exit `2`; 403 → `DRIFT
+      pin create`, exit `1`._
+- [x] 3.2 Verify against the live service: the PIN surface still conforms and exits `0`.
+
+## 3b. slskd drift check onto the same vocabulary
+
+This check *already* split "the consumed surface broke" (exit 1) from "the environment gave me no
+spec to read" (exit 2) — the workflow simply threw the distinction away. The work here is to make
+it speak the shared constants and to correct the one case filed on the wrong side.
+
+- [x] 3b.1 Route its spec fetch through the probe, so a transport fault is unavailable rather than
+      an unhandled rejection that exits `1`. Done when a dead `SLSKD_SPEC_URL` reports unavailable.
+      _Verified: a dead port reports `could not fetch latest spec: fetch failed after 4 attempts`
+      and exits `2`. Against a live `slskd/slskd:latest` container it still exits `0`._
+- [x] 3b.2 Move "manifest does not hold against its own pinned snapshot" from exit `2` to exit `1`.
+      Done when a self-contradicting checker is loud — it is a repo bug, not an outage, and quietly
+      skipping the week is how #110 would have gone unnoticed.
+
+## 4. The workflow routes the three outcomes
+
+- [x] 4.1 Read each check's exit code into a step output (`conforms` / `drift` / `unavailable`)
+      rather than a pass/fail `outcome`, keeping `pipefail` so `tee` cannot mask it. Done when
+      an exit code of `2` from a step is observable to the later steps.
+      _`scripts/drift/run-check.sh` reads `${PIPESTATUS[0]}` rather than relying on `pipefail`:
+      with `tee` on the right, `$?` is tee's status, and pipefail's rightmost-failure rule is a
+      boolean answer to a three-way question._
+- [x] 4.2 Open or refresh the `contract-drift` issue, and fail the run, **only** when some
+      check reports `drift`. Done when an all-`unavailable` run opens nothing.
+- [x] 4.3 Emit a `::warning::` and a job-summary line for each `unavailable` check, naming the
+      target. Done when an inconclusive week is visibly distinct from a conforming one in the
+      Actions run list.
+      _A summary table of all three targets, plus an explicit line saying a green run with an
+      unreached provider is not a clean bill of health for it._
+- [x] 4.4 Prove the exit code actually survives the `pnpm tsx … | tee` invocation the workflow
+      uses. Done by running the pipeline locally against a script that exits `2`.
+      _Exercised for exit `0`, `1`, `2` and `7`; `7` maps to `drift`, so a crashing checker
+      stays loud._
+- [x] 4.5 Stop the slskd readiness wait from failing the job. A container that never came up is an
+      unavailable slskd; failing there reddens the run for the one reason this change decided is
+      not worth reddening it, and skips the very steps that would have said so. Done when a
+      not-ready slskd reports `unavailable` and the run stays green.
+      _The wait sets `ready=true|false`; the check is skipped when not ready, and an empty step
+      output is normalised to `unavailable` by the reporting step._
+
+## 5. Docs and close-out
+
+- [x] 5.1 Record the three-outcome vocabulary in `packages/downloader/test/contract/README.md`
+      tier-2 section, including that a green run means "no drift found", not "provider
+      reached".
+- [ ] 5.2 Close #184 referencing the live-replay evidence from 0.1.

--- a/packages/downloader/test/contract/README.md
+++ b/packages/downloader/test/contract/README.md
@@ -45,15 +45,40 @@ of them are the same endpoint seen in a different state:
 
 ## Tier 2 — weekly drift detection (`.github/workflows/contract-drift.yml`)
 
-Runs on a schedule + `workflow_dispatch`; never gates a commit. On drift it opens or refreshes a
-single `contract-drift` GitHub issue.
+Runs on a schedule + `workflow_dispatch`; never gates a commit.
 
 - `drift/musicbrainz.ts` — replays the recorded request set against live `musicbrainz.org` and
-  validates responses against the shared schemas (≤1 req/s, one retry).
+  validates responses against the shared schemas (≤1 req/s, identified with a contactable
+  User-Agent).
 - `drift/slskd.ts` — checks the consumed-surface manifest (`support/slskd-manifest.ts`) against a
   live `slskd/slskd:latest` OpenAPI document. slskd leaves most 2xx responses unschematized, so the
   spec check covers operations, path parameters, and request fields; response shape is pinned by the
   fixtures + runtime schemas.
+- `packages/web/test/contract/drift/plextv.ts` — the unauthenticated plex.tv PIN surface.
+
+### The three outcomes
+
+A live check is entangled with a question it must not confuse with drift: _could we reach the
+provider at all?_ Both issues this job ever filed were that confusion — #110 (a broken invocation)
+and #184 (two MusicBrainz 503s from a shared GitHub-runner egress IP, where a same-day local replay
+showed every fixture conforming). So each check reports one of three outcomes, carried by its exit
+code and mapped in `scripts/drift/run-check.sh`:
+
+| Exit | Outcome       | Means                                         | The workflow                                   |
+| ---- | ------------- | --------------------------------------------- | ---------------------------------------------- |
+| `0`  | `conforms`    | reached, and the consumed surface still holds | green                                          |
+| `1`  | `drift`       | reached, and the consumed surface changed     | **red**, opens or refreshes the tracking issue |
+| `2`  | `unavailable` | not reached — neither confirmed nor refuted   | green, with a `::warning::` and a summary row  |
+
+**A green run means "no drift found", not "every provider was reached"** — the job summary says
+which. The classification lives once in `scripts/drift/probe.ts`, which also owns the retry:
+transient statuses (`408 425 429 500 502 503 504`) and transport faults are retried with backoff,
+honouring `Retry-After` up to a ceiling. Everything else the provider answers is terminal, and the
+important members stay loud: a `404`/`410` on a recorded operation means it was **removed**, and a
+`401`/`403` on an anonymous one means the surface grew an auth requirement. Both are drift.
+
+An unhandled crash exits `1`, so a broken checker lands in the loud channel rather than passing for
+a quiet outage.
 
 ## Re-recording and refreshing
 
@@ -89,7 +114,10 @@ curl -s localhost:5030/swagger/v0/swagger.json -o test/contract/slskd-spec/swagg
 
 When a drift issue fires: if a consumed field or operation genuinely changed, update the schema,
 re-record the affected fixtures, and (for slskd) refresh the pinned snapshot and manifest. If only
-values or unconsumed surface moved, no action is needed.
+values or unconsumed surface moved, no action is needed. Triage starts by re-running the check
+locally — `pnpm tsx packages/downloader/test/contract/drift/musicbrainz.ts` needs nothing but
+network — because a run that conforms from a developer machine and not from CI is telling you about
+the runner, not the contract.
 
 ## Bumping the pinned slskd version
 

--- a/packages/downloader/test/contract/drift/musicbrainz.ts
+++ b/packages/downloader/test/contract/drift/musicbrainz.ts
@@ -1,3 +1,9 @@
+import {
+  DRIFT_EXIT_CODES,
+  probe,
+  worstOutcome,
+  type DriftOutcome,
+} from '../../../../../scripts/drift/probe.js';
 import { loadFixtures } from '../support/fixture.js';
 import { fixtureSchemas } from '../support/registry.js';
 
@@ -6,60 +12,95 @@ import { fixtureSchemas } from '../support/registry.js';
  * recorded from against the live service and validates each response with the same contract schema
  * the runtime adapter enforces. Value-level change (tags, ratings, freshly-added releases) is not
  * drift — only a consumed field going missing or changing type is, which is precisely what schema
- * validation catches. Anonymous, ≤1 req/s with a descriptive User-Agent, one retry with backoff.
- * Exits non-zero on any violation, naming the request and the failing schema path.
+ * validation catches. Anonymous, ≤1 req/s with a descriptive User-Agent.
+ *
+ * Each replay lands in one of three outcomes and the process exit code carries the run's worst
+ * (change: drift-signal-fidelity): `0` conforms, `1` drift, `2` unavailable. The split matters
+ * because MusicBrainz rate-limits per IP and GitHub-hosted runners share their egress with every
+ * other Actions customer, so a 503 here is a statement about the runner, not about the contract —
+ * issue #184 was exactly that, reported as drift. A removed operation (404/410) or an endpoint
+ * that grew an auth requirement stays drift; see `scripts/drift/probe.ts` for the full split.
  */
 
 const BASE_URL = process.env.MUSICBRAINZ_BASE_URL ?? 'https://musicbrainz.org/ws/2';
+/**
+ * MusicBrainz asks anonymous clients to identify themselves with a contactable location, and
+ * enforces it with throttling. This pointed at `github.com/anthropics/music-downloader` — a
+ * repository that does not exist — until drift-signal-fidelity; a dead URL is not politeness
+ * theatre, it is a reason to be throttled, and this job is what suffers for it.
+ */
 const USER_AGENT =
   process.env.MUSICBRAINZ_USER_AGENT ??
-  'music-downloader-drift/0.0 (https://github.com/anthropics/music-downloader)';
+  'music-downloader-drift/1.0 (https://github.com/jgchk/music-downloader)';
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function fetchWithRetry(url: string): Promise<Response> {
-  for (let attempt = 0; ; attempt += 1) {
-    const response = await fetch(url, {
-      headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
-    });
-    if (response.ok || attempt >= 1) return response;
-    await sleep(2000); // one retry with backoff (rate limit / transient)
-  }
-}
-
 async function main(): Promise<void> {
   const fixtures = loadFixtures('musicbrainz');
-  const failures: string[] = [];
+  const outcomes: DriftOutcome[] = [];
+  const drifts: string[] = [];
+  const unreached: string[] = [];
 
   for (const { name, fixture } of fixtures) {
     const schema = fixtureSchemas[`musicbrainz/${name}`];
     if (schema === undefined) continue;
     const query = new URLSearchParams(fixture.request.query).toString();
     const url = `${BASE_URL}${fixture.request.path}?${query}`;
+    const where = `${name} (${fixture.request.path})`;
 
-    const response = await fetchWithRetry(url);
+    const result = await probe(() =>
+      fetch(url, { headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' } }),
+    );
     await sleep(1100); // ≥1 req/s
-    if (!response.ok) {
-      failures.push(`${name}: HTTP ${response.status} for ${fixture.request.path}`);
+
+    if (result.kind === 'unavailable') {
+      outcomes.push('unavailable');
+      unreached.push(`${name}: ${result.reason}`);
+      console.log(`? ${where} — not verified: ${result.reason}`);
       continue;
     }
-    const result = schema.safeParse(await response.json());
-    if (result.success) {
-      console.log(`✓ ${name} (${fixture.request.path})`);
+
+    // Reached, but not with a body: the operation the adapter depends on answered something it
+    // never answered when the fixture was recorded. That is the consumed surface changing.
+    if (!result.response.ok) {
+      outcomes.push('drift');
+      drifts.push(`${name}: HTTP ${result.response.status} for ${fixture.request.path}`);
+      console.log(`✗ ${where} — HTTP ${result.response.status}`);
+      continue;
+    }
+
+    const parsed = schema.safeParse(await result.response.json());
+    if (parsed.success) {
+      outcomes.push('conforms');
+      console.log(`✓ ${where}`);
     } else {
-      const paths = result.error.issues.map((i) => i.path.join('.') || '(root)').join(', ');
-      failures.push(`${name}: schema violation at [${paths}]`);
+      const paths = parsed.error.issues.map((i) => i.path.join('.') || '(root)').join(', ');
+      outcomes.push('drift');
+      drifts.push(`${name}: schema violation at [${paths}]`);
+      console.log(`✗ ${where} — schema violation`);
     }
   }
 
-  if (failures.length > 0) {
-    console.error(`\n✗ MusicBrainz contract drift (${failures.length}):`);
-    for (const f of failures) console.error(`  - ${f}`);
-    process.exit(1);
+  const outcome = worstOutcome(outcomes);
+  if (drifts.length > 0) {
+    console.error(`\n✗ MusicBrainz contract drift (${drifts.length}):`);
+    for (const drift of drifts) console.error(`  - ${drift}`);
   }
-  console.log('\n✓ live MusicBrainz responses conform to the contract');
+  if (unreached.length > 0) {
+    console.error(`\n? MusicBrainz not verified (${unreached.length} of ${outcomes.length}):`);
+    for (const reason of unreached) console.error(`  - ${reason}`);
+  }
+  if (outcome === 'conforms') {
+    console.log('\n✓ live MusicBrainz responses conform to the contract');
+  } else if (outcome === 'unavailable') {
+    console.log(
+      '\n? MusicBrainz was not fully reachable — the contract is neither confirmed nor refuted',
+    );
+  }
+
+  process.exit(DRIFT_EXIT_CODES[outcome]);
 }
 
 void main();

--- a/packages/downloader/test/contract/drift/slskd.ts
+++ b/packages/downloader/test/contract/drift/slskd.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { DRIFT_EXIT_CODES, probe } from '../../../../../scripts/drift/probe.js';
 import { SLSKD_CONSUMED_OPERATIONS } from '../support/slskd-manifest.js';
 import { checkSlskdSpec } from '../support/spec-compat.js';
 import type { OpenApiSpec } from '../support/spec-compat.js';
@@ -8,8 +9,12 @@ import type { OpenApiSpec } from '../support/spec-compat.js';
  * drift workflow boots `slskd/slskd:latest` with `SLSKD_SWAGGER=true` and points `SLSKD_SPEC_URL`
  * at it — and runs the consumed-surface manifest against it. It first re-confirms the manifest
  * still holds against the committed pinned snapshot (a self-check), then reports the pinned→latest
- * delta for the surface we depend on. Exits non-zero if the live spec drops or reshapes anything we
- * consume, so the workflow can raise a drift issue.
+ * delta for the surface we depend on.
+ *
+ * This check has always separated "the consumed surface broke" from "the environment did not give
+ * me a spec to read" by exit code; drift-signal-fidelity is where the workflow finally *honours*
+ * that split rather than collapsing both into a red run and a tracking issue. `1` is the loud
+ * channel (drift, or a checker that contradicts itself), `2` the quiet one (unavailable).
  *
  *   SLSKD_SPEC_URL=http://localhost:5030/swagger/v0/swagger.json \
  *   SLSKD_LATEST_LABEL=latest pnpm tsx test/contract/drift/slskd.ts
@@ -30,25 +35,31 @@ async function main(): Promise<void> {
 
   const pinnedViolations = checkSlskdSpec(pinnedSpec, SLSKD_CONSUMED_OPERATIONS);
   if (pinnedViolations.length > 0) {
+    // A checker that contradicts its own committed evidence is broken, and a broken checker is the
+    // loud channel — quietly skipping the week is how #110 would have gone unnoticed.
     console.error('BUG: manifest does not hold against its own pinned snapshot:');
     console.error(JSON.stringify(pinnedViolations, null, 2));
-    process.exit(2);
+    process.exit(DRIFT_EXIT_CODES.drift);
   }
 
   console.log(`fetching latest slskd spec from ${SPEC_URL} …`);
-  const response = await fetch(SPEC_URL);
-  if (!response.ok) {
-    console.error(`could not fetch latest spec: HTTP ${response.status}`);
-    process.exit(2);
+  const fetched = await probe(() => fetch(SPEC_URL));
+  if (fetched.kind === 'unavailable') {
+    console.error(`could not fetch latest spec: ${fetched.reason}`);
+    process.exit(DRIFT_EXIT_CODES.unavailable);
   }
-  const latestSpec = JSON.parse(await response.text()) as OpenApiSpec | null;
+  if (!fetched.response.ok) {
+    console.error(`could not fetch latest spec: HTTP ${fetched.response.status}`);
+    process.exit(DRIFT_EXIT_CODES.unavailable);
+  }
+  const latestSpec = JSON.parse(await fetched.response.text()) as OpenApiSpec | null;
 
   // Guard against a half-ready or wrong endpoint: an (almost) empty paths object is an environment
-  // fault, not "every operation we consume vanished". Fail as an error (2), not a drift signal (1).
+  // fault, not "every operation we consume vanished" — unavailable, never a drift signal.
   const pathCount = Object.keys(latestSpec?.paths ?? {}).length;
   if (latestSpec === null || pathCount < 10) {
     console.error(`fetched spec has only ${pathCount} paths — looks empty/unready, not real drift`);
-    process.exit(2);
+    process.exit(DRIFT_EXIT_CODES.unavailable);
   }
 
   const violations = checkSlskdSpec(latestSpec, SLSKD_CONSUMED_OPERATIONS);
@@ -61,7 +72,7 @@ async function main(): Promise<void> {
   }
   console.error(`✗ ${violations.length} breaking change(s) on the consumed surface:`);
   for (const v of violations) console.error(`  - ${v.operation}: ${v.problem}`);
-  process.exit(1);
+  process.exit(DRIFT_EXIT_CODES.drift);
 }
 
 void main();

--- a/packages/web/test/contract/drift/plextv.ts
+++ b/packages/web/test/contract/drift/plextv.ts
@@ -1,4 +1,11 @@
 import type { z } from 'zod';
+import {
+  DRIFT_EXIT_CODES,
+  probe,
+  worstOutcome,
+  type DriftOutcome,
+  type ProbeResult,
+} from '../../../../../scripts/drift/probe.js';
 import { PLEX_CLIENT_IDENTIFIER, PLEX_PRODUCT } from '../../../src/lib/server/plex/identity.js';
 import { plexPinCheckSchema, plexPinCreateSchema } from '../../../src/lib/server/plex/schemas.js';
 
@@ -7,8 +14,13 @@ import { plexPinCheckSchema, plexPinCreateSchema } from '../../../src/lib/server
  * unauthenticated PIN operations and validates the responses against the shared consumed-surface
  * schemas. The token-requiring operations (/user, /resources) are deliberately NOT drift-checked —
  * doing so would require storing a long-lived Plex credential, the exact thing the access design
- * refuses to hold; their drift surfaces as fail-closed login failures instead. Exits non-zero on
- * drift; the workflow turns that into the single contract-drift issue.
+ * refuses to hold; their drift surfaces as fail-closed login failures instead.
+ *
+ * The exit code carries the run's worst outcome (change: drift-signal-fidelity): `0` conforms,
+ * `1` drift, `2` unavailable. Until that change this script reported *any* non-2xx as DRIFT, so a
+ * plex.tv 502 would have filed the same false tracking issue that a MusicBrainz 503 filed as #184.
+ * A status that means "not now" is unavailability; a status that means the consumed surface
+ * changed — a removed operation, or an anonymous one that grew an auth requirement — is drift.
  */
 
 const BASE = process.env.PLEX_API_BASE_URL ?? 'https://plex.tv/api/v2';
@@ -19,13 +31,17 @@ const HEADERS = {
   'X-Plex-Client-Identifier': PLEX_CLIENT_IDENTIFIER,
 };
 
-/** Every reported drift, in report order — non-empty is the non-zero exit. */
-const drifts: string[] = [];
+const outcomes: DriftOutcome[] = [];
 
-function report(operation: string, error: z.ZodError | string): void {
-  drifts.push(operation);
+function reportDrift(operation: string, error: z.ZodError | string): void {
+  outcomes.push('drift');
   const detail = typeof error === 'string' ? error : JSON.stringify(error.issues, undefined, 2);
   console.error(`DRIFT ${operation}: ${detail}`);
+}
+
+function reportUnavailable(operation: string, reason: string): void {
+  outcomes.push('unavailable');
+  console.error(`UNAVAILABLE ${operation}: ${reason}`);
 }
 
 /** A non-JSON 2xx (captive portal, CDN interstitial) is drift too, not an unhandled crash. */
@@ -33,60 +49,93 @@ async function jsonBody(operation: string, response: Response): Promise<unknown>
   try {
     return await response.json();
   } catch {
-    report(operation, 'response body is not JSON');
+    reportDrift(operation, 'response body is not JSON');
     return undefined;
   }
 }
 
+/**
+ * Probe an operation that must answer 2xx, returning the response or `undefined` once the outcome
+ * has been recorded. `undefined` deliberately conflates "unavailable" and "drift" for the caller:
+ * both mean there is no body to read, and which of the two it was is already in `outcomes`.
+ */
+async function reachable(
+  operation: string,
+  request: () => Promise<Response>,
+): Promise<Response | undefined> {
+  const result: ProbeResult = await probe(request);
+  if (result.kind === 'unavailable') {
+    reportUnavailable(operation, result.reason);
+    return undefined;
+  }
+  if (!result.response.ok) {
+    reportDrift(operation, `unexpected status ${result.response.status}`);
+    return undefined;
+  }
+  return result.response;
+}
+
 async function main(): Promise<void> {
   // 1. PIN create — the login flow's first live call.
-  const pinCreateResponse = await fetch(`${BASE}/pins?strong=true`, {
-    method: 'POST',
-    headers: HEADERS,
-  });
-  if (!pinCreateResponse.ok) {
-    report('pin create', `unexpected status ${pinCreateResponse.status}`);
-    return;
-  }
+  const pinCreateResponse = await reachable('pin create', () =>
+    fetch(`${BASE}/pins?strong=true`, { method: 'POST', headers: HEADERS }),
+  );
+  if (pinCreateResponse === undefined) return;
   const createBody = await jsonBody('pin create', pinCreateResponse);
   if (createBody === undefined) return;
   const created = plexPinCreateSchema.safeParse(createBody);
   if (!created.success) {
-    report('pin create', created.error);
+    reportDrift('pin create', created.error);
     return;
   }
+  outcomes.push('conforms');
   console.log('ok: pin create conforms');
 
   // 2. PIN check (pending) — same shape the callback consumes.
-  const checkResponse = await fetch(`${BASE}/pins/${created.data.id}`, { headers: HEADERS });
-  if (!checkResponse.ok) {
-    report('pin check', `unexpected status ${checkResponse.status}`);
-    return;
-  }
-  const checkBody = await jsonBody('pin check', checkResponse);
-  if (checkBody !== undefined) {
-    const checked = plexPinCheckSchema.safeParse(checkBody);
-    if (checked.success) {
-      console.log('ok: pin check conforms');
-    } else {
-      report('pin check', checked.error);
+  const checkResponse = await reachable('pin check', () =>
+    fetch(`${BASE}/pins/${created.data.id}`, { headers: HEADERS }),
+  );
+  if (checkResponse !== undefined) {
+    const checkBody = await jsonBody('pin check', checkResponse);
+    if (checkBody !== undefined) {
+      const checked = plexPinCheckSchema.safeParse(checkBody);
+      if (checked.success) {
+        outcomes.push('conforms');
+        console.log('ok: pin check conforms');
+      } else {
+        reportDrift('pin check', checked.error);
+      }
     }
   }
 
-  // 3. Nonexistent PIN — the expired outcome must stay a 404.
-  const goneResponse = await fetch(`${BASE}/pins/999999999`, { headers: HEADERS });
-  if (goneResponse.status === 404) {
+  // 3. Nonexistent PIN — the expired outcome must stay a 404. Here the 404 IS the contract, so it
+  // is asserted rather than classified: `probe` never retries it, and a 200 or a 401 in its place
+  // would be the drift.
+  const gone = await probe(() => fetch(`${BASE}/pins/999999999`, { headers: HEADERS }));
+  if (gone.kind === 'unavailable') {
+    reportUnavailable('pin check (nonexistent)', gone.reason);
+  } else if (gone.response.status === 404) {
+    outcomes.push('conforms');
     console.log('ok: nonexistent pin still answers 404');
   } else {
-    report('pin check (nonexistent)', `expected 404, got ${goneResponse.status}`);
+    reportDrift('pin check (nonexistent)', `expected 404, got ${gone.response.status}`);
   }
 }
 
 try {
   await main();
 } catch (error) {
-  // Whatever escapes (transport fault mid-run) is still a DRIFT-labelled failure, not a bare stack.
-  report('drift run', error instanceof Error ? error.message : String(error));
+  // Whatever escapes is a broken checker, not a provider outage — and a broken checker is exactly
+  // what #110 was, so it stays in the loud channel rather than the quiet one.
+  reportDrift('drift run', error instanceof Error ? error.message : String(error));
 }
-if (drifts.length > 0) process.exit(1);
-console.log('plex.tv consumed surface: no drift detected');
+
+const outcome = worstOutcome(outcomes);
+if (outcome === 'conforms') {
+  console.log('plex.tv consumed surface: no drift detected');
+} else if (outcome === 'unavailable') {
+  console.log(
+    'plex.tv was not fully reachable — the consumed surface is neither confirmed nor refuted',
+  );
+}
+process.exit(DRIFT_EXIT_CODES[outcome]);

--- a/scripts/drift/probe.test.ts
+++ b/scripts/drift/probe.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DRIFT_EXIT_CODES,
+  MAX_ATTEMPTS,
+  RETRY_AFTER_CEILING_MS,
+  RETRY_BACKOFF_MS,
+  TRANSIENT_STATUSES,
+  isTransientStatus,
+  probe,
+  retryAfterMs,
+  worstOutcome,
+} from './probe.ts';
+
+/**
+ * The tier-2 drift job's judgement, one level down: is a failed live request evidence about the
+ * provider's *contract*, or only about our ability to reach it? Every alert this job has ever
+ * produced (issues #110 and #184) was the second mistaken for the first, so the split these tests
+ * pin is the whole point of the change — a classifier that leans one way files noise nobody reads,
+ * and one that leans the other way masks a genuinely removed endpoint.
+ *
+ * Nothing here sleeps: `probe` takes its clock, so the retry schedule is asserted as a recorded
+ * list of intended delays rather than by waiting for them.
+ */
+
+/** A `probe` harness whose fetches are scripted and whose sleeps are recorded, never taken. */
+function harness(attempts: readonly [Response | Error, ...(Response | Error)[]], now = 0) {
+  const slept: number[] = [];
+  const requested: number[] = [];
+  let index = 0;
+  const request = (): Promise<Response> => {
+    requested.push(index);
+    // Past the end, the last scripted answer repeats — that is how "the provider is simply down"
+    // is expressed without writing MAX_ATTEMPTS copies of the same 503.
+    const next = attempts.at(Math.min(index, attempts.length - 1)) ?? attempts[0];
+    index += 1;
+    return next instanceof Error ? Promise.reject(next) : Promise.resolve(next);
+  };
+  const options = {
+    sleep: (ms: number): Promise<void> => {
+      slept.push(ms);
+      return Promise.resolve();
+    },
+    now: () => now,
+  };
+  return { request, options, slept, attemptCount: () => requested.length };
+}
+
+function unavailable(status: number, headers?: Record<string, string>): Response {
+  return new Response(undefined, { status, headers });
+}
+
+describe('the transient/terminal split', () => {
+  it.each([...TRANSIENT_STATUSES])(
+    'treats %i as transient — a fault to retry, not drift',
+    (status) => {
+      expect(isTransientStatus(status)).toBe(true);
+    },
+  );
+
+  // The important members: a removed operation (404/410) and a surface that grew an auth
+  // requirement (401/403) are real changes to what we consume. Filing them as "the provider was
+  // busy" is the exact mask a quiet unavailable outcome would otherwise create.
+  it.each([400, 401, 403, 404, 410, 422, 501, 505])(
+    'treats %i as terminal — the consumed surface changed',
+    (status) => {
+      expect(isTransientStatus(status)).toBe(false);
+    },
+  );
+
+  it('lists 501 nowhere in the transient set, so a not-implemented operation stays loud', () => {
+    expect(TRANSIENT_STATUSES).not.toContain(501);
+  });
+});
+
+describe('Retry-After', () => {
+  it('reads the delta-seconds spelling', () => {
+    expect(retryAfterMs('120', 0)).toBe(120_000);
+  });
+
+  it('reads the HTTP-date spelling, relative to the injected clock', () => {
+    const now = Date.parse('Mon, 17 Aug 2026 07:00:00 GMT');
+    expect(retryAfterMs('Mon, 17 Aug 2026 07:00:30 GMT', now)).toBe(30_000);
+  });
+
+  it('reads a date already in the past as no wait at all, never as a negative delay', () => {
+    const now = Date.parse('Mon, 17 Aug 2026 07:00:00 GMT');
+    expect(retryAfterMs('Mon, 17 Aug 2026 06:59:00 GMT', now)).toBe(0);
+  });
+
+  it('declines an unparseable value so the caller falls back to its own backoff', () => {
+    expect(retryAfterMs('soon', 0)).toBeUndefined();
+  });
+
+  it('declines an absent header', () => {
+    expect(retryAfterMs(null, 0)).toBeUndefined();
+  });
+
+  it('declines a negative delta-seconds rather than reading it as a wait', () => {
+    expect(retryAfterMs('-5', 0)).toBeUndefined();
+  });
+
+  it('declines an empty header rather than reading it as "retry immediately"', () => {
+    expect(retryAfterMs('', 0)).toBeUndefined();
+  });
+});
+
+describe('probing a live request', () => {
+  it('returns the response untouched when the first attempt succeeds', async () => {
+    const { request, options, slept } = harness([new Response('{}', { status: 200 })]);
+
+    const result = await probe(request, options);
+
+    expect(result).toMatchObject({ kind: 'response' });
+    expect(slept).toEqual([]);
+  });
+
+  it('returns a terminal non-2xx to the caller to classify, without retrying it', async () => {
+    const { request, options, slept, attemptCount } = harness([unavailable(404)]);
+
+    const result = await probe(request, options);
+
+    expect(result.kind).toBe('response');
+    expect(attemptCount()).toBe(1);
+    expect(slept).toEqual([]);
+  });
+
+  it('retries a transient status and returns the response that clears it', async () => {
+    const { request, options, slept } = harness([
+      unavailable(503),
+      new Response('{}', { status: 200 }),
+    ]);
+
+    const result = await probe(request, options);
+
+    expect(result.kind).toBe('response');
+    expect(result.kind === 'response' && result.response.status).toBe(200);
+    expect(slept).toEqual([RETRY_BACKOFF_MS[0]]);
+  });
+
+  it('waits the interval the provider named instead of its own backoff', async () => {
+    const { request, options, slept } = harness([
+      unavailable(429, { 'Retry-After': '7' }),
+      new Response('{}', { status: 200 }),
+    ]);
+
+    await probe(request, options);
+
+    expect(slept).toEqual([7000]);
+  });
+
+  it('backs off increasingly across attempts and gives up as unavailable', async () => {
+    const { request, options, slept, attemptCount } = harness([unavailable(503)]);
+
+    const result = await probe(request, options);
+
+    expect(result).toEqual({
+      kind: 'unavailable',
+      reason: `HTTP 503 after ${MAX_ATTEMPTS} attempts`,
+    });
+    expect(attemptCount()).toBe(MAX_ATTEMPTS);
+    expect(slept).toEqual([...RETRY_BACKOFF_MS]);
+  });
+
+  it('stops immediately when the provider asks for longer than the run will wait', async () => {
+    const { request, options, slept, attemptCount } = harness([
+      unavailable(503, { 'Retry-After': '3600' }),
+    ]);
+
+    const result = await probe(request, options);
+
+    expect(result).toEqual({
+      kind: 'unavailable',
+      reason: 'HTTP 503, Retry-After 3600000ms exceeds the 30000ms this run will wait',
+    });
+    expect(attemptCount()).toBe(1);
+    expect(slept).toEqual([]);
+  });
+
+  it('treats a transport fault as transient and never lets it escape as an exception', async () => {
+    const { request, options, attemptCount } = harness([new TypeError('fetch failed')]);
+
+    const result = await probe(request, options);
+
+    expect(result).toEqual({
+      kind: 'unavailable',
+      reason: `fetch failed after ${MAX_ATTEMPTS} attempts`,
+    });
+    expect(attemptCount()).toBe(MAX_ATTEMPTS);
+  });
+
+  it('recovers from a transport fault that clears on a later attempt', async () => {
+    const { request, options } = harness([
+      new TypeError('fetch failed'),
+      new Response('{}', { status: 200 }),
+    ]);
+
+    const result = await probe(request, options);
+
+    expect(result.kind).toBe('response');
+  });
+
+  it('names a non-Error rejection rather than reporting "undefined"', async () => {
+    // A bare string rejection is not idiomatic, which is exactly why it is pinned: undici and the
+    // agents beneath it are third-party, and `String(error)` is the only thing that holds for
+    // whatever they choose to throw.
+    // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- modelling a badly-behaved third party is the point
+    const request = (): Promise<Response> => Promise.reject('socket hang up');
+    const sleep = (): Promise<void> => Promise.resolve();
+
+    const result = await probe(request, { sleep });
+
+    expect(result).toEqual({
+      kind: 'unavailable',
+      reason: `socket hang up after ${MAX_ATTEMPTS} attempts`,
+    });
+  });
+
+  it('holds a ceiling low enough that a weekly job never sits on one request', () => {
+    expect(RETRY_AFTER_CEILING_MS).toBeLessThanOrEqual(60_000);
+  });
+});
+
+describe('aggregating a run of many checks', () => {
+  it('reports conforms only when every check conformed', () => {
+    expect(worstOutcome(['conforms', 'conforms'])).toBe('conforms');
+  });
+
+  it('reports conforms for a run with nothing to check', () => {
+    expect(worstOutcome([])).toBe('conforms');
+  });
+
+  it('lets one drift outrank any number of conforming checks', () => {
+    expect(worstOutcome(['conforms', 'drift', 'conforms'])).toBe('drift');
+  });
+
+  it('lets drift outrank unavailability — a proven violation beats an unproven one', () => {
+    expect(worstOutcome(['unavailable', 'drift'])).toBe('drift');
+  });
+
+  it('reports unavailable when some checks conformed and the rest were unreachable', () => {
+    expect(worstOutcome(['conforms', 'unavailable'])).toBe('unavailable');
+  });
+
+  it('maps each outcome to the exit code the workflow routes on', () => {
+    expect(DRIFT_EXIT_CODES).toEqual({ conforms: 0, drift: 1, unavailable: 2 });
+  });
+});

--- a/scripts/drift/probe.ts
+++ b/scripts/drift/probe.ts
@@ -1,0 +1,153 @@
+/**
+ * Shared judgement for the tier-2 drift checks (change: drift-signal-fidelity).
+ *
+ * A live drift check answers one question — *has a provider changed a shape we consume?* — by
+ * going to the live world, which entangles it with a second question it must not confuse with the
+ * first: *could we reach the live world at all?* Both alerts this job has ever raised were the
+ * second mistaken for the first (#110, a broken invocation; #184, two MusicBrainz 503s on a
+ * shared GitHub-runner egress IP), and a detector whose whole alert history is noise is a
+ * detector nobody reads when the real dropped field finally arrives.
+ *
+ * So a check reports one of three outcomes and this module owns the split:
+ *
+ * - `conforms`     — the provider answered and the response satisfies the contract schema.
+ * - `drift`        — the provider answered and the consumed surface changed. LOUD: fails the run,
+ *                    opens or refreshes the tracking issue.
+ * - `unavailable`  — we could not reach the provider, so the contract was neither confirmed nor
+ *                    refuted. QUIET: the run stays green and reports a warning.
+ *
+ * The dangerous edge is what counts as unreachable. A removed operation (404/410) and a surface
+ * that grew an auth requirement (401/403) are *changes*, not outages — classifying them as
+ * unavailable is precisely how a quiet outcome would mask the failure it exists to report. Only
+ * the statuses a provider uses to say "not now" are transient.
+ *
+ * `probe` takes its clock so the retry schedule is unit-testable without waiting for it.
+ */
+
+/** The statuses a provider uses to mean "not now" — everything else is a statement about shape. */
+export const TRANSIENT_STATUSES = [408, 425, 429, 500, 502, 503, 504] as const;
+
+/** The wait before each retry when the provider names no interval of its own. */
+export const RETRY_BACKOFF_MS = [2000, 5000, 10_000] as const;
+
+/**
+ * Total attempts per request, initial included — derived from the backoff schedule rather than
+ * stated beside it, so the two can never drift into disagreeing about how many retries there are.
+ */
+export const MAX_ATTEMPTS = RETRY_BACKOFF_MS.length + 1;
+
+/**
+ * A provider is entitled to ask for an hour; a weekly job is not entitled to sit for one. Above
+ * this, giving up IS the honest report: we were told to come back later than this run will wait.
+ */
+export const RETRY_AFTER_CEILING_MS = 30_000;
+
+export type DriftOutcome = 'conforms' | 'drift' | 'unavailable';
+
+/** The exit code each outcome leaves for `.github/workflows/contract-drift.yml` to route on. */
+export const DRIFT_EXIT_CODES: Readonly<Record<DriftOutcome, number>> = {
+  conforms: 0,
+  drift: 1,
+  unavailable: 2,
+};
+
+export type ProbeResult =
+  /** The provider answered. A non-2xx here is terminal — the caller classifies what it means. */
+  | { readonly kind: 'response'; readonly response: Response }
+  /** We never got an answer worth reading. Never drift. */
+  | { readonly kind: 'unavailable'; readonly reason: string };
+
+export interface ProbeOptions {
+  /** Injected so tests assert the intended schedule instead of living through it. */
+  readonly sleep?: (ms: number) => Promise<void>;
+  /** Injected so an HTTP-date `Retry-After` is deterministic. */
+  readonly now?: () => number;
+}
+
+export function isTransientStatus(status: number): boolean {
+  return (TRANSIENT_STATUSES as readonly number[]).includes(status);
+}
+
+/**
+ * The delay a `Retry-After` asks for, in milliseconds, or `undefined` when the header is absent,
+ * unparseable, or asks for a wait in the past — in every one of which cases the caller falls back
+ * to its own backoff rather than inventing a number from a header it did not understand. A date
+ * already past means "go now", which is a zero wait, not a negative one.
+ */
+export function retryAfterMs(header: string | null, now: number): number | undefined {
+  // `Number('')` is 0, so an empty header would otherwise read as "retry immediately" and hammer a
+  // provider that told us nothing.
+  if (header === null || header.trim() === '') return undefined;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds)) return seconds < 0 ? undefined : seconds * 1000;
+  const date = Date.parse(header);
+  if (Number.isNaN(date)) return undefined;
+  return Math.max(0, date - now);
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function describeRejection(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Issue one live request, retrying only what is worth retrying, and never throwing: a transport
+ * fault escaping as an exception would abort the whole check and be reported as the broken-checker
+ * failure that #110 was, rather than as the outage it is.
+ */
+export async function probe(
+  request: () => Promise<Response>,
+  options: ProbeOptions = {},
+): Promise<ProbeResult> {
+  const sleep = options.sleep ?? defaultSleep;
+  const now = options.now ?? Date.now;
+  let lastFailure = 'no attempt was made';
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+    // The vendor call is the only thing allowed to throw, and it is converted here, at the call.
+    let outcome: { response: Response } | { rejection: unknown };
+    try {
+      outcome = { response: await request() };
+    } catch (error) {
+      outcome = { rejection: error };
+    }
+
+    let asked: number | undefined;
+    if ('response' in outcome) {
+      const { response } = outcome;
+      if (response.ok || !isTransientStatus(response.status)) return { kind: 'response', response };
+      lastFailure = `HTTP ${response.status}`;
+
+      asked = retryAfterMs(response.headers.get('retry-after'), now());
+      if (asked !== undefined && asked > RETRY_AFTER_CEILING_MS) {
+        return {
+          kind: 'unavailable',
+          reason: `${lastFailure}, Retry-After ${asked}ms exceeds the ${RETRY_AFTER_CEILING_MS}ms this run will wait`,
+        };
+      }
+    } else {
+      lastFailure = describeRejection(outcome.rejection);
+    }
+
+    // No backoff entry for this attempt means it was the last one — the schedule's length IS the
+    // retry budget, so there is no separate bound to keep in step with it.
+    const backoff = RETRY_BACKOFF_MS[attempt];
+    if (backoff !== undefined) await sleep(asked ?? backoff);
+  }
+
+  return { kind: 'unavailable', reason: `${lastFailure} after ${MAX_ATTEMPTS} attempts` };
+}
+
+/**
+ * A run's outcome is its worst check. Drift outranks unavailability because a proven violation
+ * beats an unproven one: a run that reached four endpoints and found a broken shape on the fifth
+ * has found drift, whatever it failed to reach afterwards.
+ */
+export function worstOutcome(outcomes: readonly DriftOutcome[]): DriftOutcome {
+  if (outcomes.includes('drift')) return 'drift';
+  if (outcomes.includes('unavailable')) return 'unavailable';
+  return 'conforms';
+}

--- a/scripts/drift/run-check.sh
+++ b/scripts/drift/run-check.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Runs one tier-2 drift check and translates its exit code into the step output the drift workflow
+# routes on (change: drift-signal-fidelity). One place, so the three checks cannot disagree about
+# what a code means:
+#
+#   0 → conforms      the provider answered and the consumed surface still holds
+#   1 → drift         the consumed surface changed — or the checker itself is broken (issue #110)
+#   2 → unavailable   the provider could not be reached, so nothing was confirmed OR refuted
+#
+# Anything other than 0 or 2 is `drift`, deliberately: an unhandled crash exits 1, and a checker
+# that fell over belongs in the loud channel rather than being mistaken for a quiet outage.
+#
+# Usage: run-check.sh <target-name> <log-file> <command...>
+set -uo pipefail
+
+target="$1"
+log="$2"
+shift 2
+
+"$@" 2>&1 | tee "$log"
+# PIPESTATUS, not $?: with `tee` on the right of the pipe, $? is tee's status. pipefail would give
+# the rightmost failure, which is close enough for a boolean and useless for a three-way code.
+code="${PIPESTATUS[0]}"
+
+case "$code" in
+  0) status=conforms ;;
+  2) status=unavailable ;;
+  *) status=drift ;;
+esac
+
+echo "status=${status}" >>"$GITHUB_OUTPUT"
+echo "${target}: ${status} (exit ${code})"
+
+# Always 0: this wrapper reports, it does not judge. Whether the run goes red is decided once, by
+# the workflow's own step, from the collected statuses — so a red run always has an issue behind it.
+exit 0


### PR DESCRIPTION
Fixes #184.

## The triage

**Nothing drifted.** Replaying the exact recorded request set against live `musicbrainz.org` shows all seven fixtures conforming, including the two #184 named:

```
✓ recording-lookup.json (/recording/6fd45825-5e07-48b7-801c-433c48d3262e)
✓ release-group-no-official-browse.json (/release)
… 7/7
✓ live MusicBrainz responses conform to the contract
```

The two `HTTP 503`s were MusicBrainz's per-IP rate limit hitting a GitHub-hosted runner, whose egress IP is shared with every other Actions customer. No schema is edited and no fixture is re-recorded by this PR, because there is nothing to edit.

## The actual defect

The job has filed **two issues in its life and both were false positives** — #110 was a broken invocation (`ERR_MODULE_NOT_FOUND`, no live response ever fetched), #184 was reachability. A detector whose entire alert history is noise is one nobody reads when a real dropped field finally arrives.

The cause is that the job conflates two facts — *the provider's shape changed* and *we could not reach the provider* — and reports both as drift, with the same red run and the same tracking issue.

## What changes

Each check reports one of three outcomes, carried by exit code:

| Exit | Outcome | The workflow does |
| --- | --- | --- |
| `0` | `conforms` | green |
| `1` | `drift` | **red**, opens or refreshes the tracking issue |
| `2` | `unavailable` | green, with a `::warning::` and a job-summary row |

**Unreachable is not the same as gone.** A transient status (`408 425 429 500 502 503 504`) or a transport fault is `unavailable`. A `404`/`410` on a request whose fixture recorded a `200` is **drift** — the operation was removed. A `401`/`403` on an anonymous request is drift too — the consumed surface grew an auth requirement. Those are the cases a quiet outcome could have masked, and they stay loud.

- **`scripts/drift/probe.ts`** (new) holds the classification and retry once — exponential backoff, `Retry-After` honoured in both spellings up to a ceiling above which giving up *is* the honest report. Unit-tested in the existing tooling tier with an injected clock, so no test sleeps.
- **slskd already drew this line** by exit code (`2` = "environment fault, not real drift") and the workflow discarded it. Its self-check failure — the manifest contradicting its own committed snapshot — moves to the *loud* channel, where a broken checker belongs. Its readiness wait no longer fails the job: a container that never came up is an unavailable slskd, and reddening the run there skips the very steps that would have said so.
- **plex.tv had the same latent bug** from the other end — it labelled any non-2xx `DRIFT`, so a 502 would have filed the same false issue.
- **The MusicBrainz User-Agent now points at a repository that exists** (`anthropics/…` → `jgchk/…`). MusicBrainz asks anonymous clients to identify themselves contactably and enforces it with throttling; a dead URL is a reason to be throttled, and this job is what suffers for it.

**A green run now means "no drift found", not "every provider was reached"** — the job summary says which, and this is stated in the workflow header and the tier README so the next reader of a green Actions history is not misled.

## Verification

Each path exercised against real providers and local stand-ins:

| Case | Result |
| --- | --- |
| MusicBrainz, live | `conforms`, exit `0` |
| MusicBrainz, server answering 503 | 7× `not verified`, exit `2`, no drift section |
| MusicBrainz, server answering 404 | 7× drift, exit `1` |
| plex.tv, live | `conforms`, exit `0` |
| plex.tv, 502 / 403 | `UNAVAILABLE` exit `2` / `DRIFT` exit `1` |
| slskd, live `slskd/slskd:latest` container | `conforms`, exit `0` |
| slskd, dead `SLSKD_SPEC_URL` | `unavailable`, exit `2` |
| `run-check.sh` exit `0`/`1`/`2`/`7` | `conforms`/`drift`/`unavailable`/`drift` |

The last row matters: an unhandled crash exits `1`, so a broken checker stays loud rather than passing for a quiet outage.

`pnpm check` green. `openspec validate drift-signal-fidelity` passes.

**`chore`, not `fix`, deliberately** — this touches only tier-2 tooling, CI and specs. No `packages/*/src` change, so the built image is byte-identical and demanding a release would be noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
