### PR TITLE
chore(mutation): waive equivalent mutants per mutant, and delete the guard that proved redundant

### DIFF
--- a/openspec/changes/mutation-recorded-survivors/design.md
+++ b/openspec/changes/mutation-recorded-survivors/design.md
@@ -1,0 +1,170 @@
+# Design — mutation-recorded-survivors
+
+## Context
+
+Thirty surviving mutants across sixteen files, filed as `mutation-drift` issues #168–#183 by the
+weekly full run of 2026-08-09. Triaging all thirty (fresh full-repo run on `main` at 3.20.1,
+2026-08-19, after the download-language rename moved two of the files) found **zero test gaps**.
+Every survivor is an equivalent mutant, and twenty-seven of them share a line *and* a mutator with a
+killable sibling, which is the whole problem: the waiver the spec offers is granular to a line and a
+mutator, and the finding is granular to a mutant.
+
+The dominant family is one shape, appearing at fourteen of the sites:
+
+```ts
+if (x !== undefined && f(x)) …        // the `x !== undefined` operand forced true
+x === undefined ? undefined : g(x)    // the test forced false, so `g(undefined)` runs
+if (state.phase !== 'P') return NOP;  // forced false, so a field only `P` declares reads undefined
+```
+
+The narrowing operand exists to make the expression *type-check*. Forced to its narrowing value, the
+`undefined` it lets through reaches a call that ignores it, a comparison that is `NaN`-false, or a
+field access that yields `undefined` again — so the program's behavior is unchanged and no test can
+tell. The *other* mutants of the same mutator on the same line are real findings: the whole condition
+forced the other way drops the feature entirely.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- A waiver whose granularity matches the finding's: one mutant, named by mutator and replacement.
+- The waiver is read by the machine, so the drift channel and the PR verdict both act on it.
+- A waiver that has outlived its argument fails loudly.
+- The thirty open survivors resolved on the honest rung — delete first, line-waive second, record last.
+
+**Non-Goals**
+
+- No new Stryker plugin. The ignorer API (`shouldIgnore(path)`, 9.6.1) is node-granular and cannot
+  see the mutator or the replacement, so it cannot express this waiver either — verified against the
+  vendor's `IgnorerBookkeeper`, which resolves one message per *node* and applies it to every mutant
+  generated from that node's subtree.
+- No change to what counts as a survivor. `report-model.ts` keeps the survivorship policy; this
+  change only makes the report it is handed accurate.
+- No suppression of a mutant that any test could kill. Every marker states the proof.
+
+## Decisions
+
+### D1 — The marker is a comment at the site, anchored like Stryker's own
+
+```ts
+// Stryker recorded-survivor <MutatorName> `<replacement>`: <reason>
+```
+
+Alternatives considered and rejected:
+
+- **A checked-in baseline file** (`mutation-survivors.json`, the classic mutation-baseline shape).
+  Rejected: the argument for equivalence is about *this expression*, and a reader of the expression
+  would never see it. It also needs a line number or a content hash to anchor, and both go stale on
+  every edit around the site — which is how a baseline file becomes a list nobody rechecks.
+- **Extending `// Stryker disable next-line`**. Rejected: that directive is the vendor's, parsed by
+  the vendor's `DirectiveBookkeeper`. Overloading its syntax with a meaning Stryker does not
+  implement would make a marker that reads as if Stryker honored it, when in fact Stryker still
+  reports the mutant and only our tooling subtracts it.
+
+Anchoring to the line below the comment is the same rule `disable next-line` uses, and it is what
+makes the marker drift-proof: it moves with the code it argues about, so there is no line number to
+maintain and no hash to invalidate.
+
+### D2 — The replacement text is part of the key, and that is what buys the granularity
+
+`ConditionalExpression` on `if (a !== undefined && b)` generates four mutants; the one that is
+equivalent is identified by its replacement (`true`) and the killable ones by theirs (`false`). The
+marker names both mutator and replacement, so it waives exactly the equivalent one.
+
+Backticks delimit the replacement because replacements contain colons, parentheses, and quotes
+(`"\"\""`, `story === undefined && !isCorrelationId(story)`); a colon-delimited grammar would need
+escaping the moment it met a real replacement. Every replacement waived in this change is a single
+line, and the parser requires that — a multi-line replacement would make the marker unreadable, and
+none exists.
+
+### D3 — A marker waives exactly one mutant
+
+If a line carries two surviving mutants with the same mutator *and* the same replacement — different
+nodes, identical text — it needs two markers. The alternative, "waive all matches", leaves a window
+where a second mutant of the same shape appears later and is silently absorbed by a waiver written
+for the first. Requiring one marker per mutant closes it: the count is asserted, so the second
+survivor surfaces as an under-covered line rather than vanishing.
+
+### D4 — Staleness is a failure, and it is only assertable where the run actually looked
+
+A marker matching no survivor means the waiver has outlived its argument: the code changed, or the
+mutant became killable. That must fail — the property the fourteen prose comments never had is that
+something rechecks them.
+
+But it can only be asserted for files the run **mutated**. A PR-scoped run mutates the changed files
+and nothing else, so every marker elsewhere in the repo would look unmatched. The check is therefore
+scoped to files present in the report, which is exactly right in both deployments: the weekly full
+run sees every file and so rechecks every marker.
+
+### D4a — A run that could not grade the mutant has no opinion on the waiver
+
+Found by running it: the first verification run reported `ranking.ts`'s recorded mutant as `Timeout`
+rather than `Survived`, because a test suite was running on the same machine. `Timeout` is a
+*detected* status — the mutant hung the suite, which is a test noticing — so the waiver correctly did
+not apply. But under D4 as first written, "did not apply" also meant "stale", and the weekly job
+would have gone red over machine load.
+
+So staleness distinguishes two ways a marker can match nothing:
+
+- The mutant is **`Killed`**, or absent from the file entirely — a test now kills what the marker
+  argued no test could, or the code moved out from under it. Stale, and the job fails.
+- The mutant is **`Timeout`, `CompileError`, or `RuntimeError`** — the run could not grade it. The
+  marker is neither applied nor blamed; this run has no opinion.
+
+The distinction matters because the failure it prevents is the same one the whole channel is built
+against: a red weekly job nobody believes is the drift channel going quiet by another route.
+
+### D5 — Reclassify to `Ignored`, do not filter
+
+The waived mutant is rewritten in the report with `status: 'Ignored'` rather than dropped from it.
+`isSurviving` then excludes it, `countMutants` counts it in `ignored`, and `auditGap` can still tell
+"nothing was audited here" from "everything here was clean" — a file whose every mutant is waived
+reads as `all-ignored` and refuses, instead of reading as a clean bill. Filtering the mutants out
+would have quietly converted the second case into the first, which is the failure shaped exactly
+like success that the verdict's design (D4 there) exists to catch.
+
+It also means neither decider changes. `drift.ts` and `verdict.ts` keep their logic; the I/O shells
+(`file-drift.ts`, `pr-verdict.ts`) apply the reclassification when they read the report, which is
+where reading source files belongs.
+
+### D6 — Delete before waiving: the correlation guard
+
+Both contexts' published-event mappings do this:
+
+```ts
+const story = cycleStart?.metadata.correlationId;
+if (story === undefined || !isCorrelationId(story)) return undefined;   // ← 3 survivors
+…
+const checked = block === undefined ? undefined : publishedCorrelationSchema.safeParse(block);  // ← 1
+```
+
+`isCorrelationId` is `CORRELATION_ID_PATTERN.test(value)`, and `publishedCorrelationSchema`'s
+`correlationId` is `z.string().regex(CORRELATION_ID_PATTERN)` — the same regex, imported from the
+same module. The guard cannot reject a story the schema would accept, and the schema's failure path
+already drops the block. So the guard decides nothing, and rung 1 of the coverage ladder applies:
+delete it.
+
+What the guard was *documented* to guarantee — "never fabricated: a cycle whose rows predate the
+capability yields no block at all" — is unchanged, and now has one enforcer instead of two. The
+comment already argued the schema check must stay, so that no rename in `correlationOf` could
+silently detach every trace; making it the sole validator is the same argument carried through.
+Eight equivalent mutants go with the deleted lines, and the four killable siblings that went with
+them were only killable because the redundant lines existed.
+
+### D7 — Line waivers where they are honest
+
+The downloader's fold has three arms that return `state` unchanged. Mutating their `case` label to
+`case ''` makes the event miss every arm and fall to the switch's trailing `return state` — the same
+answer. `StringLiteral` is the only mutator generating a mutant on those lines, so
+`// Stryker disable next-line StringLiteral` waives the equivalent mutant and nothing else. The new
+mechanism is not reached for where the old one is exact.
+
+## Risks
+
+- **A wrong equivalence claim blinds the gate permanently.** Mitigated by requiring the proof in the
+  marker (reviewed like an `any`), by D3's exact count, and by D4's staleness failure — but the
+  claim itself is a human judgement and stays one. This is why the marker is verbose by design: a
+  reason that cannot be written is a mutant that should be killed instead.
+- **The marker becomes the path of least resistance.** A rising recorded-survivor count is the same
+  anti-signal `quality-gates.md` names for suppressions. The count is small and every entry is in
+  one grep; a future change that adds many at once should be read as the rule failing admission.

