### PR TITLE
chore(deps): move the beets pin to 2.13.1

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -178,8 +178,15 @@ jobs:
 
           # A path that is in scope by package but was dropped by the character class is a case
           # nobody intended; fail rather than silently mutate less than the diff.
+          #
+          # "In scope" means TypeScript, so the pre-filter says so: the character class is the only
+          # thing a path is compared against here, and it accepts nothing but `.ts`. Selecting on
+          # `src/` alone swept in files that were never candidates — the Python bridge and its
+          # `requirements.txt` live under `packages/importer/src/` and are audited by
+          # `pnpm test:bridge` — so touching either failed this job for a scope violation it had
+          # not committed, with nothing to mutate either way.
           REJECTED="$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD \
-            | match -E '^packages/(downloader|eventing|importer)/src/' \
+            | match -E '^packages/(downloader|eventing|importer)/src/.*\.ts$' \
             | match -vE '(\.test\.ts$|/__fixtures__/)' \
             | match -vE '^packages/(downloader|eventing|importer)/src/[A-Za-z0-9._/-]+\.ts$')"
           if [ -n "$REJECTED" ]; then

--- a/packages/importer/src/adapters/beets/bridge/requirements.txt
+++ b/packages/importer/src/adapters/beets/bridge/requirements.txt
@@ -4,5 +4,5 @@
 # skipped re-measure breaks main, not the PR), and re-run the gate.
 # The extras cover the production plugin chain's Python dependencies (binaries — ffmpeg, fpcalc,
 # oggz-tools, opus-tools — are baked into the runtime image by the Dockerfile).
-beets[fetchart,embedart,chroma,discogs,lastgenre,lyrics,scrub]==2.12.0
+beets[fetchart,embedart,chroma,discogs,lastgenre,lyrics,scrub]==2.13.1
 requests>=2.32.5

--- a/packages/importer/test/contract/fixtures/beets-bridge/apply-applied-with-failures.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/apply-applied-with-failures.json
@@ -7,12 +7,12 @@
         "stage": "import-pipeline"
       }
     ],
-    "location": "/tmp/tmp.O9luAHKFGr/library/Twin Alpha zz1/Alpha Sessions zz1",
+    "location": "/tmp/tmp.rrdeP9exsY/library/Twin Alpha zz1/Alpha Sessions zz1",
     "status": "applied"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/apply-applied.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/apply-applied.json
@@ -2,12 +2,12 @@
   "name": "apply-applied",
   "output": {
     "failures": [],
-    "location": "/tmp/tmp.5AUSmTvULo/library/The Beatles/Love Me Do",
+    "location": "/tmp/tmp.rrdeP9exsY/library/The Beatles/Love Me Do",
     "status": "applied"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/apply-as-is-applied.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/apply-as-is-applied.json
@@ -2,12 +2,12 @@
   "name": "apply-as-is-applied",
   "output": {
     "failures": [],
-    "location": "/tmp/tmp.5AUSmTvULo/library/The Beatles/Love Me Do",
+    "location": "/tmp/tmp.rrdeP9exsY/library/The Beatles/Love Me Do",
     "status": "applied"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/apply-doomed-bad-ref.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/apply-doomed-bad-ref.json
@@ -6,8 +6,8 @@
     "status": "doomed"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/apply-doomed-candidate-not-found.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/apply-doomed-candidate-not-found.json
@@ -6,8 +6,8 @@
     "status": "doomed"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/apply-skipped-duplicate.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/apply-skipped-duplicate.json
@@ -5,14 +5,14 @@
       {
         "album": "Love Me Do",
         "artist": "The Beatles",
-        "path": "/tmp/tmp.5AUSmTvULo/library/The Beatles/Love Me Do"
+        "path": "/tmp/tmp.rrdeP9exsY/library/The Beatles/Love Me Do"
       }
     ],
     "status": "skipped-duplicate"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/propose-diff-detail.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/propose-diff-detail.json
@@ -18,7 +18,7 @@
         "distance": 0.07327586206896551,
         "extra_items": [
           {
-            "path": "/tmp/tmp.5AUSmTvULo/intake/diff/99 Bonus Beatz.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/diff/99 Bonus Beatz.mp3",
             "title": "Bonus Beatz",
             "track": 9
           }
@@ -44,7 +44,7 @@
             },
             "distance": 0.125,
             "index": 1,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/diff/01 Luv Me Do.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/diff/01 Luv Me Do.mp3",
             "title": "Love Me Do"
           },
           {
@@ -56,7 +56,7 @@
             },
             "distance": 0.0,
             "index": 2,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/diff/02 P.S. I Love You.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/diff/02 P.S. I Love You.mp3",
             "title": "P.S. I Love You"
           }
         ]
