### PR TITLE
chore(deps): hold TypeScript majors in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,12 @@
       "matchManagers": ["nvm", "dockerfile"],
       "matchDepNames": ["node"],
       "groupName": "node runtime"
+    },
+    {
+      "description": "Hold TypeScript majors. The source is TS7-ready, but the toolchain is not: typescript-eslint pins `typescript <6.1.0` (it hard-throws above, taking lint and the boundaries test with it) and svelte-check declares `^5 || ^6` and crashes at module load. A version bump is therefore the wrong shape — the tested adoption path is tsgo side-by-side (keep typescript@^6, add @typescript/native-preview, point typecheck and svelte-check at tsgo). Lift this once both peers accept TS>=7.",
+      "matchDepNames": ["typescript"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Closes #40 — the typescript v7 PR that has been reopened and left red every cycle.

The reason is stable enough to encode as config rather than re-litigate monthly. The source is TS7-ready; the toolchain is not, and both blockers are still live at the versions on main today:

- **typescript-eslint 8.67.0** declares `typescript: ">=4.8.4 <6.1.0"` and hard-throws above it — taking `lint` and the boundaries test with it.
- **svelte-check 4.7.6** declares `typescript: "^5.0.0 || ^6.0.0"` and crashes at module load.

So this is not a bump that is merely early — it is the **wrong shape**. The tested adoption path is tsgo side-by-side (keep `typescript@^6`, add `@typescript/native-preview`, point `typecheck` and `svelte-check` at tsgo), which no version bump can express; it belongs in a dedicated change if typecheck speed is ever wanted.

The rule carries that rationale and the lift condition — re-enable once both peers accept TS >= 7 — so the next person to see it does not have to rediscover any of this.

Scoped to `typescript` majors only; minors and patches still flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)