### PR TITLE
chore(agents): scaffold per-repo config for the engineering skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,3 +78,19 @@ Node · TypeScript (strict) · pnpm workspace · neverthrow · zod · pino · vi
 - `test/e2e`, `scripts/release` — product-level tiers and tooling at the workspace root.
 
 **Keep the two at their right altitude.** `docs/development/*.md` is constitutional: durable, largely project-agnostic principles for _how_ we build. Write them without domain specifics — no aggregate names, no source names, no schemas. Code-level, project-specific design (the actual aggregate, ports, event schema, policies, endpoints) belongs in OpenSpec under `openspec/changes/<change>/`, which already carries that detail. If a development doc starts needing concrete design specifics, that's the signal it belongs in OpenSpec instead.
+
+## Agent skills
+
+Per-repo configuration for the `mattpocock-skills` engineering skills lives in `docs/agents/`.
+
+### Issue tracker
+
+GitHub Issues on `jgchk/music-downloader`, via the `gh` CLI. See [docs/agents/issue-tracker.md](docs/agents/issue-tracker.md).
+
+### Triage labels
+
+The five canonical triage roles, each label string equal to its role name. See [docs/agents/triage-labels.md](docs/agents/triage-labels.md).
+
+### Domain docs
+
+Multi-context: `CONTEXT-MAP.md` + `packages/*/CONTEXT.md`, with OpenSpec standing in for ADRs. See [docs/agents/domain.md](docs/agents/domain.md).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,77 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring
+the codebase.
+
+## Before exploring, read these
+
+1. **`CONTEXT-MAP.md`** at the repo root — the cross-context map: which context owns which
+   concept, and the homonym table for terms that mean different things on each side.
+2. **The relevant `packages/<context>/CONTEXT.md`** — per-context glossaries: canonical
+   terms, and the words that context deliberately avoids.
+3. **`openspec/specs/<capability>/spec.md`** — the _living_ capability specs: what is true
+   of the system today.
+4. **`openspec/changes/<change>/design.md`** — decisions and their rationale for work in
+   flight. Shipped decisions live in `openspec/changes/archive/<date>-<change>/`.
+5. **`docs/development/*.md`** — the constitution: how we build, independent of what.
+
+If a file doesn't exist, proceed silently. Don't flag its absence or suggest creating it
+upfront; `/domain-modeling` creates them lazily when terms actually get resolved.
+
+## This repo has no `docs/adr/` — OpenSpec is the ADR
+
+Deliberately. `CLAUDE.md` splits the two altitudes: `docs/development/` holds durable,
+project-agnostic principles with **no** domain specifics, and every code-level design
+decision — aggregates, ports, event schemas, policies, endpoints — belongs in
+`openspec/changes/<change>/design.md`.
+
+So when a skill says "read the ADRs for this area", read the OpenSpec `design.md` files —
+active for in-flight work, `archive/` for shipped. **Do not create `docs/adr/`.** A second
+home for decisions is exactly the split the constitution warns against.
+
+## File structure
+
+```
+/
+├── CONTEXT-MAP.md                      ← cross-context map + homonym table
+├── docs/development/                   ← the constitution (how we build)
+├── openspec/
+│   ├── specs/<capability>/spec.md      ← living specs (what is true now)
+│   └── changes/<change>/
+│       ├── design.md                   ← decisions + rationale (the ADR)
+│       ├── proposal.md
+│       ├── specs/                      ← delta specs (NOT current truth)
+│       └── tasks.md
+└── packages/
+    ├── downloader/CONTEXT.md
+    ├── importer/CONTEXT.md
+    ├── web/CONTEXT.md
+    └── eventing/                       ← no CONTEXT.md yet
+```
+
+Note the two spec locations. `openspec/specs/` is what the system does today;
+`openspec/changes/<change>/specs/` is a delta not yet shipped. Reading a delta as current
+truth is the easy mistake.
+
+`packages/eventing` has no glossary. If you resolve a term there, that's the signal to
+start one.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept — an issue title, a refactor proposal, a
+hypothesis, a test name — use the term as defined in the owning context's `CONTEXT.md`.
+Don't drift to synonyms the glossary explicitly lists as avoided.
+
+Watch the homonym table in `CONTEXT-MAP.md`: a word that is canonical in one context may be
+a banned synonym in the other. Name the context when ambiguity is possible.
+
+If the concept isn't in the glossary yet, that's a signal — either you're inventing language
+the project doesn't use (reconsider), or there's a real gap (note it for `/domain-modeling`).
+
+## Flag conflicts with recorded decisions
+
+If your output contradicts a decision recorded in an OpenSpec `design.md`, surface it
+explicitly rather than silently overriding:
+
+> _Contradicts the halt-only seam decision in
+> `openspec/changes/archive/…-extract-eventing-package/design.md` — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,83 @@
+# Issue tracker: GitHub
+
+Issues for this repo live as GitHub issues on `jgchk/music-downloader`. Use the `gh` CLI
+for all operations; it infers the repo from `git remote -v` when run inside the clone.
+
+## Conventions
+
+- **Create**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read**: `gh issue view <number> --comments`
+- **List**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'`
+- **Comment**: `gh issue comment <number> --body "..."`
+- **Label**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+## This repo runs on `jj`, not `git`
+
+`jj` keeps git's `HEAD` detached, so **any `gh` subcommand that infers "the current branch"
+fails with `not on any branch`**. Issue operations are unaffected — they take an explicit
+number. But never let `gh` infer branch state, and never judge repo state from
+`git status` / `git log` (stale in a colocated repo) — trust `jj st` and
+`jj bookmark list --all`. See the "PRs with `jj` + `gh`" section of `CLAUDE.md`.
+
+Run `gh` from the colocated main repo, not a bare `jj` workspace (no `.git` there).
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.**
+
+Every PR on this repo is authored by the maintainer; there are no external contributors,
+so external-PR triage would always return an empty queue. Set this to `yes` if that
+changes — `/triage` reads this flag.
+
+## Labels beyond triage
+
+This tracker carries repo-specific labels that are _not_ triage states and should be left
+alone unless you're deliberately working that queue:
+
+- `quality-gate` — a review finding nominated for promotion to a machine-enforced rule
+- `mutation-drift` — surviving mutants found by the weekly full mutation run
+- `contract-drift` — a third-party API no longer matching its recorded contract
+- `dependencies`, `released` — Renovate and release automation
+
+Issue **#6** is Renovate's Dependency Dashboard. It is bot-managed, permanently open, and
+not triage work — skip it in every sweep.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far /
+  Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the
+  sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the
+  map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>`
+  (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the
+  driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible
+  representation. Add an edge with
+  `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`,
+  where `<blocker-db-id>` is the blocker's numeric **database id**
+  (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`).
+  GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live
+  gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line
+  at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to
+  the map's sub-issues / task list), drop any with an open blocker
+  (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line)
+  or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then
+  append a context pointer (gist + link) to the map's Decisions-so-far.
+
+The `wayfinder:*` labels (`map`, `research`, `prototype`, `grilling`, `task`) already exist
+on this repo. If you need another, create it before use — `gh issue create --label <name>`
+fails on an unknown label rather than creating it.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,24 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the
+actual label strings used in this repo's tracker. Here they are identical.
+
+| Canonical role    | Label in our tracker | Meaning                                  |
+| ----------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`    | Requires human implementation            |
+| `wontfix`         | `wontfix`            | Will not be actioned                     |
+
+Category roles use GitHub's stock `bug` and `enhancement`, both already present.
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the
+corresponding label string from this table.
+
+## How these actually get used here
+
+This is a single-maintainer tracker: every issue is authored by the person triaging it, and
+most are filed by review agents during ship cycles. Two states do the real work —
+**`ready-for-agent`** (a brief is attached; an AFK agent can pick it up) and
+**`ready-for-human`**. `needs-info` has no external reporter to ask and will rarely apply.


### PR DESCRIPTION
Scaffolds `docs/agents/` — the per-repo configuration the `mattpocock-skills`
engineering skills assume exists. Without it `/triage` can't run at all (it has no
label mapping) and every other skill guesses at this repo's conventions.

Docs and tooling only — no source, no behaviour change. Typed `chore` so
`version-check` doesn't demand a release bump.

## What's here

- **`docs/agents/issue-tracker.md`** — GitHub via `gh`. Records the `jj` detached-`HEAD`
  hazard that breaks any branch-inferring `gh` subcommand, the repo-specific label
  vocabulary (`quality-gate`, `mutation-drift`, `contract-drift`) that isn't triage state,
  and the `/wayfinder` operations. PRs-as-a-request-surface is **off**: every PR here is
  the maintainer's, so external-PR triage would always return empty.
- **`docs/agents/triage-labels.md`** — the five canonical triage roles, mapped 1:1.
- **`docs/agents/domain.md`** — read-order for the multi-context glossaries
  (`CONTEXT-MAP.md` → `packages/*/CONTEXT.md`), the distinction between `openspec/specs/`
  (true now) and `openspec/changes/*/specs/` (delta, not yet true), and OpenSpec's
  `design.md` as this repo's ADR home.
- **`CLAUDE.md`** — an `## Agent skills` section pointing at the three.

## The one judgment call

The template wants a `docs/adr/`. This repo deliberately has none — `CLAUDE.md` routes
code-level design decisions to `openspec/changes/<change>/design.md` and reserves
`docs/development/` for domain-free principles. `domain.md` therefore points skills at the
OpenSpec `design.md` files and says **not** to create `docs/adr/`, since a second home for
decisions is exactly the split the constitution warns against.

## Tracker side-effects (already applied)

Labels created: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`
(`wontfix` already existed), plus `wayfinder:map` and the four `wayfinder:` ticket types —
`gh issue create --label` fails on an unknown label rather than creating it.

## Follow-up, not in this PR

`packages/eventing` is the one package without a `CONTEXT.md`; `domain.md` notes it as a
gap for `/domain-modeling` to fill when a term there next gets resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)