@@ -66,8 +66,8 @@
     "status": "proposal"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/propose-doomed-missing-directory.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/propose-doomed-missing-directory.json
@@ -2,12 +2,12 @@
   "name": "propose-doomed-missing-directory",
   "output": {
     "kind": "directory-not-found",
-    "reason": "not a directory: /tmp/tmp.5AUSmTvULo/never-existed",
+    "reason": "not a directory: /tmp/tmp.rrdeP9exsY/never-existed",
     "status": "doomed"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/propose-doomed-no-audio.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/propose-doomed-no-audio.json
@@ -2,12 +2,12 @@
   "name": "propose-doomed-no-audio",
   "output": {
     "kind": "no-audio-files",
-    "reason": "no readable audio files under: /tmp/tmp.5AUSmTvULo/intake/empty",
+    "reason": "no readable audio files under: /tmp/tmp.rrdeP9exsY/intake/empty",
     "status": "doomed"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/propose-free-search-weak.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/propose-free-search-weak.json
@@ -59,7 +59,7 @@
             },
             "distance": 0.7777777777777777,
             "index": 1,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/mystery/01 Jam One.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/mystery/01 Jam One.mp3",
             "title": "They Know Me Very Well"
           },
           {
@@ -71,7 +71,7 @@
             },
             "distance": 0.8333333333333334,
             "index": 2,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/mystery/02 Jam Two.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/mystery/02 Jam Two.mp3",
             "title": "Drunk"
           }
         ]
@@ -137,7 +137,7 @@
             },
             "distance": 0.4166666666666667,
             "index": 1,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/mystery/01 Jam One.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/mystery/01 Jam One.mp3",
             "title": "I Am One"
           },
           {
@@ -149,7 +149,7 @@
             },
             "distance": 0.8333333333333334,
             "index": 2,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/mystery/02 Jam Two.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/mystery/02 Jam Two.mp3",
             "title": "Bury Me"
           }
         ]
@@ -211,7 +211,7 @@
             },
             "distance": 0.7564102564102564,
             "index": 1,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/mystery/01 Jam One.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/mystery/01 Jam One.mp3",
             "title": "Channel Affair"
           },
           {
@@ -223,7 +223,7 @@
             },
             "distance": 0.7797619047619048,
             "index": 2,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/mystery/02 Jam Two.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/mystery/02 Jam Two.mp3",
             "title": "Channel Affair (The Love I Lost Mix)"
           }
         ]
@@ -293,7 +293,7 @@
             },
             "distance": 0.7619047619047619,
             "index": 1,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/mystery/01 Jam One.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/mystery/01 Jam One.mp3",
             "title": "Beach Babe Bogan"
           },
           {
@@ -305,7 +305,7 @@
             },
             "distance": 0.7708333333333334,
             "index": 2,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/mystery/02 Jam Two.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/mystery/02 Jam Two.mp3",
             "title": "I\u2019m in Love"
           }
         ]
@@ -451,7 +451,7 @@
             },
             "distance": 0.7745098039215685,
             "index": 1,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/mystery/01 Jam One.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/mystery/01 Jam One.mp3",
             "title": "Million Dollar Bash"
           },
           {
@@ -463,7 +463,7 @@
             },
             "distance": 0.6041666666666666,
             "index": 18,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/mystery/02 Jam Two.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/mystery/02 Jam Two.mp3",
             "title": "Open the Door Homer"
           }
         ]
@@ -473,8 +473,8 @@
     "status": "proposal"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/propose-missing-track.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/propose-missing-track.json
@@ -39,7 +39,7 @@
             },
             "distance": 0.0,
             "index": 1,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/missing/01 Love Me Do.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/missing/01 Love Me Do.mp3",
             "title": "Love Me Do"
           }
         ]
@@ -49,8 +49,8 @@
     "status": "proposal"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/propose-pinned-strong.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/propose-pinned-strong.json
@@ -29,7 +29,7 @@
             },
             "distance": 0.0,
             "index": 1,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/love-me-do/01 Love Me Do.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/love-me-do/01 Love Me Do.mp3",
             "title": "Love Me Do"
           },
           {
@@ -41,7 +41,7 @@
             },
             "distance": 0.0,
             "index": 2,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/love-me-do/02 P.S. I Love You.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/love-me-do/02 P.S. I Love You.mp3",
             "title": "P.S. I Love You"
           }
         ]
@@ -51,8 +51,8 @@
     "status": "proposal"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/propose-weak-durations.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/propose-weak-durations.json
