### PR TITLE
chore(deps): take eslint-plugin-unicorn 73, with one rule declined

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -253,6 +253,14 @@ export default tseslint.config(
       // catch-up `drain`/`redrive` pair adjacent. Enforcing a strict accessibility order would
       // scatter those groups across a 500-line class, so the rule is off — grouping is the convention.
       'unicorn/consistent-class-member-order': 'off',
+      // The one-line doc comment (`/** What this is. */`) is this codebase's house form, used ~780
+      // times: a short "what it is" sits on one line, and only a comment with something more to say
+      // — a rationale, a list, a worked example — earns the three-line block. unicorn 73's new rule
+      // inverts that, expanding every one-liner to three lines. Adopting it would triple the
+      // vertical cost of the cheapest documentation we write, which is exactly the documentation we
+      // most want people to keep writing. Off — the multi-line block stays reserved for prose that
+      // needs it.
+      'unicorn/single-line-block-comment-style': 'off',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-sonarjs": "^4.2.0",
     "eslint-plugin-svelte": "^3.22.0",
-    "eslint-plugin-unicorn": "^72.0.0",
+    "eslint-plugin-unicorn": "^73.0.0",
     "prettier": "^3.4.2",
     "prettier-plugin-svelte": "^4.1.1",
     "tsx": "^4.19.2",

--- a/packages/importer/src/composition/runtime.ts
+++ b/packages/importer/src/composition/runtime.ts
@@ -124,7 +124,7 @@ function isDirectoryAbsent(error: unknown): boolean {
   return code === 'ENOENT' || code === 'ENOTDIR';
 }
 
-async function realDirectoryExists(directory: string): Promise<boolean> {
+async function isRealDirectory(directory: string): Promise<boolean> {
   try {
     const statResult = await stat(directory);
     return statResult.isDirectory();
@@ -274,7 +274,7 @@ export async function createImporterRuntime(
         handler: intakeEventConsumer(dependencies, {
           sourceRoot: options.sourceRoot,
           intakeRoot: config.intakeRoot,
-          directoryExists: overrides.directoryExists ?? realDirectoryExists,
+          directoryExists: overrides.directoryExists ?? isRealDirectory,
           warn: logger.warn.bind(logger),
         }),
         logger,

--- a/packages/web/src/lib/server/runtime.test.ts
+++ b/packages/web/src/lib/server/runtime.test.ts
@@ -302,7 +302,7 @@ describe('bootRuntimes', () => {
   });
 
   it('a defect thrown inside shutdown itself is logged, never an unhandled rejection', async () => {
-    // stopSettled absorbs runtime-stop failures, but shutdown still calls the seam
+    // didStopsSettle absorbs runtime-stop failures, but shutdown still calls the seam
     // subscriptions' sync stop()s directly — a defect thrown there rejects the fire-and-forget
     // shutdown call, which has no awaiting caller. The last-resort catch must observe it.
     const log: string[] = [];

--- a/packages/web/src/lib/server/runtime.ts
+++ b/packages/web/src/lib/server/runtime.ts
@@ -94,7 +94,7 @@ export interface BootOverrides {
  * and one runtime's failed stop must never skip the other's (its pollers would keep the event
  * loop alive until SIGKILL). Returns whether every stop settled cleanly.
  */
-async function stopSettled(
+async function didStopsSettle(
   logger: Logger,
   message: string,
   stops: readonly Promise<void>[],
@@ -153,7 +153,7 @@ async function boot(
   );
   if (importerResult.isErr()) {
     // Settled, never bare-awaited: a failing downloader stop must not mask the startup error.
-    await stopSettled(logger, 'runtime stop failed during boot teardown', [downloader.stop()]);
+    await didStopsSettle(logger, 'runtime stop failed during boot teardown', [downloader.stop()]);
     throw new Error(`importer startup failed: ${importerResult.error.detail}`);
   }
   const importer: ImporterRuntime = importerResult.value;
@@ -170,10 +170,10 @@ async function boot(
   } catch (error) {
     // A subscription whose start throws must not strand two booted runtimes with live pollers
     // behind a rejected boot: stop everything already started, then surface the ORIGINAL fatal —
-    // cleanup rejections are logged by stopSettled, never thrown over it. The subscription stops
+    // cleanup rejections are logged by didStopsSettle, never thrown over it. The subscription stops
     // settle alongside the runtime stops: each runtime already awaits its own subscription before
     // closing its store, so these are the prompt detach, not the ordering guarantee.
-    await stopSettled(logger, 'runtime stop failed during boot teardown', [
+    await didStopsSettle(logger, 'runtime stop failed during boot teardown', [
       acquisitions.stop(),
       verdicts.stop(),
       downloader.stop(),
@@ -183,7 +183,7 @@ async function boot(
   }
 
   const shutdown = async (): Promise<void> => {
-    const isClean = await stopSettled(logger, 'runtime stop failed during shutdown', [
+    const isClean = await didStopsSettle(logger, 'runtime stop failed during shutdown', [
       acquisitions.stop(),
       verdicts.stop(),
       downloader.stop(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^3.22.0
         version: 3.23.0(eslint@10.8.1(supports-color@7.2.0))(svelte@5.56.9(@typescript-eslint/types@8.67.0))
       eslint-plugin-unicorn:
-        specifier: ^72.0.0
-        version: 72.0.0(eslint@10.8.1(supports-color@7.2.0))
+        specifier: ^73.0.0
+        version: 73.0.0(eslint@10.8.1(supports-color@7.2.0))
       prettier:
         specifier: ^3.4.2
         version: 3.9.6
@@ -1831,8 +1831,8 @@ packages:
       svelte:
         optional: true
 
-  eslint-plugin-unicorn@72.0.0:
-    resolution: {integrity: sha512-hqO6ksoOHO+ZhdseTuKRVQbx9U7PRO/cv8qAR1mctwzdVO2hYud8uS9luAhp43RJgziYgHAph8eHyipT8GL0ng==}
+  eslint-plugin-unicorn@73.0.0:
+    resolution: {integrity: sha512-V0YatLe9nkGhXEXKe2Qljb1EY0sJHwDV0HUF1NKFwtsHh/fU7qGHDgv+6fchzZcgU2/7noHo2gdjnmo0P2uDPw==}
     engines: {node: '>=22'}
     peerDependencies:
       eslint: '>=10.4'
@@ -5002,7 +5002,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  eslint-plugin-unicorn@72.0.0(eslint@10.8.1(supports-color@7.2.0)):
+  eslint-plugin-unicorn@73.0.0(eslint@10.8.1(supports-color@7.2.0)):
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1(supports-color@7.2.0))
       '@eslint/css-tree': 4.0.5

--- a/scripts/mutation/report-model.ts
+++ b/scripts/mutation/report-model.ts
@@ -47,7 +47,7 @@ export interface MutationReport {
  * exactly what would happen otherwise: the fixtures are built from *our* type, so they could never
  * notice the vendor moving.
  */
-export type VendorReportStaysAssignable = schema.MutationTestResult extends MutationReport
+export type IsVendorReportAssignable = schema.MutationTestResult extends MutationReport
   ? true
   : never;
 
@@ -57,8 +57,8 @@ export type VendorReportStaysAssignable = schema.MutationTestResult extends Muta
  * exactly nothing and the comment above it would be a promise the compiler never made. Assigning
  * `true` to it is what turns vendor drift into the build break this file claims.
  */
-const VENDOR_REPORT_STAYS_ASSIGNABLE: VendorReportStaysAssignable = true;
-void VENDOR_REPORT_STAYS_ASSIGNABLE;
+const IS_VENDOR_REPORT_ASSIGNABLE: IsVendorReportAssignable = true;
+void IS_VENDOR_REPORT_ASSIGNABLE;
 
 /**
  * `status` stays an open `string` on the interface — a tolerant reader must not fail to *parse* a

--- a/test/e2e/full-loop.e2e.test.ts
+++ b/test/e2e/full-loop.e2e.test.ts
@@ -15,7 +15,7 @@ import {
   eventTypes,
   pollForEvent,
   pollUntilTerminal,
-  reviewQueueEmpty,
+  isReviewQueueEmpty,
   seedStagedFixture,
   submitAcquisition,
   waitForOk,
@@ -92,7 +92,7 @@ describe('out-of-process full loop (web interface, real socket)', () => {
 
     // Terminal outcome observable over the interface: the acquisition reports Fulfilled and the
     // review queue's explicit empty marker proves nothing waits on a human.
-    expect(await reviewQueueEmpty()).toBe(true);
+    expect(await isReviewQueueEmpty()).toBe(true);
 
     // The stores are durable files, not :memory: — both modules' events are on disk, and the
     // whole flow recorded exactly one import for the one acquisition.

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -216,7 +216,7 @@ export const DELIVERED_NARRATION: ReadonlySet<string> = new Set([
 ]);
 
 /** True when the review queue page shows its explicit empty marker. */
-export async function reviewQueueEmpty(): Promise<boolean> {
+export async function isReviewQueueEmpty(): Promise<boolean> {
   const res = await fetch(`${BASE_URL}/reviews`, {
     signal: AbortSignal.timeout(3000),
     headers: { Cookie: sessionCookieHeader() },

--- a/test/e2e/nonblocking.e2e.test.ts
+++ b/test/e2e/nonblocking.e2e.test.ts
@@ -54,10 +54,10 @@ async function cancelDeletesSeen(): Promise<number> {
     ).length;
 }
 
-async function pollUntil(check: () => Promise<boolean>, what: string): Promise<void> {
+async function pollUntil(isSatisfied: () => Promise<boolean>, what: string): Promise<void> {
   const deadline = Date.now() + 30_000;
   for (;;) {
-    if (await check()) return;
+    if (await isSatisfied()) return;
     if (Date.now() >= deadline) throw new Error(`timed out waiting for ${what}`);
     await new Promise((resolve) => setTimeout(resolve, 500));
   }

--- a/test/e2e/restart-mid-download.e2e.test.ts
+++ b/test/e2e/restart-mid-download.e2e.test.ts
@@ -86,10 +86,10 @@ const HOLD_MAPPING = {
   },
 };
 
-async function pollUntil(check: () => Promise<boolean>, what: string): Promise<void> {
+async function pollUntil(isSatisfied: () => Promise<boolean>, what: string): Promise<void> {
   const deadline = Date.now() + 60_000;
   for (;;) {
-    if (await check()) return;
+    if (await isSatisfied()) return;
     if (Date.now() >= deadline) throw new Error(`timed out waiting for ${what}`);
     await new Promise((resolve) => setTimeout(resolve, 500));
   }

--- a/test/e2e/restart.e2e.test.ts
+++ b/test/e2e/restart.e2e.test.ts
@@ -13,7 +13,7 @@ import {
   pollForEvent,
   pollForStatus,
   pollUntilTerminal,
-  reviewQueueEmpty,
+  isReviewQueueEmpty,
   seedStagedFixture,
   submitAcquisition,
   waitForOk,
@@ -69,6 +69,6 @@ describe('restart resilience (durable stores + subscription checkpoint)', () => 
 
     // And the interface still tells the same story after the restart.
     expect(await pollUntilTerminal(acquisitionId)).toBe(IMPORT_VOICE_PHRASE.applied);
-    expect(await reviewQueueEmpty()).toBe(true);
+    expect(await isReviewQueueEmpty()).toBe(true);
   });
 });


### PR DESCRIPTION
Supersedes #210. Kept out of the dependency batches because the config decision, not the version number, is the thing worth reviewing.

The major ships two new rules. They deserve opposite answers, so this gives them opposite answers rather than one blanket one.

## `unicorn/consistent-boolean-name` — 6 hits, fixed rather than silenced

| | | file |
|---|---|---|
| `realDirectoryExists` | `isRealDirectory` | `packages/importer/src/composition/runtime.ts` |
| `stopSettled` | `didStopsSettle` | `packages/web/src/lib/server/runtime.ts` |
| `VENDOR_REPORT_STAYS_ASSIGNABLE` | `IS_VENDOR_REPORT_ASSIGNABLE` | `scripts/mutation/report-model.ts` |
| `reviewQueueEmpty` | `isReviewQueueEmpty` | `test/e2e/helpers.ts` |
| `check` (×2, `pollUntil` param) | `isSatisfied` | `test/e2e/{nonblocking,restart-mid-download}.e2e.test.ts` |

All local or test-tier names — no exported production contract moves. Prose references to the old names were updated with them.

## `unicorn/single-line-block-comment-style` — 783 hits, declined

The one-line doc comment (`/** What this is. */`) is this codebase's house form, used ~780 times: a short "what it is" sits on one line, and only a comment with something more to say — a rationale, a list, a worked example — earns the three-line block. The new rule inverts that, expanding every one-liner to three lines.

That triples the vertical cost of the cheapest documentation we write, which is exactly the documentation we most want people to keep writing, and buys no correctness. So it is off, with the rationale recorded in `eslint.config.js` next to the other unicorn opt-outs (`no-null`, `consistent-class-member-order`, `name-replacements`, …) — same house pattern.

If you would rather adopt it, the fix is `eslint --fix` on 783 of the 789 and a follow-up PR; that is a one-line config flip away and deliberately not bundled here.

Full `pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)