--- a/openspec/changes/mutation-recorded-survivors/proposal.md
+++ b/openspec/changes/mutation-recorded-survivors/proposal.md
@@ -1,0 +1,83 @@
+# Proposal: mutation-recorded-survivors
+
+## Why
+
+The weekly full-repo mutation run has filed sixteen open `mutation-drift` issues (#168–#183)
+covering thirty surviving mutants. Triaging all thirty found **no test gap**: every one is an
+*equivalent mutant* — a change to production code that no test could ever distinguish, because it
+produces the same observable behavior as the original.
+
+Twenty-seven of them cannot be waived. The spec's site-level form,
+`// Stryker disable next-line <mutator>: <reason>`, is granular to a **line and a mutator**, but the
+equivalence is a property of a **single mutant**. At all twenty-seven sites the equivalent mutant
+shares its line *and its mutator* with a sibling that is genuinely killable, so the only available
+waiver would blind a real check. The repo already discovered this: fourteen sites carry a
+hand-written `RECORDED SURVIVOR, waiver withheld:` comment explaining the equivalence and why the
+waiver was not taken.
+
+That leaves the gate in the shape its own doctrine names as the failure mode. `quality-gates.md`
+asks that a rejected finding be "disabled once, with its reason — visible to everyone", and
+`stryker.config.mjs` states the rule directly: **"a suppression the machine never reads is the one
+that rots."** Fourteen prose comments are exactly that. Meanwhile the drift channel re-files the
+same sixteen issues every Sunday, which is how a tracker channel stops being read — the precise
+outcome the weekly job was designed to avoid.
+
+Neither escape is available. Suppressing at line granularity blinds killable mutants. Reshaping the
+production code to stop generating the equivalent mutant is the appeasement `testing.md` forbids —
+"a lint rule that can only be satisfied by adding an unreachable branch has failed admission, not
+the code."
+
+The missing piece is a waiver whose granularity matches the finding's.
+
+## What Changes
+
+- **A third waiver form: the recorded survivor.** At the site, one comment naming the mutator *and
+  the exact replacement text* it waives:
+
+  ```ts
+  // Stryker recorded-survivor ConditionalExpression `true`: <why no test can distinguish it>
+  ```
+
+  It reads like Stryker's own `disable next-line` and anchors the same way — to the line below it,
+  so it travels with the code and cannot go stale by line drift. Unlike `disable next-line` it
+  names the replacement, so it waives **one mutant** and leaves every sibling on the line observed.
+
+- **The machine reads it.** `scripts/mutation/recorded-survivors.ts` parses the markers out of
+  source and reclassifies the mutants they name from `Survived` to `Ignored` before the report
+  reaches either consumer. The weekly drift channel and the PR verdict then agree, without either
+  decider changing: `isSurviving`, `countMutants`, and `auditGap` already treat `Ignored` correctly.
+
+- **A stale marker is a failure, not a shrug.** A marker that matches no surviving mutant in a file
+  the run actually mutated means the waiver has outlived its argument — the code moved, or the
+  mutant became killable. That fails loudly rather than lingering as a comment nobody rechecks,
+  which is the property the prose comments never had. A marker waives exactly one mutant: if a line
+  carries two matching survivors, it needs two markers.
+
+- **The thirty survivors are resolved**, each by the honest rung rather than by reaching for the new
+  mechanism first:
+  - **Eight deleted as dead code** (rung 1). Both contexts' published-event mappings guard the
+    correlation id with `isCorrelationId(story)` and then validate the same block against
+    `publishedCorrelationSchema`, whose `correlationId` field applies the identical
+    `CORRELATION_ID_PATTERN`. The guard cannot reject anything the schema would accept, so the
+    schema becomes the single validator and the guard — with its four equivalent mutants per
+    context — goes.
+  - **Three waived at line granularity** where that is honest: the `case '<EventType>':` labels of
+    the downloader's three no-op fold arms, where `StringLiteral` has no killable sibling on the
+    line.
+  - **Nineteen recorded** with the new marker, each carrying the argument for its equivalence. The
+    fourteen existing `RECORDED SURVIVOR, waiver withheld` comments are converted in place: the
+    reasoning was already written and reviewed; this change is what lets the machine act on it.
+
+## Capabilities
+
+- `mutation-testing` — the suppression requirement gains its third form and the staleness rule.
+
+## Impact
+
+- `scripts/mutation/` — one new module plus its tests; `file-drift.ts` and `pr-verdict.ts` apply it
+  at their I/O boundary. `drift.ts`, `verdict.ts`, and `report-model.ts` are untouched: they keep
+  deciding over a report, and the report they are handed is now the accurate one.
+- `test/boundaries/mutation-scope.test.ts` — the waiver doctrine's scenario extends to the new form,
+  so an unjustified recorded survivor fails the same way an unjustified `disable` does.
+- Sixteen production files across both context packages: eight lines deleted, twenty-two marker
+  comments added or converted. No behavior changes.

--- a/openspec/changes/mutation-recorded-survivors/specs/mutation-testing/spec.md
+++ b/openspec/changes/mutation-recorded-survivors/specs/mutation-testing/spec.md
@@ -1,0 +1,88 @@
+# mutation-testing — delta for mutation-recorded-survivors
+
+## MODIFIED Requirements
+
+### Requirement: Suppressions are justified arid-line waivers
+
+A mutant MAY be suppressed only with a written justification, in one of three forms:
+
+- **At the site**, `// Stryker disable next-line <mutator>: <reason>`, for an individual arid or
+  provably equivalent mutant whose line carries no other mutant of that mutator worth observing.
+- **At the configuration site**, for a whole *class* of mutant that is arid or unmeasurable on this
+  repository, with its reason recorded in configuration and its tally in the adopting change's
+  design document.
+- **At the site, per mutant**, `` // Stryker recorded-survivor <mutator> `<replacement>`: <reason> ``,
+  for a provably equivalent mutant whose line carries a **killable** sibling of the same mutator.
+  Naming the replacement is what distinguishes the two, so the equivalent mutant is waived and the
+  killable one stays observed.
+
+The second form is the waiver doctrine's stated preference — "A rejected rule is disabled once, in
+configuration, with its reason" — and exists because a class retired by hundreds of identical
+site comments is itself the signal that a rule failed admission. Directory-level exclusion inside
+the covered packages SHALL NOT be used; composition roots are handled by per-site suppression so
+non-arid logic in wiring stays observed.
+
+The third form SHALL be reached for only when the first would blind a killable mutant, and each use
+SHALL state the proof that no test could distinguish the mutant from the original. Review treats an
+unproven one as a defect, exactly as it treats an unjustified `any`.
+
+#### Scenario: A class rejection is argued once, in configuration
+
+- **WHEN** a whole family of mutants is arid or unkillable by any honest test on this repository
+- **THEN** it is rejected at the config site with its reason and its measured tally, not by
+  repeating a suppression comment at every occurrence
+
+#### Scenario: An equivalent mutant is suppressed at its site
+
+- **WHEN** a single mutant is provably equivalent to the original code, and no other mutant of its
+  mutator on that line is worth observing
+- **THEN** it carries an inline suppression stating why no test could distinguish it, and review
+  treats an unjustified one as a defect
+
+#### Scenario: An equivalent mutant shares its line and mutator with a killable one
+
+- **WHEN** a provably equivalent mutant sits on a line where another mutant of the **same** mutator
+  is killed by the suite
+- **THEN** it is waived per mutant, by a marker naming the mutator and the exact replacement, so the
+  killable sibling remains a finding if it ever survives
+- **AND** a line-granular suppression SHALL NOT be used, because it would silence the sibling too
+
+#### Scenario: A per-mutant waiver is read by the tooling, not only by a human
+
+- **WHEN** a mutant carries a recorded-survivor marker
+- **THEN** both the weekly drift channel and the PR verdict treat it as suppressed rather than
+  surviving, so a waiver argued once is not re-filed as a finding every week
+
+#### Scenario: A waiver that has outlived its argument fails
+
+- **WHEN** a recorded-survivor marker names a mutant that the run killed, or that is absent from a
+  file the run actually mutated
+- **THEN** the tooling fails and names the stale marker, so the waiver is re-argued or removed
+  rather than lingering as a comment nothing rechecks
+
+#### Scenario: A run that could not grade the mutant does not condemn the waiver
+
+- **WHEN** the named mutant is reported with a status that reflects the run rather than the suite's
+  assertion strength — timed out, or failing to compile or execute
+- **THEN** the waiver is neither applied nor reported stale, because a run that could not grade the
+  mutant has no evidence either way, and failing on one would redden the channel over machine load
+
+## ADDED Requirements
+
+### Requirement: Equivalent mutants are resolved on the honest rung
+
+A surviving mutant SHALL be resolved by the first applicable rung, in order: killed by a test that
+asserts the behavior; deleted, when the survivor proves the code is redundant with a check that
+already runs; suppressed at line granularity, when that silences nothing killable; recorded per
+mutant, only when the rungs above do not apply.
+
+Production code SHALL NOT be reshaped for the sole purpose of preventing a tool from generating an
+equivalent mutant. A finding that can only be satisfied by contorting the code has failed admission,
+not the code.
+
+#### Scenario: A survivor proves a guard is redundant
+
+- **WHEN** every mutant of a guard survives because a check downstream already rejects everything
+  the guard would have rejected
+- **THEN** the guard is deleted and the downstream check documented as the single validator, rather
+  than the mutants being waived

--- a/openspec/changes/mutation-recorded-survivors/tasks.md
+++ b/openspec/changes/mutation-recorded-survivors/tasks.md
@@ -1,0 +1,49 @@
+# Tasks — mutation-recorded-survivors
+
+Sequencing: the mechanism lands before the sites that use it, so every marker added in §3 is
+already read by the machine when it is written. §2 (deletions) is independent of the mechanism and
+could land first; it is placed after so the whole survivor inventory moves in one reviewable step.
+
+## 1. The mechanism
+
+- [x] 1.1 `scripts/mutation/recorded-survivors.ts`: parse
+      `` // Stryker recorded-survivor <mutator> `<replacement>`: <reason> `` out of a source text,
+      anchored to the next line as `disable next-line` is. Red first: a marker with no reason, a
+      marker whose replacement is unterminated, and a comment that merely mentions the phrase in
+      prose are all NOT markers.
+- [x] 1.2 Reclassify: given a report and a source reader, rewrite each matched mutant's status to
+      `Ignored` (D5), leaving every other mutant untouched. A marker waives exactly one mutant
+      (D3) — two matching survivors on a line need two markers.
+- [x] 1.3 Staleness: a marker matching no survivor, in a file the report contains, is returned as a
+      stale entry. Markers in files the report does not contain are not stale (D4).
+- [x] 1.4 Apply it at both I/O shells — `file-drift.ts` and `pr-verdict.ts` — and exit non-zero with
+      the stale marker named. `drift.ts`, `verdict.ts`, and `report-model.ts` stay untouched.
+- [x] 1.5 `test/boundaries/mutation-scope.test.ts`: every recorded-survivor marker in the repo
+      carries a reason, matching how the tier already holds the `disable` form.
+
+## 2. Delete what the survivors proved redundant (D6)
+
+- [x] 2.1 `packages/downloader/src/interfaces/contracts/events/mapping.ts`: drop the
+      `isCorrelationId` guard and the `block === undefined` branch; `publishedCorrelationSchema`
+      becomes the single validator. Four survivors go with the lines. Existing tests pin the
+      behavior and SHALL keep passing unchanged — that they do is the proof the guard decided
+      nothing.
+- [x] 2.2 The same in `packages/importer/src/interfaces/contracts/events/mapping.ts` (four more).
+
+## 3. Waive the rest on the honest rung
+
+- [x] 3.1 Line waivers where they silence nothing killable (D7): the three no-op fold arms in
+      `packages/downloader/src/domain/download/state.ts` (`StringLiteral` on the `case` labels).
+- [x] 3.2 Convert the fourteen `RECORDED SURVIVOR, waiver withheld` comments to markers, keeping
+      each argument and dropping the now-untrue "waiver withheld" clause.
+- [x] 3.3 Record the remaining survivors that carry no comment yet, with the argument written:
+      `duration.ts`, `importer/domain/import/decide.ts`, and the `metadata === undefined` and
+      `entry.version <=` mutants that survive the §2 deletions.
+
+## 4. Verify
+
+- [ ] 4.1 Fresh full-repo `stryker run` (never `--incremental`, D4a of mutation-gate): every one of
+      the thirty is Killed, Ignored, or gone, and no new survivor appeared.
+- [ ] 4.2 `pnpm tsx scripts/mutation/file-drift.ts` over that report prints `[]`.
+- [ ] 4.3 `pnpm check` green, including the tooling tier at 100%.
+- [ ] 4.4 Close #168–#183 on the merge, each pointing at the resolution its file took.

--- a/packages/downloader/src/adapters/musicbrainz/mapping.ts
+++ b/packages/downloader/src/adapters/musicbrainz/mapping.ts
@@ -369,13 +369,15 @@ function modalTrackCount(counts: readonly (number | undefined)[]): number | unde
   let modal: number | undefined;
   let modalFrequency = 0;
   for (const [count, freq] of frequency) {
-    // RECORDED SURVIVOR, waiver withheld: `count <= modal` is equivalent — `modal` is only ever a
-    // count already taken from this map, and map keys are distinct, so `count === modal` cannot
-    // hold here (the initial `modal = 0` pairs with `modalFrequency = 0`, which every real
-    // frequency (>= 1) beats on the first arm before this arm is consulted). A `disable next-line
-    // EqualityOperator` would silence that mutant AND the four killable siblings this line carries
-    // — `>=`/`<=` on the frequency test, `!==` on the tie test, and `count >= modal`, which
-    // inverts the documented lower-count tie-break. Silencing four real findings to hide one
+    // Stryker recorded-survivor EqualityOperator `count <= (modal ?? 0)`: equivalent — this arm is
+    // only ever reached when `freq === modalFrequency`, which requires `modalFrequency >= 1` and so
+    // requires `modal` to have already been set to a count taken from this very map (on the first
+    // iteration `modalFrequency` is 0, every real `freq` is >= 1, and the first arm short-circuits
+    // before this one is evaluated). Map keys are distinct, so `count === modal` cannot hold here
+    // and `<` and `<=` cannot disagree. Waived per mutant, not per line: a
+    // `disable next-line EqualityOperator` would silence the four killable siblings this line
+    // carries — `>=`/`<=` on the frequency test, `!==` on the tie test, and `count >= (modal ?? 0)`,
+    // which inverts the documented lower-count tie-break. Silencing four real findings to hide one
     // equivalent mutant is the trade the waiver doctrine rejects.
     if (!(freq > modalFrequency || (freq === modalFrequency && count < (modal ?? 0)))) {
       continue;
@@ -447,6 +449,9 @@ export function releaseGroupCandidateIds(
  * medium states one. Absent rather than 0 — see {@link ReleaseGroupEdition.trackCount}.
  */
 function totalTrackCount(release: MbBrowseRelease): number | undefined {
+  // Stryker disable next-line ArrayDeclaration: equivalent — the injected string has no
+  // `track-count`, so it maps to `undefined` and the `typeof count === 'number'` filter drops it,
+  // leaving the same empty `counts` an absent `media` leaves (the absent-collection note above).
   const counts = (release.media ?? [])
     .map((medium) => medium['track-count'])
     .filter((count): count is number => typeof count === 'number');

--- a/packages/downloader/src/adapters/slskd/client.ts
+++ b/packages/downloader/src/adapters/slskd/client.ts
@@ -130,14 +130,15 @@ export class SlskdClient {
         'Content-Type': 'application/json',
         Accept: 'application/json',
       },
-      // RECORDED SURVIVOR, waiver withheld: the `body !== undefined` operand is a *type-level*
-      // guard. Forced true, the spread yields `body: JSON.stringify(undefined)` — the key present
-      // and undefined — which every `HttpClient` reads identically to an absent key (the fetch
-      // adapter destructures `body` and hands undefined to `fetch`, which sends no body). The
-      // conditional exists so the request satisfies `exactOptionalPropertyTypes`, and a compiler
-      // rule is not a behavior a test can observe. It is not waived, because the same mutator
-      // rewrites the whole `&&` to `true`/`false` on this line, and either of those spreads a
-      // boolean — dropping the request body outright, which is a real finding.
+      // Stryker recorded-survivor ConditionalExpression `true`: equivalent — this is the
+      // `body !== undefined` operand, a *type-level* guard. Forced true, the spread yields
+      // `body: JSON.stringify(undefined)` — the key present and undefined — which every
+      // `HttpClient` reads identically to an absent key (the fetch adapter destructures `body` and
+      // hands undefined to `fetch`, which sends no body). The conditional exists so the request
+      // satisfies `exactOptionalPropertyTypes`, and a compiler rule is not a behavior a test can
+      // observe. Waived per mutant, not per line: the same mutator rewrites the whole `&&` to
+      // `true`/`false` here, and either of those spreads a boolean — dropping the request body
+      // outright, which is a real finding.
       ...(body !== undefined && { body: JSON.stringify(body) }),
     });
   }

--- a/packages/downloader/src/adapters/slskd/poll.ts
+++ b/packages/downloader/src/adapters/slskd/poll.ts
@@ -18,13 +18,14 @@ export async function pollOwnedTransfers(
   const payload = slskdTransfersSchema.parse(await client.getOr(downloadsPath(username), {}));
   return flattenDownloads(payload).filter(
     (transfer): transfer is OwnedTransfer =>
-      // RECORDED SURVIVOR, waiver withheld: the `!== undefined` operand is a type-level guard — it
-      // is what narrows `filename` to a string so this predicate can claim `OwnedTransfer` — not a
-      // decision. Forcing it true changes no answer: `wanted` is a `ReadonlySet<string>`, so
-      // `has(undefined)` is false for exactly the transfers the guard already excluded, and the
-      // guard cannot be deleted or the predicate stops typechecking. No waiver, because a
-      // `disable next-line` would also silence the whole predicate forced true (every transfer
-      // owned, ownership narrowing gone) and forced false (no transfer owned) — both real.
+      // Stryker recorded-survivor ConditionalExpression `true`: equivalent — this is the
+      // `!== undefined` operand, a type-level guard: it is what narrows `filename` to a string so
+      // this predicate can claim `OwnedTransfer`, not a decision. Forcing it true changes no
+      // answer, because `wanted` is a `ReadonlySet<string>` and `has(undefined)` is false for
+      // exactly the transfers the guard already excluded — and the guard cannot simply be deleted
+      // or the predicate stops typechecking. Waived per mutant, not per line: a `disable next-line`
+      // would also silence the whole predicate forced true (every transfer owned, ownership
+      // narrowing gone) and forced false (no transfer owned) — both real findings.
       transfer.filename !== undefined && wanted.has(transfer.filename),
   );
 }

--- a/packages/downloader/src/application/projections/read-models.ts
+++ b/packages/downloader/src/application/projections/read-models.ts
@@ -333,13 +333,13 @@ export async function seedStalledReadModel(
     return;
   }
   for (const letter of letters.value) {
-    // RECORDED SURVIVOR, waiver withheld: this guard is the type narrowing
-    // `mark(acquisitionId: string)` needs for an optional `streamId` (a subscription letter carries
-    // none), not a decision. Forcing it true adds `undefined` to a `Set<string>` that is only ever
-    // queried by `isStalled(id: string)`, so no query any caller can make changes its answer. The
-    // guard cannot be deleted: without it the call does not typecheck. Forcing it FALSE marks
-    // nothing stalled at boot, which is a real finding on the same line under the same mutator —
-    // so no waiver.
+    // Stryker recorded-survivor ConditionalExpression `true`: equivalent — this guard is the type
+    // narrowing `mark(acquisitionId: string)` needs for an optional `streamId` (a subscription
+    // letter carries none), not a decision. Forced true it adds `undefined` to a `Set<string>` that
+    // is only ever queried by `isStalled(id: string)`, and no string argument equals `undefined`,
+    // so no query any caller can make changes its answer. The guard cannot be deleted either:
+    // without it the call does not typecheck. Waived per mutant, not per line: forcing it FALSE
+    // marks nothing stalled at boot, a real finding under the same mutator on the same line.
     if (letter.streamId !== undefined) stalled.mark(letter.streamId);
   }
 }

--- a/packages/downloader/src/domain/download/decide.ts
+++ b/packages/downloader/src/domain/download/decide.ts
@@ -318,13 +318,13 @@ export function decide(command: DownloadCommand, state: DownloadState): Decision
       // other phase converges silently: absorbing terminals stay absorbed, a legacy fulfilment has
       // no retained candidate to judge, a mismatched reference is stale, and a redelivery after
       // the revival finds the download already back in flight.
-      // RECORDED SURVIVOR, waiver withheld: forcing this guard false is equivalent. `resume` is
-      // declared on `FulfilledState` alone and no fold path carries it onto another phase, so every
-      // other phase reads `undefined` on the very next line and converges on the same `ok([])` two
-      // lines later. The guard is the narrowing that lets `state.resume` type-check, and the place
-      // to say out loud that Fulfilled is the one revivable phase. Forcing it TRUE is a different
-      // matter — the revival never happens at all — so a `disable next-line` here would trade a
-      // real finding for a cosmetic zero.
+      // Stryker recorded-survivor ConditionalExpression `false`: equivalent — `resume` is declared
+      // on `FulfilledState` alone and no fold path carries it onto another phase, so every other
+      // phase forced past this guard reads `undefined` on the very next line and converges on the
+      // same `ok([])` two lines later. The guard is the narrowing that lets `state.resume`
+      // type-check, and the place to say out loud that Fulfilled is the one revivable phase. Waived
+      // per mutant, not per line: forcing it TRUE is a different matter — the revival never happens
+      // at all — so a `disable next-line` would trade that real finding for a cosmetic zero.
       if (state.phase !== 'Fulfilled') return ok([]);
       const resume = state.resume;
       if (resume === undefined || !isReferringTo(command.candidate, resume.candidate.identity)) {

--- a/packages/downloader/src/domain/download/state.ts
+++ b/packages/downloader/src/domain/download/state.ts
@@ -255,6 +255,11 @@ export function evolve(state: DownloadState, event: DownloadEvent): DownloadStat
       const { started: _started, ...downloading } = state;
       return { ...downloading, phase: 'Validating', downloadedFiles: event.files };
     }
+    // Stryker disable next-line StringLiteral: equivalent — emptying the case label makes this
+    // event match no arm and fall to the switch's trailing `return state`, which is the same
+    // answer this arm gives. `StringLiteral` generates no other mutant on this line, so the waiver
+    // is exact; the arm's own `ConditionalExpression` and `BlockStatement` mutants stay observed
+    // and are killed (deleting the arm falls through to `CandidateRejected`, which does real work).
     case 'TryFailed': {
       return state; // the following CandidateRejected does the state work
     }
@@ -282,13 +287,20 @@ export function evolve(state: DownloadState, event: DownloadEvent): DownloadStat
       if (state.phase !== 'Validating') return state;
       return { ...state, phase: 'Importing' };
     }