@@ -34,7 +34,7 @@
             },
             "distance": 0.3333333333333333,
             "index": 1,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/weak/01 Love Me Do.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/weak/01 Love Me Do.mp3",
             "title": "Love Me Do"
           },
           {
@@ -46,7 +46,7 @@
             },
             "distance": 0.0,
             "index": 2,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/weak/02 P.S. I Love You.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/weak/02 P.S. I Love You.mp3",
             "title": "P.S. I Love You"
           }
         ]
@@ -56,8 +56,8 @@
     "status": "proposal"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/propose-with-incumbent.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/propose-with-incumbent.json
@@ -29,7 +29,7 @@
             },
             "distance": 0.0,
             "index": 1,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/love-me-do/01 Love Me Do.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/love-me-do/01 Love Me Do.mp3",
             "title": "Love Me Do"
           },
           {
@@ -41,7 +41,7 @@
             },
             "distance": 0.0,
             "index": 2,
-            "path": "/tmp/tmp.5AUSmTvULo/intake/love-me-do/02 P.S. I Love You.mp3",
+            "path": "/tmp/tmp.rrdeP9exsY/intake/love-me-do/02 P.S. I Love You.mp3",
             "title": "P.S. I Love You"
           }
         ]
@@ -51,14 +51,14 @@
       {
         "album": "Love Me Do",
         "artist": "The Beatles",
-        "path": "/tmp/tmp.5AUSmTvULo/library/The Beatles/Love Me Do"
+        "path": "/tmp/tmp.rrdeP9exsY/library/The Beatles/Love Me Do"
       }
     ],
     "status": "proposal"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/validate-invalid-directory.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/validate-invalid-directory.json
