### PR TITLE
ci: drop the unused ffmpeg install from the test and mutation jobs

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -34,8 +34,9 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
-      - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      # No ffmpeg install — see the `test` job in pipeline.yml. No test in the mutated tiers spawns
+      # a real audio binary; the audio-probe adapter is driven through a fake `CommandRunner`, and
+      # its mutants die there.
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -63,15 +63,23 @@ jobs:
 
   # Test pyramid — every workspace package in one merged 100% coverage run (node + SSR + Chromium
   # browser-mode projects), plus the frozen-fixture contract tiers (incl. the cross-module seam
-  # fixtures) and the repo-tooling unit tests. ffmpeg is a real dependency of the audio-probe
-  # adapter tests; Chromium is the browser-mode runner for the web client project.
+  # fixtures) and the repo-tooling unit tests. Chromium is the browser-mode runner for the web
+  # client project.
+  #
+  # NO ffmpeg HERE, deliberately. Nothing in this job spawns a real audio binary: the audio-probe
+  # adapter's tests inject a fake `CommandRunner`, `runner.test.ts` exercises the spawn wiring
+  # against `process.execPath`, and the ffprobe contract tier REPLAYS recorded stdout through that
+  # same fake. The only code that touches a real binary is the recorder
+  # (packages/downloader/test/contract/record/ffprobe.ts), which is a developer-run script, and the
+  # e2e tier, which runs inside the image where ffmpeg is installed (Dockerfile). Verified by
+  # running all four tiers with ffmpeg/ffprobe shimmed to `exit 127`: 3300+ tests green, zero
+  # invocations. The step it replaces was not merely idle — `apt-get update` intermittently wedges
+  # on the Ubuntu mirrors, and has been measured at 11m08s here against a 20-35s norm.
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15 # observed ~100s; Chromium + apt installs dominate on a cold cache
+    timeout-minutes: 15 # observed ~100s; Chromium install dominates on a cold cache
     steps:
       - uses: actions/checkout@v7
-      - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
@@ -135,10 +143,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # the merge-base diff needs real history
-      # The audio-probe adapter's tests shell out to a real ffmpeg, and they are the tests that kill
-      # that adapter's mutants — without it those mutants read as survivors.
-      - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      # No ffmpeg install — see the `test` job. This job drives the same vitest tiers through
+      # Stryker, so it inherits the same answer: no test spawns a real audio binary, and the
+      # audio-probe mutants are killed by the fake-runner tests. Removing it also protects the
+      # timeout budget below, which an apt stall has eaten 12m45s of.
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
The `test` and `mutation` jobs each ran `apt-get update && apt-get install -y ffmpeg` before doing any work. On [run 32249959725](https://github.com/jgchk/music-downloader/actions/runs/32249959725) that step took **11m08s** (`test`) and **12m45s** (`mutation`), against a **20–35s** norm measured on three sibling runs from the same ten minutes. `apt-get update` intermittently wedges on the Ubuntu mirrors, so this is not a cost that can be tuned down reliably.

It was also buying nothing.

## The step was dead weight

Nothing in either job spawns a real audio binary:

- the audio-probe adapter tests inject a fake `CommandRunner`;
- `runner.test.ts` exercises the spawn wiring against `process.execPath`, not ffmpeg;
- the ffprobe contract tier **replays recorded stdout** through that same fake.

The only code that touches a real binary is `packages/downloader/test/contract/record/ffprobe.ts` — a developer-run recorder script — and the e2e tier, which runs inside the image where ffmpeg is installed (`Dockerfile`).

## Verified, not reasoned

All four tiers of the `test` job were run with `ffmpeg`/`ffprobe` shimmed on `PATH` to log every call and `exit 127`:

| Tier | Result | ffmpeg calls |
|---|---|---|
| `test:cov` | 185 files, 2813 tests, 100% merged coverage | 0 |
| `test:contract` | 20 files green | 0 |
| `test:tooling` | 15 files green | 0 |
| `test:bridge` | 100% (`bridge.py`) | 0 |

Zero invocations logged. The `mutation` jobs drive the same vitest tiers through Stryker and inherit the answer.

## Why the comments changed too

The comments justifying the step claimed the audio-probe tests shell out to a real ffmpeg. They no longer did. The replacements record what was measured, so the step is not reintroduced on the same stale premise.

## The budget this protects

Beyond wall-clock: the PR `mutation` job allows `timeout-minutes: 30`, and the stall ate 12m45s of it. A timeout there is a red required check on a *correct* branch — the exact failure mode that jobs own comment warns will teach an agent loop to treat the mutation gate as the flaky one to ignore.

## Follow-up spotted, not addressed here

The first shimmed `test:cov` reported 99.97% (4597/4598 statements, 1094/1095 functions); two later runs — one shimmed, one not — both reported a clean 100%. There is a nondeterministically-uncovered statement somewhere in the suite. Unrelated to ffmpeg (the shim logged nothing, and it did not reproduce under the same shim), but a flaky 100%-coverage gate carries its own red-check-on-a-correct-branch risk. Not chased in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)