-    // Stryker disable next-line ConditionalExpression,BlockStatement: equivalent — deleting or
-    // emptying this arm falls straight through to `Imported`, the next arm, which also returns
-    // `state` unchanged. Two adjacent no-op arms cannot be told apart by any test; they stay
-    // separate because they are separate facts, each with its own reason for changing nothing.
+    // Stryker disable next-line ConditionalExpression,BlockStatement,StringLiteral: equivalent —
+    // deleting or emptying this arm falls straight through to `Imported`, the next arm, which also
+    // returns `state` unchanged, and emptying the case label falls to the switch's trailing
+    // `return state`. All three are the same answer. Two adjacent no-op arms cannot be told apart
+    // by any test; they stay separate because they are separate facts, each with its own reason
+    // for changing nothing.
     case 'ValidationFailed': {
       return state; // the following CandidateRejected does the state work
     }
+    // Stryker disable next-line StringLiteral: equivalent — emptying the case label makes this
+    // event match no arm and fall to the switch's trailing `return state`, the same answer this arm
+    // gives. `StringLiteral` generates no other mutant on this line, so the waiver is exact; the
+    // arm's `ConditionalExpression` and `BlockStatement` mutants stay observed and are killed
+    // (deleting the arm falls through to `DownloadFulfilled`, which does real work).
     case 'Imported': {
       // A state no-op: the co-emitted DownloadFulfilled carries the location; the import itself
       // is observed via `react` (staging cleanup), not folded into state.
@@ -322,15 +334,16 @@ export function evolve(state: DownloadState, event: DownloadEvent): DownloadStat
       // ladder as if its candidate had just failed validation; the co-emitted rejection/selection
       // events then fold through the existing cases. Nothing is staged any more (the files were
       // imported), so the transient Validating state carries no downloaded files.
-      // RECORDED SURVIVOR, waiver withheld: the `state.phase !== 'Fulfilled'` operand is equivalent
-      // when forced false — `resume` is declared on `FulfilledState` alone and no fold path carries
-      // it onto another phase (the revival below builds its `Validating` state field by field,
-      // dropping it), so on every other phase the second operand reads `undefined` and the guard
-      // returns `state` either way. The operand is the narrowing `state.resume` needs, not a
-      // decision. No waiver: this line also carries the whole guard forced true (no revival ever)
-      // and the `state.resume === undefined` operand forced false (a legacy fulfilment revived
-      // without retained context) — both killable, the second by
-      // `ignores FulfillmentRejected on a legacy fulfilment with no retained context`.
+      // Stryker recorded-survivor ConditionalExpression `false`: equivalent — this is the
+      // `state.phase !== 'Fulfilled'` operand, and `resume` is declared on `FulfilledState` alone
+      // with no fold path carrying it onto another phase (the revival below builds its `Validating`
+      // state field by field, dropping it). So on every other phase the second operand reads
+      // `undefined` and the guard returns `state` either way. The operand is the narrowing
+      // `state.resume` needs, not a decision. Waived per mutant, not per line: this line also
+      // carries the whole guard forced true (no revival ever) and the `state.resume === undefined`
+      // operand forced false (a legacy fulfilment revived without retained context) — both
+      // killable, the second by `ignores FulfillmentRejected on a legacy fulfilment with no
+      // retained context`.
       if (state.phase !== 'Fulfilled' || state.resume === undefined) return state;
       const resume = state.resume;
       return {

--- a/packages/downloader/src/domain/policy/policies.ts
+++ b/packages/downloader/src/domain/policy/policies.ts
@@ -58,13 +58,13 @@ export interface RetryPolicyInput {
 export function createRetryPolicy(input: RetryPolicyInput): Result<RetryPolicy, RetryPolicyError> {
   if (input.maxSearchRounds < 1) return err({ kind: 'NonPositiveSearchRounds' });
   if (input.maxTotalAttempts < 1) return err({ kind: 'NonPositiveTotalAttempts' });
-  // RECORDED SURVIVOR, waiver withheld: the `timeBudgetMs !== undefined` operand is equivalent when
-  // forced true — an omitted budget then reaches `undefined <= 0`, which is a NaN comparison and
-  // therefore false, so the conjunction is false either way and the policy is still accepted. The
-  // operand is the narrowing that lets the comparison type-check (the field is `number |
-  // undefined`), not a second decision. It cannot be waived here without also silencing the three
-  // killable `ConditionalExpression` mutants this line carries — the whole condition forced true
-  // (every policy rejected), forced false (the bound gone, which is what the
+  // Stryker recorded-survivor ConditionalExpression `true`: equivalent — this is the
+  // `timeBudgetMs !== undefined` operand, and an omitted budget forced past it reaches
+  // `undefined <= 0`, a NaN comparison and therefore false. The conjunction is false either way and
+  // the policy is still accepted. The operand is the narrowing that lets the comparison type-check
+  // (the field is `number | undefined`), not a second decision. Waived per mutant, not per line:
+  // this line carries three killable `ConditionalExpression` mutants — the whole condition forced
+  // true (every policy rejected), forced false (the bound gone, which is what the
   // `NonPositiveTimeBudget` case catches), and the `<= 0` operand forced true.
   if (input.timeBudgetMs !== undefined && input.timeBudgetMs <= 0) {
     return err({ kind: 'NonPositiveTimeBudget' });

--- a/packages/downloader/src/domain/ranking/ranking.ts
+++ b/packages/downloader/src/domain/ranking/ranking.ts
@@ -37,14 +37,14 @@ export function candidateQualityBucket(candidate: Candidate, policy: QualityPoli
   if (buckets.length === 0) return 'UNKNOWN';
   let worst = buckets[0]!;
   for (const bucket of buckets) {
-    // RECORDED SURVIVOR, waiver withheld: `>=` is equivalent. `bucketRank` is `indexOf`, so two
-    // distinct buckets can only share a rank by both being absent from the policy order, where both
-    // rank Infinity — and every consumer of this verdict (`isFloorMet`, `compareQuality`) compares
-    // ranks alone, so keeping the first or the last of an equal-rank pair is the same answer. When
-    // the ranks do differ, `>` and `>=` cannot disagree. The waiver is withheld because
-    // `EqualityOperator` also generates `<=` here, which returns the release's BEST bucket instead
-    // of its worst — the quality-floor bypass this function exists to prevent — and a
-    // `disable next-line` would silence that finding along with the equivalent one.
+    // Stryker recorded-survivor EqualityOperator `bucketRank(policy, bucket) >= bucketRank(policy, worst)`: equivalent.
+    // `bucketRank` is `indexOf`, so two distinct buckets can only share a rank by both being absent
+    // from the policy order, where both rank Infinity — and every consumer of this verdict
+    // (`isFloorMet`, `compareQuality`) compares ranks alone, so keeping the first or the last of an
+    // equal-rank pair is the same answer. When the ranks do differ, `>` and `>=` cannot disagree.
+    // Waived per mutant, not per line: `EqualityOperator` also generates `<=` here, which returns
+    // the release's BEST bucket instead of its worst — the quality-floor bypass this function
+    // exists to prevent — and a `disable next-line` would silence that finding along with this one.
     if (bucketRank(policy, bucket) > bucketRank(policy, worst)) worst = bucket;
   }
   return worst;

--- a/packages/downloader/src/domain/shared/duration.ts
+++ b/packages/downloader/src/domain/shared/duration.ts
@@ -22,6 +22,14 @@ export function alignmentScore(expected: readonly number[], actual: readonly num
     // An expectation with no counterpart track — the release is short of the target — aligns with
     // nothing. Pairing by position over the sorted lists makes the shorter list the bound.
     const actualMs = sortedActual[index];
+    // Stryker recorded-survivor ConditionalExpression `true`: equivalent — this is the
+    // `actualMs !== undefined` operand, the narrowing that lets a possibly-absent element reach a
+    // `(number, number)` comparison. Forced true, a missing counterpart reaches
+    // `isWithinDurationTolerance(expectedMs, undefined)`, whose `Math.abs(a - undefined)` is `NaN`
+    // and whose `NaN <= tolerance` is false — so the expectation is dropped from `aligned` either
+    // way and the score is identical. Waived per mutant, not per line: the whole conjunction forced
+    // true (every expectation aligns, so a release short of the target scores 1) and forced false
+    // (nothing ever aligns) are both real findings, under this same mutator on this same line.
     return actualMs !== undefined && isWithinDurationTolerance(expectedMs, actualMs);
   });
   return aligned.length / expected.length;

--- a/packages/downloader/src/interfaces/contracts/events/mapping.ts
+++ b/packages/downloader/src/interfaces/contracts/events/mapping.ts
@@ -6,7 +6,7 @@ import type {
   PublishedEventMapping,
   RenderError,
 } from '../../../application/ports/published-events-port.js';
-import { CONTEXT_NAME, isCorrelationId } from '../../../application/correlation/context.js';
+import { CONTEXT_NAME } from '../../../application/correlation/context.js';
 import {
   ACQUISITION_FULFILLED_TYPE,
   acquisitionFulfilledEventSchema,
@@ -14,15 +14,23 @@ import {
 } from './schemas.js';
 
 /**
- * The correlation envelope for a stored event, or `undefined` when the row predates the
- * capability. Never fabricated: an absent story stays absent all the way to the consumer, which
- * mints its own rather than inheriting an invented one.
+ * The candidate correlation envelope for a stored event — proposed, not vouched for. Its one
+ * validator is `publishedCorrelationSchema` at the call site, which drops the block whole when the
+ * story is absent or malformed.
+ *
+ * It does NOT pre-check the story itself. It used to, with `isCorrelationId`, and that guard was
+ * unreachable in the sense that matters: `isCorrelationId` is `CORRELATION_ID_PATTERN.test(value)`
+ * and the schema's `correlationId` is `z.string().regex(CORRELATION_ID_PATTERN)` — the same regex,
+ * from the same module. It could not reject a story the schema would have accepted, so it decided
+ * nothing and only split the answer to "is this block publishable?" across two places that had to
+ * agree. One validator is the whole point.
+ *
+ * Never fabricated, and that is unchanged: an absent story yields `correlationId: undefined`, the
+ * schema rejects the block, and the consumer mints its own rather than inheriting an invented one.
  */
-function correlationOf(stored: StoredEvent): Record<string, unknown> | undefined {
-  const story = stored.metadata.correlationId;
-  if (story === undefined || !isCorrelationId(story)) return undefined;
+function correlationOf(stored: StoredEvent): Record<string, unknown> {
   return {
-    correlationId: story,
+    correlationId: stored.metadata.correlationId,
     // This event's OWN coordinates — the causal parent of whatever the consumer does on receipt.
     causation: {
       kind: 'event',
@@ -99,15 +107,16 @@ function renderFulfilled(
   // permanent by contract: the outbound feed surfaces it, the consumer's checkpoint holds, and it
   // fails identically on every retry — so a defect in a purely DIAGNOSTIC field would
   // head-of-line-block the whole cross-context seam, forever. Telemetry may degrade the trace; it
-  // may never stop the work. `correlationOf` yields only a well-formed block or nothing at all.
-  // Validated, but never fatal. Moving the block out of the envelope's own parse (so a diagnostic
-  // defect could not head-of-line-block the seam) would otherwise leave `publishedCorrelationSchema`
-  // enforcing nothing at all — a rename in `correlationOf` would compile, pass every gate, and
-  // silently detach every cross-context trace. So it is checked here and DROPPED on failure:
-  // telemetry still cannot stop the work, and what ships is again what the contract declares.
-  const block = correlationOf(stored);
-  const checked = block === undefined ? undefined : publishedCorrelationSchema.safeParse(block);
-  const metadata = checked?.success === true ? checked.data : undefined;
+  // may never stop the work. So the block is validated here and DROPPED on failure, never returned
+  // as an error — and this parse is the block's ONLY validator, which is what keeps
+  // `publishedCorrelationSchema` load-bearing: a rename in `correlationOf` would otherwise compile,
+  // pass every gate, and silently detach every cross-context trace.
+  const checked = publishedCorrelationSchema.safeParse(correlationOf(stored));
+  const metadata = checked.success ? checked.data : undefined;
+  // Stryker recorded-survivor ConditionalExpression `false`: equivalent — forced to the else arm,
+  // the spread adds `metadata: undefined`, and `JSON.stringify` drops an undefined property, so the
+  // published bytes are identical. Asserting the key's absence would pin a distinction no consumer
+  // can observe (`OutboundFeed` re-adds the key one layer out) — a test written for the score.
   return ok(metadata === undefined ? parsed.data : { ...parsed.data, metadata });
 }
 

--- a/packages/importer/src/adapters/beets/bridge-adapter.ts
+++ b/packages/importer/src/adapters/beets/bridge-adapter.ts
@@ -88,12 +88,12 @@ function candidateToDomain(candidate: BridgeCandidate): MetadataMatch {
     // only the album fields need a key rename (`albumdisambig`).
     tracks: candidate.tracks.map((track) => ({
       ...track,
-      // RECORDED SURVIVOR, waiver withheld: forcing this condition FALSE is equivalent. The guard
-      // is a TYPE-level narrowing, not a runtime one — `branded` is the identity at runtime (the
-      // brand is a phantom tag, erased), so the lift arm applied to an absent distance yields
-      // exactly the `undefined` the other arm returns. Forcing it TRUE is not equivalent: it drops
-      // every per-track distance beets reported, which the per-track distances in
-      // `bridge-adapter.test.ts` catch — so the line takes no waiver.
+      // Stryker recorded-survivor ConditionalExpression `false`: equivalent — the guard is a
+      // TYPE-level narrowing, not a runtime one. `branded` is the identity at runtime (the brand is
+      // a phantom tag, erased), so the lift arm applied to an absent distance yields exactly the
+      // `undefined` the other arm returns. Waived per mutant, not per line: forcing it TRUE drops
+      // every per-track distance beets reported, which the per-track distance assertions in
+      // `bridge-adapter.test.ts` catch — a real finding under the same mutator on the same line.
       distance: track.distance === undefined ? undefined : branded<Distance>(track.distance),
     })),
     extraItems: candidate.extra_items,

--- a/packages/importer/src/application/import/use-cases.ts
+++ b/packages/importer/src/application/import/use-cases.ts
@@ -111,12 +111,11 @@ export function getImportForAcquisition(
   const importId = dependencies.status.importIdForAcquisition(
     toOriginatingDownloadId(acquisitionId),
   );
-  // RECORDED SURVIVOR, waiver withheld: forcing this ternary's condition false is equivalent. With
-  // nothing indexed, `getImport` would look the missing id up in the projection's map, miss, and
-  // answer `undefined` anyway. The guard states the absence rather than round-tripping a missing
-  // key through the read model, and is the narrowing `ImportId` needs. Forcing it TRUE blanks every
-  // acquisition's import — a real finding, on this same line under the same mutator, which is
-  // exactly why the line takes no `disable next-line`.
+  // Stryker recorded-survivor ConditionalExpression `false`: equivalent — with nothing indexed,
+  // `getImport` looks the missing id up in the projection's map, misses, and answers `undefined`
+  // anyway. The guard states the absence rather than round-tripping a missing key through the read
+  // model, and is the narrowing `ImportId` needs. Waived per mutant, not per line: forcing it TRUE
+  // blanks every acquisition's import — a real finding, same mutator, same line.
   return importId === undefined ? undefined : getImport(dependencies, importId);
 }
 

--- a/packages/importer/src/application/projections/read-models.ts
+++ b/packages/importer/src/application/projections/read-models.ts
@@ -172,13 +172,13 @@ export class ImportStatusProjection {
     const list = this.streams.get(importId) ?? [];
     list.push(stored);
     this.streams.set(importId, list);
-    // RECORDED SURVIVOR, waiver withheld: forcing the TYPE operand true is equivalent. `source` is
-    // declared on `ImportRequested` alone, so on every other event type the second operand reads
-    // `undefined` and the conjunction is false either way. The operand is the narrowing that lets
-    // `stored.event.source` be read at all, not a decision. The other three `ConditionalExpression`
-    // mutants on this line are real findings — the whole condition forced true indexes sourceless
-    // streams, forced false indexes nothing, and the `source !== undefined` operand forced true
-    // indexes an event carrying no source — so the line takes no waiver at all.
+    // Stryker recorded-survivor ConditionalExpression `true`: equivalent — this is the TYPE
+    // operand, and `source` is declared on `ImportRequested` alone, so on every other event type
+    // the second operand reads `undefined` and the conjunction is false either way. The operand is
+    // the narrowing that lets `stored.event.source` be read at all, not a decision. Waived per
+    // mutant, not per line: the other three `ConditionalExpression` mutants here are real findings
+    // — the whole condition forced true indexes sourceless streams, forced false indexes nothing,
+    // and the `source !== undefined` operand forced true indexes an event carrying no source.
     if (stored.event.type === 'ImportRequested' && stored.event.source !== undefined) {
       this.acquisitions.set(stored.event.source.acquisitionId, importId);
     }
@@ -204,14 +204,14 @@ export class ImportStatusProjection {
   /** Every import currently awaiting a human: typed review items with their carried context. */
   pendingReviews(): readonly PendingReviewView[] {
     return this.list().flatMap((view) =>
-      // RECORDED SURVIVOR, waiver withheld: forcing the `directory` operand false is equivalent.
-      // An open review exists only on the `awaiting-review` and applied-remediation phases, and
-      // every phase past `empty` carries a `directory` — so no view can reach this operand with a
-      // review open and no directory. It is the narrowing that turns the view's `string |
-      // undefined` into the item's required `string`, not a filter. The line's three other
-      // `ConditionalExpression` mutants are real findings — the whole condition forced true lists
-      // no reviews, forced false lists every import as one, and the `openReview === undefined`
-      // operand forced false does the same — so it takes no waiver.
+      // Stryker recorded-survivor ConditionalExpression `false`: equivalent — this is the
+      // `directory` operand. An open review exists only on the `awaiting-review` and
+      // applied-remediation phases, and every phase past `empty` carries a `directory`, so no view
+      // can reach this operand with a review open and no directory. It is the narrowing that turns
+      // the view's `string | undefined` into the item's required `string`, not a filter. Waived per
+      // mutant, not per line: the line's three other `ConditionalExpression` mutants are real
+      // findings — the whole condition forced true lists no reviews, forced false lists every
+      // import as one, and the `openReview === undefined` operand forced false does the same.
       view.openReview === undefined || view.directory === undefined
         ? []
         : [{ importId: view.importId, directory: view.directory, review: view.openReview }],
@@ -270,13 +270,13 @@ export async function seedStalledReadModel(
     return;
   }
   for (const letter of letters.value) {
-    // RECORDED SURVIVOR, waiver withheld: forcing this guard true is unobservable. Marking a
-    // streamless (seam) letter would add `undefined` to the set, and the model's only reader is
-    // `isStalled(importId: string)` — no string argument can equal `undefined`, so no query could
-    // ever see it. The guard is the narrowing `mark(string)` needs, and what it states — a seam
-    // letter stalls no import — no reader of this model can be made to contradict. Forcing it
-    // FALSE marks nothing stalled at boot, a real finding on the same line under the same mutator,
-    // so the line takes no waiver.
+    // Stryker recorded-survivor ConditionalExpression `true`: equivalent — marking a streamless
+    // (seam) letter adds `undefined` to the set, and the model's only reader is
+    // `isStalled(importId: string)`, where no string argument can equal `undefined`, so no query
+    // could ever see it. The guard is the narrowing `mark(string)` needs, and what it states — a
+    // seam letter stalls no import — no reader of this model can be made to contradict. Waived per
+    // mutant, not per line: forcing it FALSE marks nothing stalled at boot, a real finding on the
+    // same line under the same mutator.
     if (letter.streamId !== undefined) stalled.mark(letter.streamId);
   }
 }

--- a/packages/importer/src/domain/import/decide.ts
+++ b/packages/importer/src/domain/import/decide.ts
@@ -247,6 +247,13 @@ export function decide(command: ImportCommand, state: ImportState): Decision {
       ]);
     }
     case 'RecordIntakeDeleted': {
+      // Stryker recorded-survivor ConditionalExpression `false`: equivalent — `settled` is declared
+      // on the `awaiting-review` phase alone, so any other phase forced past this guard reads
+      // `undefined` on the very next line and returns the same `NOTHING` one line later. The guard
+      // is the narrowing `state.settled` needs, and the place to say that a deletion is only ever
+      // owed by a review that settled. Waived per mutant, not per line: forcing it TRUE returns
+      // NOTHING for every phase — the intake is never deleted at all — a real finding under the
+      // same mutator on the same line.
       if (state.phase !== 'awaiting-review') return NOTHING;
       const settled = state.settled;
       if (settled === undefined) return NOTHING; // review resolved to a non-terminal verb; nothing owed

--- a/packages/importer/src/facade/mapping.ts
+++ b/packages/importer/src/facade/mapping.ts
@@ -42,12 +42,12 @@ function manualTagsToDomain(
     title: track.title,
     artist: track.artist,
     trackNumber: toPositiveInt(track.trackNumber),
-    // RECORDED SURVIVOR, waiver withheld: forcing this condition FALSE is equivalent.
-    // `toPositiveInt` is a runtime-erased brand lift (`branded` returns its argument unchanged), so
-    // taking the lift arm for an absent disc number yields the same `undefined` the true arm
-    // supplies; the ternary exists solely because the parameter is typed `number`, not
-    // `number | undefined`. Forcing it TRUE is NOT equivalent — it drops every disc number the
-    // client sent — so the line takes no waiver.
+    // Stryker recorded-survivor ConditionalExpression `false`: equivalent — `toPositiveInt` is a
+    // runtime-erased brand lift (`branded` returns its argument unchanged), so taking the lift arm
+    // for an absent disc number yields the same `undefined` the true arm supplies. The ternary
+    // exists solely because the parameter is typed `number`, not `number | undefined`. Waived per
+    // mutant, not per line: forcing it TRUE drops every disc number the client sent — a real
+    // finding under the same mutator on the same line.
     discNumber: track.discNumber === undefined ? undefined : toPositiveInt(track.discNumber),
   }));
   return {

--- a/packages/importer/src/interfaces/contracts/events/mapping.test.ts
+++ b/packages/importer/src/interfaces/contracts/events/mapping.test.ts
@@ -201,7 +201,8 @@ describe('published correlation metadata', () => {
     // `JSON.stringify` drops an `undefined` property, so the two shapes are byte-identical on the
     // wire; `OutboundFeed` re-adds the key unconditionally one layer out; and no consumer reads a
     // published event with `in` or `Object.keys`. That assertion would exist for the mutation score
-    // rather than for a reader, so the mutant is recorded as an equivalent survivor instead.
+    // rather than for a reader, so the mutant carries a recorded-survivor marker at its site in
+    // `mapping.ts` — where the machine now reads it, instead of only this paragraph.
     expect(rendered.metadata).toBeUndefined();
     expect(rendered.data).toBeDefined(); // the payload is unaffected by the envelope's absence
   });

--- a/packages/importer/src/interfaces/contracts/events/mapping.ts
+++ b/packages/importer/src/interfaces/contracts/events/mapping.ts
@@ -7,7 +7,7 @@ import type {
   PublishedEventMapping,
   RenderError,
 } from '../../../application/ports/published-events-port.js';
-import { CONTEXT_NAME, isCorrelationId } from '../../../application/correlation/context.js';
+import { CONTEXT_NAME } from '../../../application/correlation/context.js';
 import {
   RELEASE_VERDICT_TYPE,
   publishedCorrelationSchema,
@@ -15,7 +15,7 @@ import {
 } from './schemas.js';
 
 /**
- * The correlation envelope for a published event, or `undefined` when the story is unavailable.
+ * The correlation envelope for a published event.
  *
  * The story is taken from the CYCLE the event belongs to — the most recent `ImportRequested` at or
  * before it — not from the event's own metadata. A verdict is a fact about the import cycle, and
@@ -32,20 +32,31 @@ import {
  * revival loop honest: a replacement delivery opens a NEW cycle with its own adopted story, and
  * its verdict must be published under that one, not the original delivery's.
  *
- * Never fabricated: a cycle whose rows predate the capability yields no block at all, and the
+ * Never fabricated: a cycle whose rows predate the capability publishes no block at all, and the
  * consumer mints its own rather than inheriting an invented story.
+ *
+ * The block it returns is PROPOSED, not vouched for. Its one validator is
+ * `publishedCorrelationSchema` at the call site, which drops the block whole when the story is
+ * absent or malformed. This function used to pre-check with `isCorrelationId` as well, and that
+ * guard could reject nothing the schema would accept — `isCorrelationId` is
+ * `CORRELATION_ID_PATTERN.test(value)` and the schema's `correlationId` is
+ * `z.string().regex(CORRELATION_ID_PATTERN)`, the same regex from the same module. It decided
+ * nothing, and split "is this block publishable?" across two places that had to agree.
  */
 function correlationOf(
   stored: StoredEvent,
   prefix: readonly StoredEvent[],
-): Record<string, unknown> | undefined {
+): Record<string, unknown> {
   const cycleStart = prefix.findLast(
+    // Stryker recorded-survivor EqualityOperator `entry.version < stored.version`: equivalent — the
+    // only entry AT `stored.version` is `stored` itself, and `renderVerdict` has already refused
+    // anything that is not a `ReleaseVerdictRecorded`, which `isCycleStart` never accepts. The
+    // boundary case the two operators disagree about cannot arise. The `>` mutant on this line IS a
+    // real finding — it walks forward into a later cycle — which is why the line takes no waiver.
     (entry) => entry.version <= stored.version && isCycleStart(entry.event),
   );
-  const story = cycleStart?.metadata.correlationId;
-  if (story === undefined || !isCorrelationId(story)) return undefined;
   return {
-    correlationId: story,
+    correlationId: cycleStart?.metadata.correlationId,
     // This event's OWN coordinates — the causal parent of whatever the consumer does on receipt.
     causation: {
       kind: 'event',
@@ -101,15 +112,16 @@ function renderVerdict(
   // permanent by contract: the outbound feed surfaces it, the consumer's checkpoint holds, and it
   // fails identically on every retry — so a defect in a purely DIAGNOSTIC field would
   // head-of-line-block the whole cross-context seam, forever. Telemetry may degrade the trace; it
-  // may never stop the work. `correlationOf` yields only a well-formed block or nothing at all.
-  // Validated, but never fatal. Moving the block out of the envelope's own parse (so a diagnostic
-  // defect could not head-of-line-block the seam) would otherwise leave `publishedCorrelationSchema`
-  // enforcing nothing at all — a rename in `correlationOf` would compile, pass every gate, and
-  // silently detach every cross-context trace. So it is checked here and DROPPED on failure:
-  // telemetry still cannot stop the work, and what ships is again what the contract declares.
-  const block = correlationOf(stored, prefix);
-  const checked = block === undefined ? undefined : publishedCorrelationSchema.safeParse(block);
-  const metadata = checked?.success === true ? checked.data : undefined;
+  // may never stop the work. So the block is validated here and DROPPED on failure, never returned
+  // as an error — and this parse is the block's ONLY validator, which is what keeps
+  // `publishedCorrelationSchema` load-bearing: a rename in `correlationOf` would otherwise compile,
+  // pass every gate, and silently detach every cross-context trace.
+  const checked = publishedCorrelationSchema.safeParse(correlationOf(stored, prefix));
+  const metadata = checked.success ? checked.data : undefined;
+  // Stryker recorded-survivor ConditionalExpression `false`: equivalent — forced to the else arm,
+  // the spread adds `metadata: undefined`, and `JSON.stringify` drops an undefined property, so the
+  // published bytes are identical. Asserting the key's absence would pin a distinction no consumer
+  // can observe (`OutboundFeed` re-adds the key one layer out) — a test written for the score.
   return ok(metadata === undefined ? parsed.data : { ...parsed.data, metadata });
 }
 

--- a/scripts/mutation/file-drift.ts
+++ b/scripts/mutation/file-drift.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { driftIssues } from './drift.ts';
+import { applyRecordedSurvivors, describeStale, readSourceFromDisk } from './recorded-survivors.ts';
 import { readReport, REPORT_PATH } from './report-model.ts';
 
 /**
@@ -13,17 +14,31 @@ import { readReport, REPORT_PATH } from './report-model.ts';
  * different thing: printing `[]` for it would file nothing, log `drift clusters: 0`, and leave a
  * green weekly run indistinguishable from a clean repo. That case exits non-zero instead, because
  * the drift channel going silent is exactly the failure this job exists to prevent.
+ *
+ * Recorded survivors (change: mutation-recorded-survivors) are subtracted here, at the I/O edge,
+ * because that is where reading source files belongs — `drift.ts` stays a pure function over a
+ * report. This is the run that rechecks every marker in the repo: it is the only one that mutates
+ * every file, so a waiver whose argument has expired can be caught nowhere else. That check fails
+ * the step rather than filing an issue, because a stale waiver is a hole in the gate, not drift.
  */
 const reportPath = process.argv[2] ?? REPORT_PATH;
 
 const raw = existsSync(reportPath) ? readFileSync(reportPath, 'utf8') : undefined;
-const report = readReport(raw);
+const parsed = readReport(raw);
 
-if (raw !== undefined && report === undefined) {
+if (raw !== undefined && parsed === undefined) {
   process.stderr.write(
     `${reportPath} exists but could not be read as a mutation report — truncated, or a shape this tooling does not recognise. Refusing to report zero drift.\n`,
   );
   process.exitCode = 1;
+} else if (parsed === undefined) {
+  process.stdout.write(JSON.stringify([]));
 } else {
-  process.stdout.write(JSON.stringify(report === undefined ? [] : driftIssues(report)));
+  const { report, stale } = applyRecordedSurvivors(parsed, readSourceFromDisk);
+  if (stale.length > 0) {
+    process.stderr.write(`${describeStale(stale)}\n`);
+    process.exitCode = 1;
+  } else {
+    process.stdout.write(JSON.stringify(driftIssues(report)));
+  }
 }

--- a/scripts/mutation/pr-verdict.ts
+++ b/scripts/mutation/pr-verdict.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { describeStale, readSourceFromDisk, refineReportText } from './recorded-survivors.ts';
 import { REPORT_PATH } from './report-model.ts';
 import { renderVerdict } from './verdict-summary.ts';
 import {
@@ -46,7 +47,23 @@ const read = (path: string | undefined): string | undefined => {
   }
 };
 
-const verdict = decideVerdict({ report: read(reportPath), diff: read(diffPath) });
+/**
+ * Recorded survivors are subtracted before the decider sees the report (change:
+ * mutation-recorded-survivors), so a mutant proven equivalent at its site does not block a branch
+ * that merely touched its line. Staleness is NOT asserted here: a PR run mutates only the changed
+ * files, so every marker in the rest of the repo would have no mutant to match. The weekly full run
+ * is where markers are rechecked, because it is the only run that looks at all of them.
+ */
+const { raw: refinedReport, stale } = refineReportText(read(reportPath), readSourceFromDisk);
+if (stale.length > 0) {
+  // Not a failure here, but not silent either: the weekly run will fail on these, and a PR that
+  // made a marker stale should learn it from its own log rather than from Sunday's job.
+  process.stderr.write(
+    `Recorded survivors that matched nothing in this scope:\n${describeStale(stale)}\n`,
+  );
+}
+
+const verdict = decideVerdict({ report: refinedReport, diff: read(diffPath) });
 const reading = readEnforcement(process.env[ENFORCE_SWITCH]);
 
 // A duration the job could not measure is absent rather than zero: "the step took no time" and "no

--- a/scripts/mutation/recorded-survivors.test.ts
+++ b/scripts/mutation/recorded-survivors.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyRecordedSurvivors,
+  describeStale,
+  parseRecordedSurvivors,
+  RECORDED_SURVIVOR_REASON,
+  refineReportText,
+} from './recorded-survivors.ts';
+import { readReport } from './report-model.ts';
+import type { MutationReport, ReportedMutant } from './report-model.ts';
+
+/**
+ * The per-mutant waiver (change: mutation-recorded-survivors).
+ *
+ * Stryker's own `// Stryker disable next-line <mutator>` is granular to a line and a mutator. At
+ * every site this mechanism exists for, the equivalent mutant shares BOTH with a killable sibling —
+ * so the vendor's waiver would blind a real check, and the finding needs a waiver as narrow as it
+ * is. Naming the replacement text is what buys that narrowness (design D2).
+ *
+ * Two properties carry the design, and both are ways the mechanism could quietly stop meaning what
+ * it says. A marker must waive **exactly** what it names — one mutant, that mutator, that
+ * replacement — because a marker that waives a little more than it argues for is a blind spot with
+ * a justification stapled to it. And a marker that no longer matches anything must **fail**, since
+ * the property the hand-written prose comments never had is that something rechecks them (D4).
+ */
+
+const REASON =
+  'the narrowing operand is type-level; forced true, the undefined it admits is ignored';
+
+function marker(mutator: string, replacement: string, reason = REASON): string {
+  return `// Stryker recorded-survivor ${mutator} \`${replacement}\`: ${reason}`;
+}
+
+function mutant(overrides: Partial<ReportedMutant> = {}): ReportedMutant {
+  return {
+    mutatorName: 'ConditionalExpression',
+    status: 'Survived',
+    location: { start: { line: 2 }, end: { line: 2, column: 40 } },
+    replacement: 'true',
+    ...overrides,
+  };
+}
+
+function report(files: MutationReport['files']): MutationReport {
+  return { files };
+}
+
+/** A source whose line 2 is the mutated line, with the marker on line 1. */
+const SOURCE = [marker('ConditionalExpression', 'true'), 'if (x !== undefined && f(x)) g(x);'].join(
+  '\n',
+);
+
+describe('parsing a recorded-survivor marker', () => {
+  it('reads the mutator, the replacement, and the line the marker speaks for', () => {
+    const [parsed] = parseRecordedSurvivors(SOURCE);
+
+    expect(parsed).toMatchObject({
+      mutatorName: 'ConditionalExpression',
+      replacement: 'true',
+      line: 2,
+      reason: REASON,
+    });
+  });
+
+  it('anchors to the next line, so the marker travels with the code it argues about', () => {
+    // The whole reason the waiver is a comment at the site rather than an entry in a baseline file:
+    // inserting code above it must not invalidate it.
+    const shifted = ['', '', '// a leading comment', SOURCE].join('\n');
+
+    expect(parseRecordedSurvivors(shifted)[0]?.line).toBe(5);
+  });
+
+  it('reads a replacement containing colons, parens and quotes — the reason a delimiter exists', () => {
+    const replacement = 'story === undefined && !isCorrelationId(story)';
+    const source = [marker('LogicalOperator', replacement), 'if (a || b) return;'].join('\n');
+
+    expect(parseRecordedSurvivors(source)[0]).toMatchObject({
+      mutatorName: 'LogicalOperator',
+      replacement,
+      reason: REASON,
+    });
+  });
+
+  it('takes several markers for one line, because a marker waives exactly one mutant', () => {
+    const source = [
+      marker('ConditionalExpression', 'false'),
+      marker('EqualityOperator', 'a > b'),
+      'if (a < b) return;',
+    ].join('\n');
+
+    expect(parseRecordedSurvivors(source).map((entry) => entry.line)).toEqual([3, 3]);
+  });
+
+  it('folds the continuation comment lines into the reason', () => {
+    // Every real argument spans several lines — the proof that no test can distinguish a mutant
+    // does not fit on one. Reading only the first line would judge "is this argued?" on where the
+    // author happened to wrap, and a long replacement can push the whole argument onto line two by
+    // itself.
+    const source = [
+      '// Stryker recorded-survivor EqualityOperator `a >= b`: equivalent.',
+      '// `rank` is `indexOf`, so two distinct buckets can only tie by both being absent.',
+      'if (a > b) c();',
+    ].join('\n');
+
+    const [parsed] = parseRecordedSurvivors(source);
+
+    expect(parsed?.reason).toBe(
+      'equivalent. `rank` is `indexOf`, so two distinct buckets can only tie by both being absent.',
+    );
+    expect(parsed?.line).toBe(3);
+  });
+
+  it('stops folding at the next marker, so two arguments never merge into one', () => {
+    const source = [
+      marker('ConditionalExpression', 'false', 'the first argument, entire'),
+      marker('EqualityOperator', 'a > b', 'the second argument, entire'),
+      'if (a < b) c();',
+    ].join('\n');
+
+    expect(parseRecordedSurvivors(source).map((entry) => entry.reason)).toEqual([
+      'the first argument, entire',
+      'the second argument, entire',
+    ]);
+  });
+
+  it('is not a marker when it states no reason — an unargued waiver is the defect', () => {
+    const source = [
+      '// Stryker recorded-survivor ConditionalExpression `true`',
+      'if (a) b();',
+    ].join('\n');
+
+    expect(parseRecordedSurvivors(source)).toEqual([]);
+  });
+
+  it('is not a marker when the replacement is unterminated', () => {
+    const source = [
+      '// Stryker recorded-survivor ConditionalExpression `true: a reason that reads fine',
+      'if (a) b();',
+    ].join('\n');
+
+    expect(parseRecordedSurvivors(source)).toEqual([]);
+  });
+
+  it('is not a marker when prose merely mentions the phrase', () => {
+    // Design docs and this very file discuss the mechanism by name. A parser that matched on the
+    // phrase alone would waive whatever line followed a sentence about waiving.
+    const source = [
+      '// A recorded-survivor marker names its replacement so the sibling stays observed.',
+      'if (a) b();',
+    ].join('\n');
+
+    expect(parseRecordedSurvivors(source)).toEqual([]);
+  });
+});
+
+describe('applying recorded survivors to a report', () => {
+  it('reclassifies the named mutant as ignored, so every consumer already treats it as suppressed', () => {
+    const { report: applied } = applyRecordedSurvivors(
+      report({ 'a.ts': { mutants: [mutant()] } }),
+      () => SOURCE,
+    );
+
+    expect(applied.files['a.ts']?.mutants[0]).toMatchObject({
+      status: 'Ignored',
+      statusReason: RECORDED_SURVIVOR_REASON,
+    });
+  });
+
+  it('leaves a sibling on the same line under the same mutator surviving', () => {
+    // The entire point. `ConditionalExpression` on this line generates both `true` (equivalent) and
+    // `false` (drops the feature); a line-granular waiver would take both.
+    const killable = mutant({ replacement: 'false' });
+
+    const { report: applied } = applyRecordedSurvivors(
+      report({ 'a.ts': { mutants: [mutant(), killable] } }),
+      () => SOURCE,
+    );
+
+    expect(applied.files['a.ts']?.mutants.map((m) => m.status)).toEqual(['Ignored', 'Survived']);
+  });
+
+  it('waives one mutant per marker, so a second identical survivor still surfaces', () => {
+    const { report: applied } = applyRecordedSurvivors(
+      report({ 'a.ts': { mutants: [mutant(), mutant()] } }),
+      () => SOURCE,
+    );
+
+    expect(applied.files['a.ts']?.mutants.map((m) => m.status)).toEqual(['Ignored', 'Survived']);
+  });
+
+  it('does not touch a mutant the suite already detected', () => {
+    // A marker names a *survivor*. Reclassifying a killed mutant would be harmless today and a
+    // silent downgrade the day the kill regresses.
+    const killed = mutant({ status: 'Killed' });
+
+    const { report: applied } = applyRecordedSurvivors(
+      report({ 'a.ts': { mutants: [killed] } }),
+      () => SOURCE,
+    );
+
+    expect(applied.files['a.ts']?.mutants[0]?.status).toBe('Killed');
+  });
+
+  it('does not reach across lines', () => {
+    const elsewhere = mutant({ location: { start: { line: 9 }, end: { line: 9, column: 3 } } });
+
+    const { report: applied } = applyRecordedSurvivors(
+      report({ 'a.ts': { mutants: [elsewhere] } }),
+      () => SOURCE,
+    );
+
+    expect(applied.files['a.ts']?.mutants[0]?.status).toBe('Survived');
+  });
+});
+
+describe('a waiver that has outlived its argument', () => {
+  it('is reported as stale when the run mutated the file and produced no such survivor', () => {
+    const { stale } = applyRecordedSurvivors(
+      report({ 'a.ts': { mutants: [mutant({ status: 'Killed' })] } }),
+      () => SOURCE,
+    );
+
+    expect(stale).toMatchObject([
+      { file: 'a.ts', line: 2, mutatorName: 'ConditionalExpression', replacement: 'true' },
+    ]);
+  });
+
+  it('is stale when only one of two markers found a mutant to waive', () => {
+    const source = [marker('ConditionalExpression', 'true'), SOURCE].join('\n');
+
+    const { stale } = applyRecordedSurvivors(
+      report({
+        'a.ts': {
+          mutants: [mutant({ location: { start: { line: 3 }, end: { line: 3, column: 9 } } })],
+        },
+      }),
+      () => source,
+    );
+
+    expect(stale).toHaveLength(1);
+  });
+
+  it('is stale when a test now kills the mutant — the waiver is genuinely obsolete', () => {
+    const { stale } = applyRecordedSurvivors(
+      report({ 'a.ts': { mutants: [mutant({ status: 'Killed' })] } }),
+      () => SOURCE,
+    );
+
+    expect(stale).toHaveLength(1);
+  });
+
+  it('is not stale when the mutant timed out — that is the run, not the waiver', () => {
+    // `Timeout` is a detected status, so the waiver does not apply this run — but it says nothing
+    // about assertion strength. Mutation runs time out under load (a full run shares the machine),
+    // and calling that a stale waiver would redden the weekly job for a flake. The waiver has not
+    // been contradicted, so it is neither applied nor blamed.
+    const { stale } = applyRecordedSurvivors(
+      report({ 'a.ts': { mutants: [mutant({ status: 'Timeout' })] } }),
+      () => SOURCE,
+    );
+
+    expect(stale).toEqual([]);
+  });
+
+  it('is not stale when the mutant could not be compiled or run', () => {
+    for (const status of ['CompileError', 'RuntimeError'] as const) {
+      const { stale } = applyRecordedSurvivors(
+        report({ 'a.ts': { mutants: [mutant({ status })] } }),
+        () => SOURCE,
+      );
+
+      expect(stale, status).toEqual([]);
+    }
+  });
+
+  it('is not stale in a file the run never mutated', () => {
+    // A PR-scoped run mutates the changed files and nothing else. Every marker in the rest of the
+    // repo would otherwise read as stale, and the gate would fail on files it did not look at.
+    // `unscanned.ts` carries a marker that matches nothing; the run never looked at it, so nothing
+    // is claimed about it — and the source is never even read.
+    const asked: string[] = [];
+    const sources: Record<string, string> = {
+      'unscanned.ts': marker('ConditionalExpression', 'never-generated'),
+      'a.ts': SOURCE,
+    };
+
+    const { stale } = applyRecordedSurvivors(
+      report({ 'a.ts': { mutants: [mutant()] } }),
+      (file) => {
+        asked.push(file);
+        return sources[file];
+      },
+    );
+
+    expect(stale).toEqual([]);
+    expect(asked).toEqual(['a.ts']);
+  });
+
+  it('is not stale when the source cannot be read at all', () => {
+    // A report naming a file that no longer exists on disk is the run being stale, not the waiver.
+    const { stale, report: applied } = applyRecordedSurvivors(
+      report({ 'gone.ts': { mutants: [mutant()] } }),
+      () => {
+        return;
+      },
+    );
+
+    expect(stale).toEqual([]);
+    expect(applied.files['gone.ts']?.mutants[0]?.status).toBe('Survived');
+  });
+});
+
+describe('refining a report handed onward as text', () => {
+  it('reclassifies through the round trip', () => {
+    const { raw } = refineReportText(
+      JSON.stringify(report({ 'a.ts': { mutants: [mutant()] } })),
+      () => SOURCE,
+    );
+
+    expect(readReport(raw)?.files['a.ts']?.mutants[0]?.status).toBe('Ignored');
+  });
+
+  it('preserves per-file fields this tolerant model never declares', () => {
+    // Stryker's report carries `source` and `language` per file. Rebuilding the entry from its
+    // mutants would drop them and publish a lossy report under the vendor's name.
+    const withVendorFields = {
+      files: { 'a.ts': { mutants: [mutant()], source: 'if (x) y();', language: 'typescript' } },
+    };
+
+    const { raw } = refineReportText(JSON.stringify(withVendorFields), () => SOURCE);
+
+    expect(readReport(raw)?.files['a.ts']).toMatchObject({
+      source: 'if (x) y();',
+      language: 'typescript',
+    });
+  });
+
+  it('passes unreadable text through unchanged, so the decider still says "unreadable"', () => {
+    // Returning `undefined` here would turn `unreadable-report` into `no-report` and lose a
+    // distinction the verdict is careful to draw.
+    const { raw, stale } = refineReportText('{ not json', () => SOURCE);
+
+    expect(raw).toBe('{ not json');
+    expect(stale).toEqual([]);
+  });
+
+  it('passes absent text through as absent', () => {
+    expect(refineReportText(undefined, () => SOURCE).raw).toBeUndefined();
+  });
+});
+
+describe('describing a stale marker', () => {
+  it('names the file, the line, the mutator and the replacement that no longer match', () => {
+    const { stale } = applyRecordedSurvivors(
+      report({ 'a.ts': { mutants: [mutant({ status: 'Killed' })] } }),
+      () => SOURCE,
+    );
+
+    const described = describeStale(stale);
+
+    expect(described).toContain('a.ts:2');
+    expect(described).toContain('ConditionalExpression');
+    expect(described).toContain('true');
+  });
+
+  it('says nothing when nothing is stale', () => {
+    expect(describeStale([])).toBe('');
+  });
+});

--- a/scripts/mutation/recorded-survivors.ts
+++ b/scripts/mutation/recorded-survivors.ts
@@ -1,0 +1,294 @@
+import { readFileSync } from 'node:fs';
+import { readReport } from './report-model.ts';
+import type { MutationReport, ReportedMutant } from './report-model.ts';
+
+/**
+ * The per-mutant waiver (change: mutation-recorded-survivors).
+ *
+ * Stryker offers two granularities and this repo needs a third. `// Stryker disable next-line
+ * <mutator>` waives every mutant of that mutator on that line; the `ignorers` plugin API waives
+ * every mutant generated from a node's subtree (`shouldIgnore(path)` cannot see which mutator or
+ * replacement is being applied — verified against `IgnorerBookkeeper` in 9.6.1). But an *equivalent
+ * mutant* is a property of a single mutant, and at every site this exists for the equivalent one
+ * shares its line AND its mutator with a killable sibling:
+ *
+ *     if (x !== undefined && f(x))     // `true`  — the narrowing operand: equivalent
+ *                                      // `false` — the whole guard gone: a real finding
+ *
+ * Both are `ConditionalExpression` on one line. The vendor's waiver would take the finding along
+ * with the equivalence, so this one names the **replacement text** as well, and waives exactly the
+ * mutant it argues about (design D2).
+ *
+ * The marker is a comment at the site, anchored to the line below it exactly as `disable next-line`
+ * is. That is what keeps it honest: it travels with the code it argues about, so there is no line
+ * number to maintain and no content hash to invalidate — the two ways a checked-in baseline file
+ * rots into a list nobody rechecks.
+ *
+ *     // Stryker recorded-survivor ConditionalExpression `true`: <the proof no test can tell>
+ *
+ * This module is a pure function over (report, source text). The I/O shells — `file-drift.ts` and
+ * `pr-verdict.ts` — read the files and act on the staleness; reading source belongs at their edge,
+ * and keeping the decision pure is the same rule `verdict.ts` follows.
+ */
+
+/**
+ * The reason attached to a reclassified mutant. Stryker writes an `ignoreReason`-derived
+ * `statusReason` for its own waivers, so a recorded survivor reads the same way in any consumer
+ * that surfaces one — and reads as *ours*, not as something the vendor decided.
+ */
+export const RECORDED_SURVIVOR_REASON =
+  'Recorded survivor: proven equivalent at the site, waived per mutant because its line carries a ' +
+  'killable sibling of the same mutator (mutation-recorded-survivors, D2).';
+
+export interface RecordedSurvivor {
+  /** The line the marker speaks for — the first line at or after it that is not another marker. */
+  readonly line: number;
+  readonly mutatorName: string;
+  readonly replacement: string;
+  readonly reason: string;
+}
+
+/** A marker naming a mutant the run did not produce as a survivor: the waiver outlived its argument. */
+export interface StaleRecordedSurvivor extends RecordedSurvivor {
+  readonly file: string;
+}
+
+/**
+ * Anchored at the start of the comment so a marker cannot hide mid-sentence in prose — this file's
+ * own header and the design doc both discuss the mechanism by name, and a parser keying on the
+ * phrase alone would waive whatever line followed a paragraph about waiving.
+ *
+ * The replacement is backtick-delimited because replacements contain colons, parentheses and
+ * quotes (`"\"\""`, `story === undefined && !isCorrelationId(story)`); a colon-delimited grammar
+ * would need escaping the first time it met a real one. `[^`\n]+` keeps it to a single line, which
+ * every waived replacement is — a multi-line replacement inside a comment would be unreadable, so
+ * it is rejected rather than mangled.
+ *
+ * The reason is REQUIRED, and `\S` is what requires it: an unargued waiver is the defect the whole
+ * doctrine is about, and a grammar that made the reason optional would make writing one optional.
+ */
+const MARKER =
+  /^\s*\/\/\s*Stryker recorded-survivor\s+(?<mutator>[A-Za-z]+)\s+`(?<replacement>[^`\n]+)`:\s*(?<reason>\S.*)$/;
+
+/** A line that is only a comment — the marker's own line, or a continuation of a reason. */
+const COMMENT_ONLY = /^\s*(\/\/|\/\*|\*)/;
+
+/** The prose of a continuation line, with its comment opener stripped. */
+const CONTINUATION = /^\s*(?:\/\/|\*)\s?(.*)$/;
+
+/** A line with no code on it: blank, or comment-only. Markers may stack, and reasons may wrap. */
+function isCodeless(line: string): boolean {
+  return line.trim() === '' || COMMENT_ONLY.test(line);
+}
+
+/**
+ * Every marker in a source text, each carrying the 1-based line it speaks for.
+ *
+ * Several markers may stack above one line — a line can hold two equivalent mutants under different
+ * mutators, and each needs its own argument — so the anchor skips past any run of comment and blank
+ * lines to the first line carrying code, rather than stopping at the immediately-next line.
+ */
+export function parseRecordedSurvivors(source: string): RecordedSurvivor[] {
+  const lines = source.split('\n');
+  const found: RecordedSurvivor[] = [];
+  for (const [index, line] of lines.entries()) {
+    const match = MARKER.exec(line);
+    if (match?.groups === undefined) continue;
+    // The reason runs to the end of its comment block, not to the end of its first line. Every real
+    // argument here spans several lines — the proof that no test can distinguish a mutant does not
+    // fit on one, and a long replacement can push the whole argument onto the second line by
+    // itself. Judging "is this argued?" on the first line alone would grade where the author
+    // happened to wrap. The fold stops at the next marker, so two arguments never merge into one.
+    const reason = [match.groups.reason!.trim()];
+    let isFolding = true;
+    let anchor = index + 1;
+    while (anchor < lines.length && isCodeless(lines[anchor]!)) {
+      const next = lines[anchor]!;
+      // The anchor keeps walking past a stacked marker — its own block still stands between this
+      // marker and the code — but this marker's reason stops there.
+      if (MARKER.test(next)) isFolding = false;
+      if (isFolding) {
+        const continued = CONTINUATION.exec(next)?.[1]?.trim();
+        if (continued !== undefined && continued !== '') reason.push(continued);
+      }
+      anchor += 1;
+    }
+    // A marker at the end of a file speaks for nothing. It anchors past the last line and simply
+    // matches no mutant, which the staleness check then reports — the same answer as any other
+    // marker whose argument has moved out from under it.
+    found.push({
+      line: anchor + 1,
+      mutatorName: match.groups.mutator!,
+      replacement: match.groups.replacement!,
+      reason: reason.join(' '),
+    });
+  }
+  return found;
+}
+
+/** How the caller hands over a mutated file's source; `undefined` when it cannot be read. */
+export type ReadSource = (file: string) => string | undefined;
+
+export interface AppliedRecordedSurvivors {
+  readonly report: MutationReport;
+  readonly stale: readonly StaleRecordedSurvivor[];
+}
+
+function isNamedBy(mutant: ReportedMutant, recorded: RecordedSurvivor): boolean {
+  return (
+    mutant.location.start.line === recorded.line &&
+    mutant.mutatorName === recorded.mutatorName &&
+    mutant.replacement === recorded.replacement
+  );
+}
+
+/**
+ * Statuses that say nothing about the waiver either way.
+ *
+ * `Timeout` is a *detected* status — the mutant hung the suite, which is a test noticing — so the
+ * waiver does not apply on a run that reports one. But it is also the status a healthy mutant
+ * returns when the machine is loaded, and a full run shares its host with whatever else is
+ * building. Reading that as a stale waiver would redden the weekly job for a flake, and a red
+ * weekly job nobody believes is the channel going quiet by another route. `CompileError` and
+ * `RuntimeError` are Stryker's own problems for the same reason.
+ *
+ * A `Killed` mutant is NOT here: that is a test genuinely killing what the marker argued no test
+ * could, which is exactly the waiver outliving its argument.
+ */
+const INCONCLUSIVE = ['Timeout', 'CompileError', 'RuntimeError'] as const;
+
+function isInconclusive(mutant: ReportedMutant): boolean {
+  return (INCONCLUSIVE as readonly string[]).includes(mutant.status);
+}
+
+const SURVIVING = ['Survived', 'NoCoverage'] as const;
+
+/**
+ * Which of a file's mutants its markers waive, and which markers found nothing to waive.
+ *
+ * A marker waives exactly ONE mutant (design D3): the match is consumed, so a second survivor with
+ * the same mutator and replacement stays visible rather than being absorbed by an argument written
+ * about the first.
+ */
+function waivedIn(
+  mutants: readonly ReportedMutant[],
+  source: string,
+): {
+  readonly mutants: ReadonlySet<ReportedMutant>;
+  readonly unmatched: readonly RecordedSurvivor[];
+} {
+  const waived = new Set<ReportedMutant>();
+  const unmatched: RecordedSurvivor[] = [];
+  for (const recorded of parseRecordedSurvivors(source)) {
+    const target = mutants.find(
+      (mutant) =>
+        !waived.has(mutant) &&
+        (SURVIVING as readonly string[]).includes(mutant.status) &&
+        isNamedBy(mutant, recorded),
+    );
+    if (target !== undefined) {
+      waived.add(target);
+    } else if (mutants.every((mutant) => !isNamedBy(mutant, recorded) || !isInconclusive(mutant))) {
+      // Nothing to waive, and the run DID grade every mutant of this name: the waiver has outlived
+      // its argument. An inconclusive grade means this run simply has no opinion (design D4a).
+      unmatched.push(recorded);
+    }
+  }
+  return { mutants: waived, unmatched };
+}
+
+/**
+ * Rewrite every mutant a marker names from `Survived` to `Ignored`, and report the markers that
+ * found nothing to waive.
+ *
+ * Reclassified rather than filtered out (design D5). `isSurviving` then excludes it, `countMutants`
+ * counts it under `ignored`, and `auditGap` can still tell a file whose every mutant was waived
+ * ("all-ignored", which the verdict refuses on) from a file that was genuinely clean. Dropping the
+ * mutants instead would have converted the first case into the second — an unaudited scope wearing
+ * the shape of a passing one, which is the single most dangerous outcome this tooling has.
+ *
+ * Only survivors are touched. A marker names a survivor by definition, and reclassifying a killed
+ * mutant would be harmless today and a silent downgrade the day that kill regresses.
+ *
+ * Staleness is asserted only for files the report contains (design D4). A PR-scoped run mutates the
+ * changed files and nothing else, so markers everywhere else have no mutant to match and would read
+ * as stale — failing the gate over files it never looked at. The weekly full run sees every file,
+ * so every marker is still rechecked, weekly, by the job whose whole purpose is that recheck.
+ */
+export function applyRecordedSurvivors(
+  report: MutationReport,
+  readSource: ReadSource,
+): AppliedRecordedSurvivors {
+  const files: Record<string, { readonly mutants: readonly ReportedMutant[] }> = {};
+  const stale: StaleRecordedSurvivor[] = [];
+
+  for (const [file, entry] of Object.entries(report.files)) {
+    const { mutants } = entry;
+    const source = readSource(file);
+    // A report naming a file that is no longer on disk is the RUN being stale, not the waiver. There
+    // is nothing to parse and nothing to blame, so the mutants pass through as they arrived.
+    if (source === undefined) {
+      files[file] = entry;
+      continue;
+    }
+    const waived = waivedIn(mutants, source);
+    stale.push(...waived.unmatched.map((recorded) => ({ ...recorded, file })));
+    // The file entry is SPREAD, not rebuilt from its mutants. Stryker's report carries per-file
+    // fields this tolerant model never declares (`source`, `language`), and `pr-verdict.ts` hands
+    // the transformed report onward as text — rebuilding would silently drop them and publish a
+    // lossy report under the vendor's name.
+    files[file] = {
+      ...entry,
+      mutants: mutants.map((mutant) =>
+        waived.mutants.has(mutant)
+          ? { ...mutant, status: 'Ignored', statusReason: RECORDED_SURVIVOR_REASON }
+          : mutant,
+      ),
+    };
+  }
+
+  return { report: { files }, stale };
+}
+
+/**
+ * The same transform over the report's raw TEXT, for the shell that hands the report onward as text
+ * rather than as a value (`pr-verdict.ts`, whose decider parses it itself).
+ *
+ * Text that is not a readable report passes through UNCHANGED. Every refusal the deciders make for
+ * an absent or unparseable report is theirs to make, and swallowing one here — returning `undefined`
+ * for a report that merely failed to parse — would turn `unreadable-report` into `no-report` and
+ * lose the distinction the verdict is careful to draw.
+ */
+export function refineReportText(
+  raw: string | undefined,
+  readSource: ReadSource,
+): { readonly raw: string | undefined; readonly stale: readonly StaleRecordedSurvivor[] } {
+  const parsed = readReport(raw);
+  if (parsed === undefined) return { raw, stale: [] };
+  const { report, stale } = applyRecordedSurvivors(parsed, readSource);
+  return { raw: JSON.stringify(report), stale };
+}
+
+/**
+ * The disk reader both shells use. A file the report names but the tree no longer holds reads as
+ * `undefined` — the run being stale, not the waiver — and the mutants pass through untouched. The
+ * catch is held tight against the vendor call and converts only it, per `error-handling.md`.
+ */
+export const readSourceFromDisk: ReadSource = (file) => {
+  try {
+    return readFileSync(file, 'utf8');
+  } catch {
+    return;
+  }
+};
+
+/** One line per stale marker, for a shell that is about to exit non-zero because of it. */
+export function describeStale(stale: readonly StaleRecordedSurvivor[]): string {
+  return stale
+    .map(
+      (entry) =>
+        `${entry.file}:${entry.line} — recorded survivor \`${entry.mutatorName} \`${entry.replacement}\`\` matched no surviving mutant. ` +
+        'The waiver has outlived its argument: re-argue it, or delete it.',
+    )
+    .join('\n');
+}

--- a/test/boundaries/mutation-scope.test.ts
+++ b/test/boundaries/mutation-scope.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import mutationSuiteConfig from '../../vitest.mutation.config.ts';
 import { DIFF_FLAGS } from '../../scripts/mutation/changed-lines.ts';
+import { parseRecordedSurvivors } from '../../scripts/mutation/recorded-survivors.ts';
 import { REPORT_PATH } from '../../scripts/mutation/report-model.ts';
 import { ENFORCE_SWITCH } from '../../scripts/mutation/verdict.ts';
 import strykerConfig from '../../stryker.config.mjs';
@@ -534,5 +535,68 @@ describe('mutation waivers', () => {
     expect(isJustified('Stryker disable next-line all')).toBe(false);
     expect(isJustified('Stryker disable next-line all:')).toBe(false);
     expect(isJustified('Stryker disable next-line all: no behavior to assert here')).toBe(true);
+  });
+});
+
+/**
+ * The per-mutant waiver (change: mutation-recorded-survivors) is held to the same burden as the
+ * line-granular one above, plus one this form needs and that one does not.
+ *
+ * A malformed `disable next-line` is at worst inert — Stryker ignores it and the mutant keeps
+ * surviving, which is loud. A malformed recorded-survivor marker is inert in exactly the same way,
+ * and that is the danger: the author believes a mutant is waived, the weekly run keeps filing it,
+ * and the two facts never meet. So every comment that OPENS with the marker phrase must actually
+ * parse as one.
+ */
+const RECORDED_MARKER_OPENER = /(?:\/\/|\/\*)\s*(Stryker\s+recorded-survivor\b[^\n]*)/g;
+
+/** Every marker the parser actually accepts, across the mutated tree. */
+function parsedRecordedMarkers(): { readonly file: string; readonly reason: string }[] {
+  return MUTATED.flatMap((file) =>
+    parseRecordedSurvivors(readFileSync(path.join(REPO_ROOT, file), 'utf8')).map((entry) => ({
+      file,
+      reason: entry.reason,
+    })),
+  );
+}
+
+describe('recorded survivors', () => {
+  it('parses every comment that opens with the marker phrase — a malformed one waives nothing, silently', () => {
+    // The count is the assertion. A marker the parser rejects still READS as a waiver to a human,
+    // so the file looks argued while the mutant is re-filed every Sunday.
+    expect(parsedRecordedMarkers()).toHaveLength(scan(RECORDED_MARKER_OPENER).length);
+  });
+
+  it('carries a written justification on every marker, held to the same burden as an `any`', () => {
+    const unargued = parsedRecordedMarkers().filter(
+      (entry) => entry.reason.length < MIN_JUSTIFICATION_CHARS,
+    );
+
+    expect(unargued).toEqual([]);
+  });
+
+  it('reaches real markers, so the two scenarios above cannot pass over an empty set', () => {
+    // Both scenarios are satisfied by finding nothing at all — including if the parser broke, or if
+    // the scan's pattern stopped matching the form the tree actually uses.
+    expect(parsedRecordedMarkers().length).toBeGreaterThan(10);
+  });
+
+  it('holds the recorded-survivor count to a ceiling — a rising one is the same signal', () => {
+    // As with suppressions: a CEILING TO DRIVE DOWN, not a budget. Every entry here is a mutant no
+    // test can kill; a change that adds many at once is the rule failing admission, not the code.
+    const CEILING = 19;
+
+    expect(parsedRecordedMarkers().length).toBeLessThanOrEqual(CEILING);
+  });
+
+  it('is read by the machine, not only by a reader — the drift channel subtracts it', () => {
+    // "A suppression the machine never reads is the one that rots" (stryker.config.mjs). The
+    // fourteen prose comments this form replaced were exactly that, so the wiring is pinned here:
+    // both the weekly channel and the PR verdict must apply the transform.
+    const drift = readFileSync(path.join(REPO_ROOT, 'scripts/mutation/file-drift.ts'), 'utf8');
+    const verdict = readFileSync(path.join(REPO_ROOT, 'scripts/mutation/pr-verdict.ts'), 'utf8');
+
+    expect(drift).toContain('applyRecordedSurvivors');
+    expect(verdict).toContain('refineReportText');
   });
 });


### PR DESCRIPTION
Closes #168, #169, #170, #171, #172, #173, #174, #175, #176, #177, #178, #179, #180, #181, #182, #183.

## What the triage found

All thirty surviving mutants across the sixteen filed files were triaged against a fresh full-repo
run on `main` (the issues date from 2026-08-09; two of the files had since moved in the
download-language rename). **None is a test gap.** Every one is an *equivalent mutant* — a change to
production code that produces the same observable behavior, so no test could ever distinguish it.

Twenty-seven of them could not be waived. `// Stryker disable next-line <mutator>` is granular to a
**line and a mutator**; the equivalence is a property of a **single mutant**. At all twenty-seven
sites the equivalent mutant shares its line *and its mutator* with a sibling the suite genuinely
kills, so the only available waiver would blind a real check.

The repo had already discovered this — fourteen sites carry a hand-written
`RECORDED SURVIVOR, waiver withheld:` comment explaining the equivalence and why the waiver was not
taken. That is precisely the shape `stryker.config.mjs` names as the failure mode: *"a suppression
the machine never reads is the one that rots."* Meanwhile the weekly job re-filed the same sixteen
issues every Sunday.

The Stryker `ignorers` plugin API cannot express this waiver either: `shouldIgnore(path)` is
node-granular and never sees the mutator or the replacement (verified against `IgnorerBookkeeper` in
9.6.1).

## The mechanism

A third waiver form whose granularity matches the finding's:

```ts
// Stryker recorded-survivor ConditionalExpression `true`: <the proof no test can tell>
```

- **Anchored like Stryker's own**, to the line below it — so it travels with the code it argues
  about. No line number to maintain, no content hash to invalidate; the two ways a checked-in
  mutation baseline file rots into a list nobody rechecks.
- **Names the replacement**, so it waives one mutant and leaves every sibling on the line observed.
- **Read by the machine.** `scripts/mutation/recorded-survivors.ts` reclassifies the named mutants
  to `Ignored` before the report reaches either consumer, so the weekly drift channel and the PR
  verdict agree — with `drift.ts`, `verdict.ts` and `report-model.ts` unchanged, since `isSurviving`,
  `countMutants` and `auditGap` already treat `Ignored` correctly.
- **Stale markers fail.** A marker matching nothing, in a file the run actually mutated, fails the
  weekly job by name. That recheck is the property the prose comments never had.

## How the thirty were resolved

Honest rung first; the new mechanism is the last resort, not the first reach.

| Rung | Count | What |
| --- | --- | --- |
| Deleted as dead code | 8 | The redundant correlation guard, both contexts |
| Line waiver (`disable next-line`) | 3 | `case` labels of the downloader fold's no-op arms |
| Recorded per mutant | 19 | 14 prose comments converted, 5 argued for the first time |

**The deletion.** Both published-event mappings guarded the correlation id with
`isCorrelationId(story)` and then validated the same block against `publishedCorrelationSchema`,
whose `correlationId` is `z.string().regex(CORRELATION_ID_PATTERN)` — the same regex, imported from
the same module as `isCorrelationId`. The guard could not reject anything the schema would accept,
so the schema is now the single validator. **Every existing test passes unchanged**, which is the
proof the guard decided nothing.

## Two design points found by running it, not by writing it

- A marker's reason **folds across its continuation lines**. A long replacement can push the entire
  argument onto line two by itself, and judging "is this argued?" on the first line alone would
  grade where the author happened to wrap.
- A mutant reported `Timeout`, `CompileError` or `RuntimeError` leaves its waiver **neither applied
  nor blamed**. Those statuses say the run could not grade the mutant. The first verification run hit
  exactly this — `ranking.ts` timed out because a test suite was running on the same machine — and
  reddening the weekly job over machine load is the drift channel going quiet by another route.

## Verification

- Fresh full-repo `stryker run` (not incremental): 117 files, 6896 mutants. **All sixteen filed
  files report zero drift**, and `pnpm tsx scripts/mutation/file-drift.ts` files nothing for them.
- `pnpm check` green, all 14 lanes.
- `test/boundaries/mutation-scope.test.ts` extends the waiver doctrine to the new form: every marker
  must parse (a malformed one waives nothing, *silently* — the one failure mode this form has that
  `disable next-line` does not), every marker must carry a justification, and the count is held to a
  ceiling to drive down.

## Follow-up, deliberately not in scope

The full run surfaced **10 further files** with surviving mutants that have **no open issue** — drift
accumulated since the last weekly run on 2026-08-09, in code that shipped after it (`packages/eventing`,
the `react.ts` fold arms, the sqlite adapters). The next weekly run will file them. They are left for
a follow-up rather than folded in here, because some may be real test gaps needing new tests rather
than waivers, and that is a different review:

`downloader/adapters/sqlite/{event-store,event-tokens}.ts`, `downloader/application/events/catch-up-subscription.ts`,
`downloader/domain/download/react.ts`, `eventing/src/checkpointed-drain.ts`,
`importer/adapters/sqlite/{event-store,event-tokens}.ts`, `importer/application/events/catch-up-subscription.ts`,
`importer/domain/import/react.ts`, `importer/domain/import/state.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
