### PR TITLE
ci(pipeline): stop paying apt for fonts Chromium never renders

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -77,7 +77,7 @@ jobs:
   # on the Ubuntu mirrors, and has been measured at 11m08s here against a 20-35s norm.
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15 # observed ~100s; Chromium install dominates on a cold cache
+    timeout-minutes: 15 # observed ~100s
     steps:
       - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
@@ -89,8 +89,18 @@ jobs:
         with:
           python-version: '3.14'
       - run: pnpm install --frozen-lockfile
+      # NO `--with-deps`, deliberately — the same reasoning as the ffmpeg step above, measured the
+      # same way. Upstream recommends the flag, so the deviation is on us to justify: on the
+      # ubuntu-latest image every shared library Playwright asks for is ALREADY the newest version,
+      # and the only packages the flag installs are 9 CJK/Cyrillic font packages (21MB fetched,
+      # 79MB on disk) that nothing here renders — there is not one screenshot or visual-snapshot
+      # assertion in the repo, `vitest.client.config.ts` sets `screenshotFailures: false`, and the
+      # parity suite records traces, not video. So the apt phase bought ~14s of the step's ~25s
+      # norm and re-armed the `apt-get update` mirror wedge: run 32275016194 sat on it for 11m+.
+      # If a runner-image bump ever does drop a real lib, Chromium fails to LAUNCH — loudly, in the
+      # very next step — and the flag goes back in.
       - name: Install Chromium (browser-mode client tests)
-        run: pnpm --dir packages/web exec playwright install --with-deps chromium
+        run: pnpm --dir packages/web exec playwright install chromium
       - name: Test @ 100% coverage
         run: pnpm run test:cov
       - name: Contract tests (frozen fixtures; no network)
@@ -341,8 +351,9 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # No `--with-deps` — see the `test` job's step for the measurement and the failure mode.
       - name: Install Chromium (browser parity phase)
-        run: pnpm --dir packages/web exec playwright install --with-deps chromium
+        run: pnpm --dir packages/web exec playwright install chromium
 
       # THE GATE: stand up the freshly built image + WireMock stubs, drive it end to end over a real
       # socket — a real browser first (parity phase), then the loop phases (run.sh owns the list) —


### PR DESCRIPTION
## What

Drops `--with-deps` from both `playwright install chromium` call sites (the `test` job's browser-mode client tests, and the e2e job's browser parity phase).

## Why

`--with-deps` was installing **no browser libraries at all** on the `ubuntu-latest` image. Reading the apt output from a healthy run, every `lib*` Playwright asks for reads back `already the newest version`. The only packages it actually added were 9 CJK/Cyrillic font packages — `fonts-ipafont-gothic`, `fonts-wqy-zenhei`, `fonts-unifont`, `xfonts-*` — at 21MB fetched / 79MB on disk.

Nothing here renders them:

- no `toHaveScreenshot` / `toMatchSnapshot` / `.screenshot()` anywhere in the repo
- `vitest.client.config.ts` sets `screenshotFailures: false`
- the parity suite uses `trace: 'retain-on-failure'`, not video

So the apt phase bought ~14s of the step's ~25s norm, and re-armed the exact hazard the ffmpeg step was removed for — the comment above the `test` job already records it: *"`apt-get update` intermittently wedges on the Ubuntu mirrors, and has been measured at 11m08s here against a 20-35s norm."*

That is not hypothetical. Run [32275016194](https://github.com/jgchk/music-downloader/actions/runs/32275016194) (on #222) sat on this step past **11 minutes** against a ~25s norm measured across the previous 11 runs (21–32s).

## Deviation from upstream, recorded

Playwright's docs recommend `--with-deps`, and `microsoft/playwright-github-action` is archived with a README that points at exactly that CLI invocation. This PR deviates from that advice on the strength of the measurement above, so the justification lives at the step rather than waiting to be rediscovered.

It is cheap to reverse. If a future runner-image bump does drop a real library, Chromium fails to **launch** — loudly, in the very next step — and the flag goes back in.

## Considered and rejected

Running the jobs in `mcr.microsoft.com/playwright:v1.56.0-noble` instead. The manifest is **0.92 GB compressed**, so the pull would replace a ~10s browser download with a ~40–60s image pull — before accounting for the `test` job's `setup-python` tool cache and the e2e job's `docker/build-push-action`, which does not want to run inside a container.

## Follow-up not taken

Caching `~/.cache/ms-playwright` would take the remaining ~10s download to a ~4s restore. Left out: ~6s net for an extra action plus a version-resolution step, and Renovate churn on the lockfile would thrash the cache key.

## Verification

- both call sites converted; no `--with-deps` remains in any workflow
- YAML parses; `prettier --check` passes (`.github/` is not in `.prettierignore`)
- this PR's own checks exercise the new step, so a green `test` job is the change validating itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)