### PR TITLE
chore(agents): admit quality-gate as a third triage category

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -32,10 +32,12 @@ changes — `/triage` reads this flag.
 
 ## Labels beyond triage
 
-This tracker carries repo-specific labels that are _not_ triage states and should be left
-alone unless you're deliberately working that queue:
+`quality-gate` is a **category role** on this repo, not a stray label — see
+`docs/agents/triage-labels.md`.
 
-- `quality-gate` — a review finding nominated for promotion to a machine-enforced rule
+These repo-specific labels are neither category nor state, and should be left alone unless
+you're deliberately working that queue:
+
 - `mutation-drift` — surviving mutants found by the weekly full mutation run
 - `contract-drift` — a third-party API no longer matching its recorded contract
 - `dependencies`, `released` — Renovate and release automation

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -11,10 +11,35 @@ actual label strings used in this repo's tracker. Here they are identical.
 | `ready-for-human` | `ready-for-human`    | Requires human implementation            |
 | `wontfix`         | `wontfix`            | Will not be actioned                     |
 
-Category roles use GitHub's stock `bug` and `enhancement`, both already present.
-
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the
 corresponding label string from this table.
+
+## Category roles
+
+This repo has **three** category roles, not the usual two:
+
+| Category role   | Meaning                                                        |
+| --------------- | -------------------------------------------------------------- |
+| `bug`           | Something is broken                                            |
+| `enhancement`   | New feature or improvement                                     |
+| `quality-gate`  | A review finding nominated for promotion to a machine-enforced rule |
+
+`quality-gate` is a category, not a state — an issue carrying it still needs one of the five
+state roles above. It exists because a promotion candidate is neither a defect nor a
+feature: it proposes a *check*, and its lifecycle is governed by the promotion ladder and
+admission contract in `docs/development/quality-gates.md` rather than by ordinary
+implementation.
+
+Two consequences worth knowing when triaging one:
+
+- **Filing is not adoption.** These issues are deliberately filed as candidates. Adoption is
+  its own change that runs the one-shot rule triage and records the admission tally in that
+  change's design document. A `ready-for-agent` quality-gate issue means "the rung is
+  settled and the adopting change can be written", not "turn the rule on".
+- **The state usually turns on which ladder rung applies.** Where the rung is decided and
+  the admission bar is assessable, it is `ready-for-agent`. Where the rung is genuinely open
+  — typically a choice between a cheap check with a false-positive problem and a type-level
+  change with real reach — it is `ready-for-human`.
 
 ## How these actually get used here
 


### PR DESCRIPTION
Follow-up to #224, prompted by triaging the ten open `quality-gate` issues.

Those issues are neither a defect nor a feature — each proposes a machine-enforced
**check**, and its lifecycle is governed by the promotion ladder and admission contract in
`docs/development/quality-gates.md`, not by ordinary implementation. Under the config as
merged, `quality-gate` was listed as a stray label and category roles were stock
`bug`/`enhancement` only, so none of the ten could satisfy "exactly one category and one
state" without being miscategorised.

Docs only. Typed `chore`.

## What changed

- `docs/agents/triage-labels.md` — a category-roles section admitting `quality-gate`
  alongside `bug` and `enhancement`, with the two rules that fell out of triaging all ten:
  **filing is not adoption** (these are candidates; adoption is its own change that runs the
  one-shot rule triage and records the admission tally), and **the state turns on whether the
  ladder rung is settled** — decided rung → `ready-for-agent`, open rung → `ready-for-human`.
- `docs/agents/issue-tracker.md` — moves `quality-gate` out of the "labels beyond triage"
  list and points at the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)