@@ -2,12 +2,12 @@
   "name": "validate-invalid-directory",
   "output": {
     "kind": "library-directory-missing",
-    "reason": "not a directory: /tmp/tmp.5AUSmTvULo/nonexistent",
+    "reason": "not a directory: /tmp/tmp.rrdeP9exsY/nonexistent",
     "status": "invalid"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/packages/importer/test/contract/fixtures/beets-bridge/validate-valid.json
+++ b/packages/importer/test/contract/fixtures/beets-bridge/validate-valid.json
@@ -1,9 +1,9 @@
 {
   "name": "validate-valid",
   "output": {
-    "beets_version": "2.12.0",
-    "library_database": "/tmp/tmp.5AUSmTvULo/beets/library.db",
-    "library_directory": "/tmp/tmp.5AUSmTvULo/library",
+    "beets_version": "2.13.1",
+    "library_database": "/tmp/tmp.rrdeP9exsY/beets/library.db",
+    "library_directory": "/tmp/tmp.rrdeP9exsY/library",
     "overlay": {
       "import": {
         "detail": false,
@@ -26,8 +26,8 @@
     "status": "valid"
   },
   "provenance": {
-    "beets": "2.12.0",
-    "capturedAt": "2026-07-23",
+    "beets": "2.13.1",
+    "capturedAt": "2026-08-19",
     "recorder": "test/contract/record-bridge-fixtures.sh",
     "release": "22c9f6a3-0569-4c59-b551-cb4a26b0bc3f"
   },

--- a/test/boundaries/mutation-scope.test.ts
+++ b/test/boundaries/mutation-scope.test.ts
@@ -372,6 +372,41 @@ describe('mutation gate placement', () => {
     expect(pipeline).toContain('__fixtures__');
   });
 
+  it('trips the safe-character tripwire on unsafe TypeScript, and only on TypeScript', () => {
+    // The tripwire exists to catch a path that IS in the mutate scope but whose bytes were dropped
+    // by the narrow character class — a filename carrying shell metacharacters, about to become a
+    // command argument. Its pre-filter, though, selected on `src/` alone, so it also caught files
+    // that were never in scope to begin with: the Python bridge and its `requirements.txt` live
+    // under `packages/importer/src/`, and `bridge.py` is audited by `pnpm test:bridge`, not here.
+    // Touching either failed the whole mutation job with "rejected by the safe-character filter" —
+    // a change with nothing to mutate, reported as a scope violation.
+    //
+    // Evaluated rather than pattern-matched: the greps are read out of the shipped workflow and run
+    // against representative paths, so this fails on the behaviour and not on a rewording.
+    const rejectedBlock = /REJECTED="\$\((.*?)\)"/s.exec(
+      stepNamed('Resolve the changed production files'),
+    )?.[1];
+    expect(rejectedBlock).toBeDefined();
+
+    const filters = (rejectedBlock ?? '')
+      .matchAll(/match (-vE|-E) '([^']+)'/g)
+      .map(([, flag, pattern]) => ({ drop: flag === '-vE', test: new RegExp(pattern ?? '') }))
+      .toArray();
+    // Three greps: select in-scope, drop test code and fixtures, drop everything the class accepts.
+    expect(filters).toHaveLength(3);
+
+    const isRejected = (file: string): boolean =>
+      filters.every(({ drop, test }) => (drop ? !test.test(file) : test.test(file)));
+
+    // The Python tier is not TypeScript, so it is not in scope, so it is not a rejection.
+    expect(isRejected('packages/importer/src/adapters/beets/bridge/requirements.txt')).toBe(false);
+    expect(isRejected('packages/importer/src/adapters/beets/bridge/bridge.py')).toBe(false);
+    // Ordinary production TypeScript passes the class and is likewise no rejection.
+    expect(isRejected('packages/downloader/src/domain/download/state.ts')).toBe(false);
+    // …and the case the tripwire is FOR still bites, or this scenario has argued it away.
+    expect(isRejected('packages/downloader/src/domain/oops; rm -rf ~.ts')).toBe(true);
+  });
+
   it('carries the changed-line verdict in a step of its own', () => {
     // Without this, deleting the whole gate — the step that decides — leaves the boundary tier
     // green. The existing scenarios pin the mutation RUN; the run is now advisory by construction

--- a/test/e2e/fixtures/README.md
+++ b/test/e2e/fixtures/README.md
@@ -11,7 +11,7 @@ review-queued assertion fails loudly when this calibration drifts; that failure 
 | `track.flac`             | clean match (auto-apply)         | identical                                           | 0.0000            |
 | `track-review-band.flac` | review-band match (human review) | album `Basement Sessions`, title `Track One (Live)` | 0.3028            |
 
-Calibration provenance: **beets 2.12.0** (the image's `requirements.txt` pin), measured through
+Calibration provenance: **beets 2.13.1** (the image's `requirements.txt` pin), measured through
 the production bridge's `propose` verb with the hint pinned to the stub release, exactly as the
 importer invokes it. The harness runs `AUTO_APPLY_THRESHOLD=0.15`; the review band is
 `distance > 0.15` (a hinted candidate is returned at any distance, so tag deviation cannot


### PR DESCRIPTION
Supersedes #126, which was red because the contract fixtures assert the beets version they were recorded against. Upgrading the pin is a deliberate event — `requirements.txt` names both obligations, and both were done rather than skipped.

Two commits: the pin bump, and a CI fix the bump surfaced.

## Contract fixtures — re-recorded

All 17 `beets-bridge` fixtures re-recorded via `packages/importer/test/contract/record-bridge-fixtures.sh` against beets 2.13.1.

Every candidate distance, penalty, track mapping and outcome is **byte-identical** to the 2.12.0 recording — 2.13.1 scores these fixtures exactly the same. The only semantic change is the provenance version; the rest of the diff is the recorder tmpdir path.

## E2E review-band calibration — re-measured, not assumed

`test/e2e/fixtures/README.md` calls these numbers "measured, not estimated", and the assertion guarding them runs **only on main** — so a skipped re-measure breaks main, not this PR. Re-measured through the production bridge's `propose` verb against the WireMock MusicBrainz stub, exactly as the importer invokes it:

| fixture | before (2.12.0) | after (2.13.1) |
|---|---|---|
| `track.flac` | 0.0000 | **0.0000** |
| `track-review-band.flac` | 0.3028 | **0.3028** (penalties: album 0.2917, tracks 0.0111) |

The band is unchanged, so `AUTO_APPLY_THRESHOLD=0.15` still puts the review-band fixture comfortably above the edge. No fixture regeneration needed — only the provenance line naming the pin the numbers were measured under.

## `ci(mutation)`: the tripwire this bump tripped

The first CI run failed:

```
In-scope paths rejected by the safe-character filter:
packages/importer/src/adapters/beets/bridge/requirements.txt
```

That is a latent bug, not a fact about this PR — **any** change to the Python bridge (`bridge.py` included) would have hit it.

The tripwire is right to exist: it catches a path that *is* in the mutate scope but whose bytes the narrow character class dropped — a filename carrying shell metacharacters, about to become a command argument. Its pre-filter was just wider than the thing it guards. It selected on `src/` alone, while the class it compares against accepts nothing but `.ts`, so the Python bridge — which lives under `packages/importer/src/` and is audited by `pnpm test:bridge` — read as in-scope-but-rejected. A change with nothing to mutate, failed for a violation it had not committed.

Anchoring the pre-filter to `.ts` leaves the tripwire's real case biting and the mutate scope byte-identical (verified under real `grep` semantics, not just in the test).

Written test-first. The new boundaries scenario reads the greps out of the shipped workflow and **runs** them against representative paths — the Python pair, an ordinary source, and a metacharacter filename — so it fails on behaviour rather than on a rewording, and cannot pass by arguing the tripwire away. It was red against the old pre-filter with exactly the CI failure, green after.

Full `pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)